### PR TITLE
Document the village biome roster

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,8 @@ in it, and update it in the same change that moves what it describes.
 - [buildings.md](buildings.md): the building catalog. The categories a village can
   build, the three axes they vary on (category, variant, level), the production chains
   that connect them, and which biomes can support which. Proposed, not yet decided.
+- [village-biomes.md](village-biomes.md): the canonical village-biome roster, divided into
+  playable catalogs, locked directions, and future settlement systems.
 - [birch-village.md](birch-village.md): the approved playable Birch Forest catalog, exact
   amenities and intentionally omitted tiers, biome selection, identity slots and preservation.
 - [badlands-village.md](badlands-village.md): the approved Pueblo/Mesa local catalog, house

--- a/docs/structure-review.md
+++ b/docs/structure-review.md
@@ -168,6 +168,9 @@ Towns and Towers forest, rustic, Swedish, Tudor, Mediterranean, and Iberian fami
 
 ## Recommended village-biome roster
 
+The current three-state roster lives in [village-biomes.md](village-biomes.md). The discussion
+below remains as gallery history and source-family evidence rather than the current status list.
+
 The twelve-group proposal was too coarse. It pooled several complete Towns and Towers families
 under Plains, Forest, Tundra, Badlands, and Jungle, which would discard exactly the settlement
 variety the gallery exposed.
@@ -1754,7 +1757,6 @@ natural founding in a mangrove swamp world) all passed; the public record is
 `tools/structure/floodplain-catalog-20260910.json`.
 The release went live the same afternoon: 104 building definitions, the seven old-family villages removed
 after a flushed snapshot, and Ruwaleni founded at the nearest mangrove swamp (centre -3982 67 5344).
-
 Aaron's first walk through Ruwaleni found four things, fixed and released the same evening: a floor candle
 people pressed into (candles are obstacles now), keepers stuck at closed trapdoors (walls to them now), the
 well one block high (it sinks one), and the mine ramp starting at the pit's edge (its middle column now). The
@@ -1776,7 +1778,6 @@ the building, its door went, and a step leads down into the pit; the miner stand
 with the ramp mouth one column in. The Desert mine gained a shared chest at the pit floor plus two wall
 posts, a fence, a trapdoor and a lantern, exported in its existing frame. Both were captured from a flushed
 snapshot, re-exported, checked and installed in their packs.
-
 ### Jungle catalog verified: September 10
 
 The approved Jungle selection is now a playable private catalog with 22 definitions: nineteen

--- a/docs/village-biomes.md
+++ b/docs/village-biomes.md
@@ -1,0 +1,68 @@
+# Village biome roster
+
+A **village biome** is an architectural catalog selected from a settlement's founding
+environment and retained for the life of that village. It is separate from biome traits,
+which describe environmental facts such as wet, cold, wooded, or coastal.
+
+This roster tracks only three useful states. Runtime fallback behavior does not change a
+catalog's status here.
+
+## Playable
+
+These catalogs are integrated, selectable, and verified as complete founding villages.
+
+| Village biome | Founding environments | Direction |
+| --- | --- | --- |
+| Birch Forest | Birch Forest, Old Growth Birch Forest, and compatible modded birch biomes | Pale birch timber, mossy stone, intimate woodland buildings |
+| Desert Oasis | Desert and sandy desert families | Smooth sandstone, shaded courts, wells, oasis planting, candles, and the optional castle |
+| Pueblo | Badlands, Eroded Badlands, Wooded Badlands, and compatible mesa families | Dense adobe and terracotta housing, roof terraces, courtyards, and red sandstone walls |
+| Floodplain | Mangrove Swamp and compatible tropical floodplain biomes | Mud brick, mangrove details, raised earth, and water-oriented sites |
+
+## Locked directions
+
+These village biomes have an agreed environmental home and architectural direction. A locked
+direction may already have a complete gallery selection, but it remains in this section until
+its production catalog and founding behavior are verified.
+
+| Village biome | Founding environments | Direction |
+| --- | --- | --- |
+| Jungle Tribal | Jungle and compatible dense tropical forest biomes | Selected Jungle timber buildings, stripped bamboo roofs, compact huts, treehouses, three markets, the timber wall, and the Firewatch tower |
+| Mediterranean | Plains and Sunflower Plains | Rural Mediterranean farmsteads, stone and plaster homes, tile roofs, courts, and open agriculture |
+| Rustic Woodland | Forest and compatible ordinary oak woodland biomes | Familiar timber woodland settlement with a restrained rustic character |
+| Romanian | Dark Forest, forested highlands, and wooded valleys | Heavy timber roofs, enclosed yards, and substantial woodland buildings |
+| Japanese | Cherry Grove, Flower Forest, and compatible Sakura biomes | Garden settlement shaped around flowering woodland and deliberate landscape details |
+| Viking | Taiga, Old Growth Pine Taiga, Old Growth Spruce Taiga, and compatible cold forests | Cold forest settlement with strong timber halls and steep roofs |
+| Tundra | Snowy Plains, Ice Spikes, and compatible exposed frozen lowlands | Compact igloos and snowbound buildings suited to treeless terrain |
+| Alpine | Meadow, Grove, Snowy Slopes, and compatible mountain valleys and peaks | Swiss-inspired mountain settlement with steep roofs and slope-conscious buildings |
+| Swamp | Swamp, Orchid Swamp, and compatible ordinary wetlands | Boat-based or overgrown wetland village, distinct from the mud-brick Floodplain catalog |
+| Polynesian Coast | Sparse Jungle, tropical beaches, warm-ocean islands, and compatible tropical coasts | Open, warm-climate coastal buildings based on the Polynesian reference family |
+| Nautical Coast | Beach, Stony Shore, and compatible temperate or cold coasts | Fishing town, docks, shoreline buildings, and lighthouse landmarks |
+| Savanna Tent | Savanna, Savanna Plateau, Windswept Savanna, and compatible dry grasslands | African-inspired tent and grassland settlement with portable-looking structures and a coherent warm-climate material palette |
+| Mushroom | Mushroom Fields and compatible fungal biomes | Fantasy mushroom settlement drawn from the complete mushroom reference families |
+
+Jungle has no remaining building-selection work. Its nineteen selected buildings, founding
+homes, market tiers, wall, stripped-bamboo roof treatment, and tower are recorded in
+`tools/structure/jungle-selections-20260910.json` and the related Jungle manifests. It moves to
+Playable when those assets are exported as a production catalog and pass founding, housing,
+worker-access, and guard-access verification.
+
+Swedish and Polish references do not reserve separate village biomes. Their strongest buildings
+may contribute to Viking, Rustic Woodland, or Alpine when their shape and materials fit the
+selected catalog. Swiss remains the primary direction for Alpine because mountain terrain needs
+architecture distinct from forested Taiga and exposed Tundra.
+
+Rivers do not receive a separate village biome. An ordinary land village resolves from the
+surrounding environment rather than a narrow river strip. Tropical riverbanks and deltas belong
+to Floodplain when site selection can classify them reliably.
+
+## Future systems
+
+These ideas require placement or simulation work beyond an ordinary land village catalog.
+
+| Settlement | Environment | Required system work |
+| --- | --- | --- |
+| Ship or floating village | Deep Ocean and other suitable ocean families | Water-aware founding, access, expansion, farms, walls, and construction |
+| Piglin-influenced village | Nether Wastes, with later Nether families considered independently | Nether-specific resources, survival, threats, food, terrain, and resident behavior |
+
+Seasonal, ruined, fortified, and inhabited-skeleton settlements are presentation, defense,
+condition, or population concepts that may later modify one of the village biomes above.

