### PR TITLE
Keeper routing and naming, candle obstacles, lodge composting, floodplain well and mine

### DIFF
--- a/docs/allay-quartermasters.md
+++ b/docs/allay-quartermasters.md
@@ -93,3 +93,13 @@ round. Wooden doors are different: a keeper's route may pass through one, and th
 opens the door it is brushing past itself, since allays have no door behaviour of their own.
 Buildings should therefore leave keepers an open panel or a door into every room they
 serve; the floodplain storehouse exports its doorway trapdoor open for exactly this reason.
+
+## Naming
+
+An adopted keeper wears one of ten fallback names at once (Wisp, Fen, Reed, Sedge, Mote, Lumen,
+Dewdrop, Rush, Tallow, Pip), the way a guard's golem does. The quartermaster who took it on
+then names it themselves through the same single-voice talk an owner has when naming a pet
+(`village/KeeperNaming`, on the shared `SingleVoiceNaming` plumbing with `PetNaming`): they
+speak as themselves about the spirit at their counter, are shown the ten as the kind of name a
+keeper carries, and settle a name of their own, which the keeper takes and the quartermaster
+remembers. When the LLM is down or the talk lands no valid name, the fallback stays.

--- a/docs/allay-quartermasters.md
+++ b/docs/allay-quartermasters.md
@@ -82,3 +82,14 @@ roster. `ShelvingTest` covers the shelf arithmetic both keepers share, with a on
 server, exercises the storehouse tether, quartermaster-only adoption, duplicate claims, a full
 collect-and-deliver haul from a workplace chest to the shelves, reload persistence and death removal. Never enable that
 flag on a review or play world: it creates its own fixture and stops the server when finished.
+
+## Getting around
+
+A keeper plans its flights with its own evaluator (`entities/ai/AllayPathNavigation`).
+Vanilla flight admits every trapdoor cell whether the panel is open or closed, so a keeper
+whose route crossed a closed hatch flew into it and pressed there; nobody in this mod opens
+trapdoors, people included, so a closed trapdoor is a wall to a keeper and its route goes
+round. Wooden doors are different: a keeper's route may pass through one, and the keeper
+opens the door it is brushing past itself, since allays have no door behaviour of their own.
+Buildings should therefore leave keepers an open panel or a door into every room they
+serve; the floodplain storehouse exports its doorway trapdoor open for exactly this reason.

--- a/docs/floodplain-village.md
+++ b/docs/floodplain-village.md
@@ -21,7 +21,7 @@ definitions, all new ids, so the pack needs no filter:
 | Id | Source exhibit | Beds | Stations |
 | --- | --- | --- | --- |
 | `village_center_floodplain_1` | Nilotic cartographer house with four white banners and the green carpet cross | 0 | quartermaster, builder, guard captain |
-| `mine_floodplain_1` | Nilotic armorer house with the authored pit floor | 0 | miner in the 3x3 pit; the shaft leaves east |
+| `mine_floodplain_1` | Nilotic armorer house with the authored pit floor | 0 | miner in the 3x3 pit; the ramp starts at the pit's middle column and leaves east under the wall |
 | `storehouse_floodplain_1` | small house draft with barrels, a note block and two authored allays | 0 | none; the quartermaster keeps the centre post |
 | `church_floodplain_1` | Nilotic temple | 0 | cleric |
 | `lumberjack_floodplain_1` | Nilotic farmer house | 1 | lumberjack on the jungle sapling |
@@ -30,7 +30,7 @@ definitions, all new ids, so the pack needs no filter:
 | `stoneworks_floodplain_1` | Nilotic mason house | 1 | mason |
 | `blacksmith_floodplain_1` | Nilotic toolsmith | 0 | blacksmith |
 | `fishery_floodplain_1` | desert oasis pool draft with a barrel and a lantern | 0 | fisher on the pool rim |
-| `well_floodplain_1` | mangrove tavern well draft | 0 | none |
+| `well_floodplain_1` | mangrove tavern well draft, sunk one block so its rim sits flush with the ground | 0 | none |
 | `watchtower_floodplain_1` | firewatch tower draft with four white banners | 1 | crossbow post |
 | `house_floodplain_1` | Nilotic small house 2 | 1 | none |
 | `house_floodplain_2` | Nilotic large house, standalone | 2 | none |

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -555,6 +555,13 @@ bedtime restock leaves the pack short and the village stores hold bones, the far
 brain is offered a grind through the shared `CraftOffer` press
 ([llm-brain.md](llm-brain.md)), so skeleton drops end up as crops too.
 
+The lumberjack runs the same step on the lodge's own composter with a `TIMBER` diet: every
+felled canopy drops more saplings than one stand needs, and the pack's saplings past the four
+kept for replanting go into the composter, whose bone meal `BonemealStep` then spends on the
+stand. A lodge feeds its own tree; the bedtime restock from the stores is the top-up, not the
+source.
+
+
 ## The idle camper tends the fire
 
 Idle residents get the same treatment as the farmer's idle hands, on the campfire model rather

