### PR TITLE
Record the floodplain local deployment

### DIFF
--- a/docs/floodplain-village.md
+++ b/docs/floodplain-village.md
@@ -95,3 +95,11 @@ release under `run/floodplain-integration/`.
 
 The September 10 release passed all 470 unit tests. The placement fixture passed 160 real-template placements, both paths, four rotations, colors, frames, entity/save receipts and upgrade preservation. A real server restart kept 160 saved buildings and 64 original entities. The approved-centre and house-access fixtures passed for every building. The shared reviewed-village
 fixture passed its catalogue, upgrade, founding and natural founding checks in a mangrove swamp world: 20 strict native templates, 2 housing alternatives, 12 upgrade fits, four founding rotations and codec reloads, natural biome selection, 5 beds, 4 positions, distinct meeting/fire locations and village identity.
+
+The verified runtime and private datapack were installed locally on September 10 with the old
+Village Life villages removed from the world first (a flushed world snapshot precedes their removal
+in the release backup). The server loaded the pack automatically and registered 104 building
+definitions. The first floodplain village, Ruwaleni, was founded by command at the nearest mangrove
+swamp, centre -3982 67 5344, with its six founding buildings. Force-loading that unvisited site in one
+console command stalled the server thread past the watchdog on the first start; the site is now
+loaded a few chunks at a time and the server was restarted from the same release.

--- a/docs/structure-review.md
+++ b/docs/structure-review.md
@@ -1751,3 +1751,6 @@ since two allays in a small storehouse push the probe off a container mid-check.
 Static checks, 470 unit tests and the five native modes (placement, restart, centre, access, founding with
 natural founding in a mangrove swamp world) all passed; the public record is
 `tools/structure/floodplain-catalog-20260910.json`.
+The release went live the same afternoon: 104 building definitions, the seven old-family villages removed
+after a flushed snapshot, and Ruwaleni founded at the nearest mangrove swamp (centre -3982 67 5344).
+

--- a/tools/structure/floodplain-catalog-20260910.json
+++ b/tools/structure/floodplain-catalog-20260910.json
@@ -1,6 +1,6 @@
 {
   "variant": "floodplain",
-  "status": "verified_pending_local_deployment",
+  "status": "verified_and_locally_deployed",
   "source_policy": "Locally approved playable datapack, excluded from public distribution. Source provenance is retained; written redistribution permission is not asserted.",
   "manifests": [
     "tools/structure/nilotic-selections-20260910.json"
@@ -365,5 +365,33 @@
     "storehouse_floodplain_1": {
       "allay": 2
     }
+  },
+  "deployment": {
+    "date": "2026-09-10",
+    "commit": "6a949d63ba486e6f968adad702a2895fc078bc1b",
+    "jar_sha256": "1c33d852a5a7c05673501e9e6e868de7df7225c960701e74f32605cb0e1e9a95",
+    "release": "20260910-163427-floodplain-village",
+    "datapack": "run/world/datapacks/kithkyn-floodplain",
+    "building_definitions_loaded": 104,
+    "removed_old_family_villages": [
+      "Emscott",
+      "Tanswick",
+      "Marnock",
+      "Marnwick",
+      "Tallowen",
+      "Brenavai",
+      "Avercombe"
+    ],
+    "world_backup": "before-floodplain-village-20260910-163427-floodplain-village",
+    "first_village": {
+      "name": "Ruwaleni",
+      "centre": [
+        -3982,
+        67,
+        5344
+      ],
+      "buildings": 6
+    },
+    "note": "The first start was killed by the server watchdog while a console force-load generated 81 unvisited chunks for the test village; the server was restarted from the same release and the site is now loaded a few chunks at a time."
   }
 }


### PR DESCRIPTION
## Summary
- Mark `tools/structure/floodplain-catalog-20260910.json` verified and locally deployed, with the release commit, jar hash, datapack path, definition count, removed old-family villages and the first founded village.
- Note the deployment and the first village in `docs/floodplain-village.md` and the review log.

## Test plan
- [x] Records and docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)