--- a/docs/village-biomes.md
+++ b/docs/village-biomes.md
@@ -17,6 +17,7 @@ These catalogs are integrated, selectable, and verified as complete founding vil
 | Desert Oasis | Desert and sandy desert families | Smooth sandstone, shaded courts, wells, oasis planting, candles, and the optional castle |
 | Pueblo | Badlands, Eroded Badlands, Wooded Badlands, and compatible mesa families | Dense adobe and terracotta housing, roof terraces, courtyards, and red sandstone walls |
 | Floodplain | Mangrove Swamp and compatible tropical floodplain biomes | Mud brick, mangrove details, raised earth, and water-oriented sites |
+| Jungle Tribal | Jungle, Bamboo Jungle, and Sparse Jungle | Jungle timber, stripped bamboo roofs, compact huts, treehouses, three markets, the timber wall, and the Firewatch tower |
 
 ## Locked directions
 
@@ -26,7 +27,6 @@ its production catalog and founding behavior are verified.
 
 | Village biome | Founding environments | Direction |
 | --- | --- | --- |
-| Jungle Tribal | Jungle and compatible dense tropical forest biomes | Selected Jungle timber buildings, stripped bamboo roofs, compact huts, treehouses, three markets, the timber wall, and the Firewatch tower |
 | Mediterranean | Plains and Sunflower Plains | Rural Mediterranean farmsteads, stone and plaster homes, tile roofs, courts, and open agriculture |
 | Rustic Woodland | Forest and compatible ordinary oak woodland biomes | Familiar timber woodland settlement with a restrained rustic character |
 | Romanian | Dark Forest, forested highlands, and wooded valleys | Heavy timber roofs, enclosed yards, and substantial woodland buildings |
@@ -40,11 +40,9 @@ its production catalog and founding behavior are verified.
 | Savanna Tent | Savanna, Savanna Plateau, Windswept Savanna, and compatible dry grasslands | African-inspired tent and grassland settlement with portable-looking structures and a coherent warm-climate material palette |
 | Mushroom | Mushroom Fields and compatible fungal biomes | Fantasy mushroom settlement drawn from the complete mushroom reference families |
 
-Jungle has no remaining building-selection work. Its nineteen selected buildings, founding
-homes, market tiers, wall, stripped-bamboo roof treatment, and tower are recorded in
-`tools/structure/jungle-selections-20260910.json` and the related Jungle manifests. It moves to
-Playable when those assets are exported as a production catalog and pass founding, housing,
-worker-access, and guard-access verification.
+Jungle is a complete private production catalog with nineteen selected buildings and three
+market tiers. Its founding layout, housing, physical worksites, wall, and all access routes are
+verified and locally deployed.
 
 Swedish and Polish references do not reserve separate village biomes. Their strongest buildings
 may contribute to Viking, Rustic Woodland, or Alpine when their shape and materials fit the


### PR DESCRIPTION
The biome roadmap was spread across a long gallery review and used intermediate states that made the remaining work harder to read. This change adds one canonical roster with only three categories: playable catalogs, locked architectural directions, and future settlement systems.

Floodplain is recorded as playable. Jungle is recorded as a locked direction whose building selection is complete, with its remaining production and founding verification called out directly. Savanna remains a locked tent-village direction without changing runtime fallback or biome-selection behavior.

This is documentation only. The earlier runtime routing experiment in this branch is fully reverted, so the final PR diff contains no Java or datapack behavior changes.