--- a/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
@@ -2748,6 +2748,10 @@ public class RealPerson extends Person {
       // five seconds). Level with strolling for the reason given at the guard's.
       this.goalSelector.addGoal(5, new WorkLoopGoal<>(this,
           new ChopStep(16, 0.4F, 100, true)));
+      // Felled canopies drop more saplings than one stand needs. The lodge's
+      // composter turns the surplus into bone meal for the stand, the same
+      // physical loop the farmer runs on brush, so a lodge feeds itself.
+      this.goalSelector.addGoal(8, new WorkLoopGoal<>(this, new CompostStep(CompostStep.Diet.TIMBER)));
       this.goalSelector.addGoal(8, new WorkLoopGoal<>(this, new CraftStep(
           new ItemStack(Items.STRIPPED_OAK_LOG, 4),
           new ItemStack(Items.OAK_PLANKS, 16),
@@ -2810,7 +2814,7 @@ public class RealPerson extends Person {
       // composter also eats surplus sowing seeds (CompostStep), which is what
       // replaced the abstract seeds-to-bone-meal craft that used to sit here:
       // the farmer has a real composter at the station, so it uses that.
-      this.goalSelector.addGoal(8, new WorkLoopGoal<>(this, new CompostStep()));
+      this.goalSelector.addGoal(8, new WorkLoopGoal<>(this, new CompostStep(CompostStep.Diet.FARM)));
       this.goalSelector.addGoal(8, new WorkLoopGoal<>(this, new StashBonemealStep()));
       this.goalSelector.addGoal(8, new WorkLoopGoal<>(this, new ClearBrushStep()));
     }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/AllayPathNavigation.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/AllayPathNavigation.java
@@ -1,0 +1,46 @@
+package com.quzzar.kithkyn.entities.ai;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.navigation.FlyingPathNavigation;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.TrapDoorBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.pathfinder.FlyNodeEvaluator;
+import net.minecraft.world.level.pathfinder.PathFinder;
+import net.minecraft.world.level.pathfinder.PathType;
+import net.minecraft.world.level.pathfinder.PathfindingContext;
+
+/**
+ * Flight planning for a village's allay keepers. Vanilla flight admits every
+ * trapdoor cell whether the panel is open or closed, so a keeper whose route
+ * crossed a closed hatch flew into it and pressed there for good; nobody opens
+ * trapdoors for anyone in this mod. A closed trapdoor is a wall to a keeper and
+ * its route goes round, through an open panel or a door it can open itself
+ * (entities/ai/behavior/AllayQuartermasterBehavior).
+ */
+public final class AllayPathNavigation extends FlyingPathNavigation {
+
+  public AllayPathNavigation(Mob mob, Level level) {
+    super(mob, level);
+  }
+
+  @Override
+  protected PathFinder createPathFinder(int maxVisitedNodes) {
+    this.nodeEvaluator = new KeeperNodeEvaluator();
+    this.nodeEvaluator.setCanPassDoors(true);
+    return new PathFinder(this.nodeEvaluator, maxVisitedNodes);
+  }
+
+  /** The flying evaluator with closed trapdoors read as the walls they are. */
+  private static final class KeeperNodeEvaluator extends FlyNodeEvaluator {
+    @Override
+    public PathType getPathType(PathfindingContext context, int x, int y, int z) {
+      BlockState state = context.getBlockState(new BlockPos(x, y, z));
+      if (state.getBlock() instanceof TrapDoorBlock && !state.getValue(TrapDoorBlock.OPEN)) {
+        return PathType.BLOCKED;
+      }
+      return super.getPathType(context, x, y, z);
+    }
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.PathNavigationRegion;
 import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.LadderBlock;
+import net.minecraft.world.level.block.CandleBlock;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
@@ -500,6 +501,12 @@ public final class PersonPathNavigation extends GroundPathNavigation {
       // market counters even when the roof prevents stepping onto them.
       if (type == PathType.TRAPDOOR && state.getBlock() instanceof TrapDoorBlock
           && !state.getValue(TrapDoorBlock.OPEN)) {
+        return PathType.BLOCKED;
+      }
+      // A candle cluster is too low for vanilla to plan around and too tall to
+      // step onto under an indoor ceiling, so a body walks into it and stays
+      // there. It is an obstacle: people go round it.
+      if (state.getBlock() instanceof CandleBlock) {
         return PathType.BLOCKED;
       }
       if (type == PathType.FENCE && state.getBlock() instanceof FenceGateBlock) {

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/CompostStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/CompostStep.java
@@ -21,8 +21,9 @@ import net.minecraft.world.level.block.ComposterBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
 /**
- * Feeding the farm's composter and taking what it makes: a CONVERT step, and
- * the second link in the farmer's idle chain (brush in, bone meal out).
+ * Feeding a trade's composter and taking what it makes: a CONVERT step, the
+ * second link in the farmer's idle chain (brush in, bone meal out) and the
+ * lumberjack's way of turning spare saplings into feed for the stand.
  *
  * Physical the whole way (docs/worker-loops.md): the composter is a real block
  * every farm structure ships, each fill spends one plant out of the pack rolled
@@ -38,8 +39,33 @@ import net.minecraft.world.level.block.state.BlockState;
  */
 public final class CompostStep implements BlockWorkStep {
 
+  /**
+   * What a trade may spend on its composter. A farm eats the brush its clearing
+   * gathered and any sowing seed past the keep; a lumber lodge eats the saplings
+   * its felled canopies drop past what {@link PlantStep} needs for the stand.
+   */
+  public enum Diet {
+    FARM("the farm's composter"),
+    TIMBER("the lodge's composter");
+
+    private final String composter;
+
+    Diet(String composter) {
+      this.composter = composter;
+    }
+  }
+
   /** The composter sits inside the farm, so the station scan stays tight. */
   private static final int STATION_RADIUS = 8;
+
+  /** Saplings the lodge keeps for replanting; only what the pack holds past this is compost. */
+  private static final int SAPLINGS_KEPT_FOR_PLANTING = 4;
+
+  private final Diet diet;
+
+  public CompostStep(Diet diet) {
+    this.diet = diet;
+  }
 
   /**
    * Seeds kept back for sowing, per type; only what the pack holds past this is
@@ -106,12 +132,12 @@ public final class CompostStep implements BlockWorkStep {
 
   @Override
   public String describe() {
-    return "the farm's composter";
+    return this.diet.composter;
   }
 
   @Override
   public String activity() {
-    return "feeding the farm's composter";
+    return "feeding " + this.diet.composter;
   }
 
   /** A fill every second or so reads as work without eating the whole day. */
@@ -121,12 +147,16 @@ public final class CompostStep implements BlockWorkStep {
   }
 
   /**
-   * What to spend next: cleared brush first, then any sowing seed the pack
-   * holds past its keep. The keep is what makes the seed half safe - the
-   * farmer never composts what they still need to plant.
+   * What to spend next. A farm spends cleared brush first, then any sowing seed
+   * the pack holds past its keep; a lodge spends saplings past its keep. The
+   * keeps are what make it safe: nobody composts what they still need to plant.
    */
   @Nullable
   private Item findFeedItem(RealPerson person) {
+    if (this.diet == Diet.TIMBER) {
+      Item sapling = PlantStep.saplingIn(person);
+      return sapling != null && person.personMainInv.countItem(sapling) > SAPLINGS_KEPT_FOR_PLANTING ? sapling : null;
+    }
     for (int slot = 0; slot < person.personMainInv.getContainerSize(); slot++) {
       ItemStack stack = person.personMainInv.getItem(slot);
       if (ClearBrushStep.brushItem(stack)) {

--- a/src/main/java/com/quzzar/kithkyn/village/KeeperNaming.java
+++ b/src/main/java/com/quzzar/kithkyn/village/KeeperNaming.java
@@ -1,0 +1,97 @@
+package com.quzzar.kithkyn.village;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.gson.JsonObject;
+import com.quzzar.kithkyn.Kithkyn;
+import com.quzzar.kithkyn.chat.Dialogue;
+import com.quzzar.kithkyn.entities.RealPerson;
+import com.quzzar.kithkyn.llm.LlmService;
+
+import net.minecraft.world.entity.animal.allay.Allay;
+
+/**
+ * The name a quartermaster gives an allay keeper they have just taken on,
+ * settled the way an owner names a pet ({@link PetNaming}): the villager speaks
+ * as themselves about the small spirit before them and names it. The keeper
+ * already wears a fallback name from the adoption, so a talk that never lands
+ * a valid name leaves it as it is; the same ten fallback names are shown to the
+ * model as the kind of name a keeper carries.
+ */
+public final class KeeperNaming {
+
+  private KeeperNaming() {
+  }
+
+  /**
+   * Runs the quartermaster's naming talk and completes with the name they
+   * settle on, or empty when the LLM is down or their talk lands no valid
+   * name. Call on the server thread: the talk's fixed facts are read as it starts.
+   */
+  public static CompletableFuture<Optional<String>> decide(RealPerson quartermaster, Allay keeper,
+      List<String> examples) {
+    if (!LlmService.get().isReady()) {
+      return CompletableFuture.completedFuture(Optional.empty());
+    }
+    return Dialogue.run(new Naming(quartermaster, keeper, examples));
+  }
+
+  /** The quartermaster as a single voice: the first valid name resolves the talk. */
+  private static final class Naming extends SingleVoiceNaming<String> {
+
+    private final String system;
+    private final String wearing;
+
+    private Naming(RealPerson quartermaster, Allay keeper, List<String> examples) {
+      super(quartermaster, quartermaster.getFirstName() + " names the storehouse keeper");
+      this.wearing = keeper.getName().getString();
+      this.system = speakerBriefing(quartermaster)
+          .append("You keep the village stores, and the village has just taken on an allay: a small winged ")
+          .append("spirit that will keep the storehouse shelves beside you, fetching what the village leaves ")
+          .append("about and shelving it. It is yours to name. Keepers carry short, light names such as ")
+          .append(quoted(examples)).append("; choose one of your own in that spirit, in keeping with who you ")
+          .append("are and with your village, rather than repeating those. Speak as yourself, in the first ")
+          .append("person, one short sentence a turn. When you have decided, state it in a decision. Reply ")
+          .append("with ONLY a JSON object: {\"say\":\"<what you say>\",\"decision\":{\"name\":\"<the keeper's name>\"}}.")
+          .toString();
+    }
+
+    @Override
+    protected String system() {
+      return system;
+    }
+
+    @Override
+    protected String user(Dialogue.Transcript transcript, boolean lastChance) {
+      StringBuilder user = new StringBuilder();
+      user.append("The allay hovers before you at the storehouse counter, answering to \"").append(wearing)
+          .append("\" for now; name it.\n\n");
+      user.append("Your words so far:\n");
+      if (transcript.isEmpty()) {
+        user.append("(nothing said yet)\n");
+      } else {
+        for (String line : transcript.lines()) {
+          user.append(line).append('\n');
+        }
+      }
+      user.append("\nIt is your turn, ").append(ownerFirst).append('.');
+      if (lastChance) {
+        user.append(" Include your \"decision\" now with the name you settle on.");
+      }
+      user.append(" Reply with ONLY the JSON object.");
+      return user.toString();
+    }
+
+    @Override
+    protected Optional<String> readDecision(JsonObject decision) {
+      return validateName(field(decision, "name"));
+    }
+
+    @Override
+    protected void logDecision(String name) {
+      Kithkyn.LOGGER.info("[keeper naming] {} names the storehouse keeper '{}'", owner.getFullName(), name);
+    }
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/village/PetNaming.java
+++ b/src/main/java/com/quzzar/kithkyn/village/PetNaming.java
@@ -10,19 +10,13 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.quzzar.kithkyn.Kithkyn;
 import com.quzzar.kithkyn.chat.Dialogue;
-import com.quzzar.kithkyn.chat.VillagerConversation;
-import com.quzzar.kithkyn.chat.VillagerText;
 import com.quzzar.kithkyn.entities.RealPerson;
-import com.quzzar.kithkyn.entities.KithkynAttachments;
 import com.quzzar.kithkyn.llm.LlmService;
-import com.quzzar.kithkyn.persona.PersonaData;
 
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.TamableAnimal;
 import net.minecraft.world.item.DyeColor;
 
@@ -42,28 +36,10 @@ import net.minecraft.world.item.DyeColor;
  * pet already wears: the owner's voice is honoured when they use it, never a pet
  * left nameless when they do not.
  *
- * <p>One voice, at most two turns: naming a pet is a small, private decision, not
- * a debate. Turns ride the background LLM lane and are spoken aloud to any players
- * in earshot, so the naming is a scene in the world. Each turn's world-touching
- * work (speaking a line) hops to the server thread; the prompts read only fixed
- * strings snapshotted when the talk was convened.
+ * <p>One voice, at most two turns, on the shared {@link SingleVoiceNaming}
+ * plumbing: naming a pet is a small, private decision, not a debate.
  */
 public final class PetNaming {
-
-  /** One voice, two turns: a first say and, if it did not decide, a second that must. */
-  private static final int MAX_TURNS = 2;
-
-  /** Room for a short line plus the small decision object; a naming reply is never long. */
-  private static final int NAMING_MAX_TOKENS = 96;
-
-  /** Warm enough for character, low enough to keep the JSON intact on a small model. */
-  private static final double NAMING_TEMPERATURE = 0.5D;
-
-  /** A mild push off words just used, the same anti-repeat nudge conversation uses. */
-  private static final double NAMING_PENALTY = 0.3D;
-
-  /** A pet's name is short; anything past this is the model running on, and is trimmed. */
-  private static final int MAX_NAME_LENGTH = 24;
 
   private PetNaming() {
   }
@@ -84,103 +60,38 @@ public final class PetNaming {
     if (!LlmService.get().isReady()) {
       return CompletableFuture.completedFuture(Optional.empty());
     }
-    return Dialogue.run(new Naming(owner, species, pet));
-  }
-
-  /** A parsed reply: what the owner said, and the look they settled on, if they settled a valid one. */
-  private record ParsedTurn(String say, Optional<PetDecision> decision) {
+    return Dialogue.run(new Naming(owner, species));
   }
 
   /**
-   * The owner as a single-voice {@link Dialogue.Protocol}: they speak as
-   * themselves and the first valid look resolves the talk. All the prompt strings
-   * and the allowed options are built once, when the talk is convened, so a turn
-   * reads no live entity state; only speaking a line touches the world, and that
-   * hops to the server thread.
+   * The owner as a single voice: they speak as themselves and the first valid
+   * look resolves the talk. The prompt strings and the allowed options are built
+   * once, when the talk is convened, so a turn reads no live entity state.
    */
-  private static final class Naming implements Dialogue.Protocol<PetDecision> {
+  private static final class Naming extends SingleVoiceNaming<PetDecision> {
 
-    private final RealPerson owner;
     private final CompanionPets.Species species;
-    private final String ownerFirst;
     private final String system;
 
     /** Coat options by lowercase path, so the model's answer can be matched back to the real key. */
     private final Map<String, ResourceLocation> allowedVariants;
 
-    private Naming(RealPerson owner, CompanionPets.Species species,
-        TamableAnimal pet) {
-      this.owner = owner;
+    private Naming(RealPerson owner, CompanionPets.Species species) {
+      super(owner, owner.getFirstName() + " names their " + species.word());
       this.species = species;
-      this.ownerFirst = owner.getFirstName();
       this.allowedVariants = variantsFor(owner, species);
       this.system = buildSystem(owner, species, allowedVariants.keySet());
     }
 
     @Override
-    public int voices() {
-      return 1;
-    }
-
-    @Override
-    public int maxTurns() {
-      return MAX_TURNS;
-    }
-
-    @Override
-    public CompletableFuture<Dialogue.Turn<PetDecision>> takeTurn(int speaker, Dialogue.Transcript transcript,
-        boolean lastChance) {
-      String user = buildUser(transcript, lastChance);
-      String purpose = ownerFirst + " names their " + species.word();
-
-      CompletableFuture<Dialogue.Turn<PetDecision>> turn = new CompletableFuture<>();
-      LlmService.get()
-          .submitBackgroundChat(purpose, system, user, List.of(), NAMING_MAX_TOKENS, NAMING_TEMPERATURE, NAMING_PENALTY)
-          .whenComplete((reply, error) -> {
-            MinecraftServer server = owner.getServer();
-            if (server == null) {
-              turn.complete(Dialogue.Turn.abort());
-              return;
-            }
-            server.execute(() -> {
-              ParsedTurn parsed = (error != null || reply == null || reply.isEmpty())
-                  ? null
-                  : parse(reply.get());
-              if (parsed == null) {
-                turn.complete(Dialogue.Turn.abort());
-                return;
-              }
-              String say = VillagerText.clean(parsed.say());
-              if (!say.isBlank()) {
-                VillagerConversation.speak(owner, say);
-              }
-              if (parsed.decision().isPresent()) {
-                PetDecision decision = parsed.decision().get();
-                Kithkyn.LOGGER.info("[pet naming] {} names their {} '{}'", owner.getFullName(),
-                    species.word(), decision.name());
-                turn.complete(Dialogue.Turn.resolved(decision));
-                return;
-              }
-              if (lastChance) {
-                turn.complete(Dialogue.Turn.abort());
-                return;
-              }
-              turn.complete(Dialogue.Turn.spoke(say.isBlank() ? "" : ownerFirst + ": " + say));
-            });
-          });
-      return turn;
+    protected String system() {
+      return system;
     }
 
     /** The owner's briefing: who they are, the animal before them, and the exact collar and coat options. */
-    private String buildSystem(RealPerson self, CompanionPets.Species species, Iterable<String> variantPaths) {
-      StringBuilder system = new StringBuilder();
-      system.append("You are ").append(self.getFullName()).append(", ").append(self.getGender().describe())
-          .append(" of ").append(self.getVillageName()).append(". ");
-      PersonaData persona = self.getData(KithkynAttachments.PERSONA.get());
-      if (persona != null && !persona.isEmpty()) {
-        system.append("About you: ").append(persona.blurb()).append(' ');
-      }
-      system.append("You have just been given a ").append(species.word())
+    private static String buildSystem(RealPerson self, CompanionPets.Species species, Iterable<String> variantPaths) {
+      return speakerBriefing(self)
+          .append("You have just been given a ").append(species.word())
           .append(" of your own, and it is yours to name and to make ready. Choose a name for it, ")
           .append("a collar colour, and its coat, in keeping with who you are. Speak as yourself, in the ")
           .append("first person, one short sentence a turn. When you have decided, state your choices in a ")
@@ -188,12 +99,12 @@ public final class PetNaming {
           .append("\"decision\":{\"name\":\"<the ").append(species.word()).append("'s name>\",")
           .append("\"collar\":\"<a collar colour>\",\"variant\":\"<a coat>\"}}. ")
           .append("The collar must be exactly one of: ").append(quoted(collarNames())).append(". ")
-          .append("The coat must be exactly one of: ").append(quoted(variantPaths)).append('.');
-      return system.toString();
+          .append("The coat must be exactly one of: ").append(quoted(variantPaths)).append('.')
+          .toString();
     }
 
-    /** The turn's cue: the scene, the talk so far, and a last turn that insists on a decision. */
-    private String buildUser(Dialogue.Transcript transcript, boolean lastChance) {
+    @Override
+    protected String user(Dialogue.Transcript transcript, boolean lastChance) {
       StringBuilder user = new StringBuilder();
       user.append("A ").append(species.word()).append(" of your own stands before you; name it and ready it.\n\n");
       user.append("Your words so far:\n");
@@ -212,33 +123,9 @@ public final class PetNaming {
       return user.toString();
     }
 
-    /**
-     * Reads a reply: the strict-then-lenient discipline used across llm-land, the
-     * spoken line from {@code say} and the look from {@code decision}. A decision
-     * counts only when the name, collar, and coat are all valid; otherwise the
-     * turn spoke but did not decide. Null when nothing parses, which ends the talk.
-     */
-    private ParsedTurn parse(String raw) {
-      int start = raw.indexOf('{');
-      int end = raw.lastIndexOf('}');
-      if (start < 0 || end <= start) {
-        return null;
-      }
-      try {
-        JsonObject node = JsonParser.parseString(raw.substring(start, end + 1)).getAsJsonObject();
-        String say = node.has("say") && node.get("say").isJsonPrimitive() ? node.get("say").getAsString() : "";
-        Optional<PetDecision> decision = Optional.empty();
-        if (node.has("decision") && node.get("decision").isJsonObject()) {
-          decision = readDecision(node.getAsJsonObject("decision"));
-        }
-        return new ParsedTurn(say, decision);
-      } catch (RuntimeException e) {
-        return null;
-      }
-    }
-
     /** A decision from its object, present only when the name, collar, and coat all validate. */
-    private Optional<PetDecision> readDecision(JsonObject decision) {
+    @Override
+    protected Optional<PetDecision> readDecision(JsonObject decision) {
       Optional<String> name = validateName(field(decision, "name"));
       Optional<DyeColor> collar = validateCollar(field(decision, "collar"));
       Optional<ResourceLocation> variant = validateVariant(field(decision, "variant"));
@@ -248,16 +135,9 @@ public final class PetNaming {
       return Optional.of(new PetDecision(name.get(), collar.get(), variant.get()));
     }
 
-    /** A cleaned, trimmed, capped name, or empty when the model gave nothing usable. */
-    private Optional<String> validateName(String candidate) {
-      if (candidate == null) {
-        return Optional.empty();
-      }
-      String cleaned = VillagerText.clean(candidate).strip();
-      if (cleaned.length() > MAX_NAME_LENGTH) {
-        cleaned = cleaned.substring(0, MAX_NAME_LENGTH).strip();
-      }
-      return cleaned.isEmpty() ? Optional.empty() : Optional.of(cleaned);
+    @Override
+    protected void logDecision(PetDecision decision) {
+      Kithkyn.LOGGER.info("[pet naming] {} names their {} '{}'", owner.getFullName(), species.word(), decision.name());
     }
 
     /** The dye colour whose name the model gave, case-insensitively, or empty. */
@@ -285,11 +165,6 @@ public final class PetNaming {
       String path = colon >= 0 ? trimmed.substring(colon + 1) : trimmed;
       return Optional.ofNullable(allowedVariants.get(path));
     }
-
-    /** The exact-field getter: a string primitive, or null when absent or not a string. */
-    private String field(JsonObject object, String key) {
-      return object.has(key) && object.get(key).isJsonPrimitive() ? object.get(key).getAsString() : null;
-    }
   }
 
   /** The species' coat variants keyed by lowercase path, in registry order, for prompt and validation. */
@@ -311,14 +186,5 @@ public final class PetNaming {
       names.add(colour.getName());
     }
     return names;
-  }
-
-  /** The options as a quoted, comma-separated list for the prompt. */
-  private static String quoted(Iterable<String> values) {
-    List<String> shown = new ArrayList<>();
-    for (String value : values) {
-      shown.add('"' + value + '"');
-    }
-    return String.join(", ", shown);
   }
 }

--- a/src/main/java/com/quzzar/kithkyn/village/SingleVoiceNaming.java
+++ b/src/main/java/com/quzzar/kithkyn/village/SingleVoiceNaming.java
@@ -1,0 +1,185 @@
+package com.quzzar.kithkyn.village;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.quzzar.kithkyn.chat.Dialogue;
+import com.quzzar.kithkyn.chat.VillagerConversation;
+import com.quzzar.kithkyn.chat.VillagerText;
+import com.quzzar.kithkyn.entities.KithkynAttachments;
+import com.quzzar.kithkyn.entities.RealPerson;
+import com.quzzar.kithkyn.llm.LlmService;
+import com.quzzar.kithkyn.persona.PersonaData;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * The shared shape of a villager naming something of their own: one voice, at
+ * most two turns on the {@link Dialogue} engine, a JSON reply of what they say
+ * and what they decide, spoken aloud to any player in earshot. {@link PetNaming}
+ * settles a pet's name and look, {@link KeeperNaming} an allay keeper's name.
+ * A subclass supplies the briefing, the cue and how its decision object is read;
+ * the background LLM turn, the parse and the speaking live here. Prompts read
+ * only fixed strings snapshotted when the talk is convened; speaking a line is
+ * the one thing that touches the world, and that hops to the server thread.
+ */
+abstract class SingleVoiceNaming<D> implements Dialogue.Protocol<D> {
+
+  /** One voice, two turns: a first say and, if it did not decide, a second that must. */
+  private static final int MAX_TURNS = 2;
+
+  /** Room for a short line plus the small decision object; a naming reply is never long. */
+  private static final int NAMING_MAX_TOKENS = 96;
+
+  /** Warm enough for character, low enough to keep the JSON intact on a small model. */
+  private static final double NAMING_TEMPERATURE = 0.5D;
+
+  /** A mild push off words just used, the same anti-repeat nudge conversation uses. */
+  private static final double NAMING_PENALTY = 0.3D;
+
+  /** A given name is short; anything past this is the model running on, and is trimmed. */
+  private static final int MAX_NAME_LENGTH = 24;
+
+  protected final RealPerson owner;
+  protected final String ownerFirst;
+  private final String purpose;
+
+  SingleVoiceNaming(RealPerson owner, String purpose) {
+    this.owner = owner;
+    this.ownerFirst = owner.getFirstName();
+    this.purpose = purpose;
+  }
+
+  /** The owner's briefing, built once when the talk is convened. */
+  protected abstract String system();
+
+  /** The turn's cue: the scene, the talk so far, and a last turn that insists on a decision. */
+  protected abstract String user(Dialogue.Transcript transcript, boolean lastChance);
+
+  /** A decision from its object, present only when every field validates. */
+  protected abstract Optional<D> readDecision(JsonObject decision);
+
+  /** The log line for a settled decision. */
+  protected abstract void logDecision(D decision);
+
+  @Override
+  public int voices() {
+    return 1;
+  }
+
+  @Override
+  public int maxTurns() {
+    return MAX_TURNS;
+  }
+
+  @Override
+  public CompletableFuture<Dialogue.Turn<D>> takeTurn(int speaker, Dialogue.Transcript transcript,
+      boolean lastChance) {
+    String user = user(transcript, lastChance);
+    CompletableFuture<Dialogue.Turn<D>> turn = new CompletableFuture<>();
+    LlmService.get()
+        .submitBackgroundChat(purpose, system(), user, List.of(), NAMING_MAX_TOKENS, NAMING_TEMPERATURE, NAMING_PENALTY)
+        .whenComplete((reply, error) -> {
+          MinecraftServer server = owner.getServer();
+          if (server == null) {
+            turn.complete(Dialogue.Turn.abort());
+            return;
+          }
+          server.execute(() -> {
+            ParsedTurn<D> parsed = (error != null || reply == null || reply.isEmpty())
+                ? null
+                : parse(reply.get());
+            if (parsed == null) {
+              turn.complete(Dialogue.Turn.abort());
+              return;
+            }
+            String say = VillagerText.clean(parsed.say());
+            if (!say.isBlank()) {
+              VillagerConversation.speak(owner, say);
+            }
+            if (parsed.decision().isPresent()) {
+              D decision = parsed.decision().get();
+              logDecision(decision);
+              turn.complete(Dialogue.Turn.resolved(decision));
+              return;
+            }
+            if (lastChance) {
+              turn.complete(Dialogue.Turn.abort());
+              return;
+            }
+            turn.complete(Dialogue.Turn.spoke(say.isBlank() ? "" : ownerFirst + ": " + say));
+          });
+        });
+    return turn;
+  }
+
+  /** A parsed reply: what the owner said, and what they settled, if they settled something valid. */
+  private record ParsedTurn<D>(String say, Optional<D> decision) {
+  }
+
+  /**
+   * Reads a reply: the strict-then-lenient discipline used across llm-land, the
+   * spoken line from {@code say} and the choice from {@code decision}. Null when
+   * nothing parses, which ends the talk.
+   */
+  private ParsedTurn<D> parse(String raw) {
+    int start = raw.indexOf('{');
+    int end = raw.lastIndexOf('}');
+    if (start < 0 || end <= start) {
+      return null;
+    }
+    try {
+      JsonObject node = JsonParser.parseString(raw.substring(start, end + 1)).getAsJsonObject();
+      String say = node.has("say") && node.get("say").isJsonPrimitive() ? node.get("say").getAsString() : "";
+      Optional<D> decision = Optional.empty();
+      if (node.has("decision") && node.get("decision").isJsonObject()) {
+        decision = readDecision(node.getAsJsonObject("decision"));
+      }
+      return new ParsedTurn<>(say, decision);
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  /** The opening of every briefing: who is speaking and what they are like. */
+  static StringBuilder speakerBriefing(RealPerson self) {
+    StringBuilder system = new StringBuilder();
+    system.append("You are ").append(self.getFullName()).append(", ").append(self.getGender().describe())
+        .append(" of ").append(self.getVillageName()).append(". ");
+    PersonaData persona = self.getData(KithkynAttachments.PERSONA.get());
+    if (persona != null && !persona.isEmpty()) {
+      system.append("About you: ").append(persona.blurb()).append(' ');
+    }
+    return system;
+  }
+
+  /** A cleaned, trimmed, capped name, or empty when the model gave nothing usable. */
+  static Optional<String> validateName(String candidate) {
+    if (candidate == null) {
+      return Optional.empty();
+    }
+    String cleaned = VillagerText.clean(candidate).strip();
+    if (cleaned.length() > MAX_NAME_LENGTH) {
+      cleaned = cleaned.substring(0, MAX_NAME_LENGTH).strip();
+    }
+    return cleaned.isEmpty() ? Optional.empty() : Optional.of(cleaned);
+  }
+
+  /** The exact-field getter: a string primitive, or null when absent or not a string. */
+  static String field(JsonObject object, String key) {
+    return object.has(key) && object.get(key).isJsonPrimitive() ? object.get(key).getAsString() : null;
+  }
+
+  /** The options as a quoted, comma-separated list for the prompt. */
+  static String quoted(Iterable<String> values) {
+    List<String> shown = new ArrayList<>();
+    for (String value : values) {
+      shown.add('"' + value + '"');
+    }
+    return String.join(", ", shown);
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/village/VillageAllays.java
+++ b/src/main/java/com/quzzar/kithkyn/village/VillageAllays.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableList;
 import com.quzzar.kithkyn.Kithkyn;
 import com.quzzar.kithkyn.chat.VillagerConversation;
 import com.quzzar.kithkyn.entities.RealPerson;
+import com.quzzar.kithkyn.entities.ai.AllayPathNavigation;
 import com.quzzar.kithkyn.entities.ai.behavior.AllayQuartermasterBehavior;
 import com.quzzar.kithkyn.village.buildings.Building;
 
@@ -22,7 +23,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.ai.navigation.FlyingPathNavigation;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.animal.allay.Allay;
 import net.minecraft.world.entity.animal.allay.AllayAi;
@@ -151,8 +151,10 @@ public final class VillageAllays {
       return;
     }
     allay.setCustomNameVisible(false);
-    if (allay.getNavigation() instanceof FlyingPathNavigation flying) {
-      flying.setCanOpenDoors(true); // paths may route through doors; the keeper opens them itself
+    if (!(allay.getNavigation() instanceof AllayPathNavigation)) {
+      AllayPathNavigation flight = new AllayPathNavigation(allay, allay.level());
+      flight.setCanOpenDoors(true); // paths may route through doors; the keeper opens them itself
+      allay.navigation = flight;
     }
     if (KEEPING.add(allay)) {
       allay.getBrain().addActivity(Activity.IDLE, 0, ImmutableList.of(new AllayQuartermasterBehavior()));

--- a/src/main/java/com/quzzar/kithkyn/village/VillageAllays.java
+++ b/src/main/java/com/quzzar/kithkyn/village/VillageAllays.java
@@ -139,6 +139,24 @@ public final class VillageAllays {
     }
     attach(allay);
     remember(level, village, allay);
+    if (recruiter != null) {
+      // The keeper wears a fallback name from here on; the quartermaster then names
+      // it themselves, the way an owner names a pet, and the fallback stays only
+      // when the talk lands nothing.
+      KeeperNaming.decide(recruiter, allay, NAMES).whenComplete((decision, error) -> {
+        if (error != null || decision == null || decision.isEmpty()) {
+          return;
+        }
+        level.getServer().execute(() -> {
+          if (allay.isRemoved()) {
+            return;
+          }
+          allay.setCustomName(Component.literal(decision.get()));
+          allay.setCustomNameVisible(false);
+          recruiter.logMemory("I named our storehouse keeper " + decision.get() + ".", Optional.of(allay.getUUID()));
+        });
+      });
+    }
   }
 
   /**

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -15,3 +15,8 @@ public net.minecraft.world.entity.animal.Cat setCollarColor(Lnet/minecraft/world
 
 # Arrest queries the same Curios death-retention rule without causing a death.
 public net.minecraft.world.entity.LivingEntity lastHurtByPlayerTime
+
+# A village's allay keepers plan their flights with their own evaluator
+# (entities/ai/AllayPathNavigation); vanilla builds the navigation in the
+# constructor with no seam to replace it.
+public net.minecraft.world.entity.Mob navigation


### PR DESCRIPTION
## Summary
- Allay keepers plan flights with their own evaluator (`AllayPathNavigation`, installed through an access transformer on `Mob.navigation`): a closed trapdoor is a wall and the route goes round; wooden doors on the route are still opened by the keeper.
- People treat candle clusters as obstacles and walk round them instead of pressing into one under a low ceiling.
- The lumberjack composts surplus saplings (keeping four) through `CompostStep` with a `TIMBER` diet and spends the bone meal on the stand.
- The quartermaster names an adopted keeper through the same single-voice talk an owner uses for a pet; the shared plumbing moved from `PetNaming` into `SingleVoiceNaming`. The ten fallback names remain the examples and the fallback.
- Floodplain data: the well sinks one block; the mine ramp starts at the pit's middle column (Aaron's choice).

## Test plan
- [x] `./gradlew test`: 470 tests, 0 failures
- [x] `run/allay-verification/run.py`: RESULT PASS after the routing change; rerun after the naming change in progress
- [x] Native floodplain modes (placement, restart, centre, access, founding) all PASS on the routing build

🤖 Generated with [Claude Code](https://claude.com/claude-code)