### PR TITLE
Clear orphaned lumberjack canopies

### DIFF
--- a/docs/block-ownership.md
+++ b/docs/block-ownership.md
@@ -58,7 +58,11 @@ places structural village blocks, it records them; that is the contract.
   circles; the two booleans are the stored facts.
 - `mayFell(level, pos)`: nobody placed it. The felling verdict. `TreeFelling` asks it for
   every log of a tree it brings down, and once more up front (with the natural-canopy test)
-  before a log is offered as a tree at all.
+  before a log is offered as a tree at all. Afterward, the same ownership facts keep
+  player- and village-owned logs from counting as living-tree support for the removed
+  trunk's natural canopy: otherwise a roof beam can preserve those leaves forever and
+  block the lumberjack stand's next sapling. Persistent and ownership-marked leaves stay,
+  and a remaining unowned natural log still preserves canopy it shares with the felled tree.
 - **The lumberjack's stand is exempt** (2026-09-02). The lodge used to ship a grown tree, so
   the stamp recorded that trunk as the village's like every other block it set down, and under
   `mayFell` the lumberjack struck it for five seconds, nothing came away, and the loop offered

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -878,7 +878,8 @@ over the yard once it finally did). The loop now runs as `ChopStep` at the stati
 fell the tree at the station whole, whoever planted it (`TreeFelling.fellStand` fells every log
 connected to the station without asking ownership, whatever its height or how far the branches
 reach, and drops each record as it goes); the grown tree's natural canopy decays and drops its
-saplings; set a sapling from the pack
+saplings as part of the fell, even when a nearby building log would make vanilla preserve it;
+set a sapling from the pack
 on the stump, any kind (a Birch lodge whose birch is down grows a spruce if spruce is what the
 pack holds), and it is nobody's, so the next fell is an ordinary one; feed it while there is
 bone meal in the pack; fell it again when it is a tree. Saplings reach the pack three ways:
@@ -914,7 +915,11 @@ Both roles run the same `ChopStep`. A worker strikes one log for a chop's worth 
 when it gives the whole connected tree comes down at once through `TreeFelling` (shared with
 building placement and a finished wall's tree-line cleanup, [site-selection.md](site-selection.md)):
 a bounded flood fill over its logs,
-all of it into the pack, with the leaves left to decay on their own. Two guards keep the axe off
+all of it into the pack. Natural leaves supported by those logs are captured before the trunk
+comes down, then any that have no other natural tree supporting them decay immediately with
+ordinary ground drops. Player- and village-owned logs do not preserve a severed canopy, so a
+building beam beside a lumberjack stand cannot jam its next sapling. Persistent or ownership-marked
+leaves stay, as do shared leaves still supported by another natural tree. Two guards keep the axe off
 anything but a wild tree. A candidate must have a natural canopy nearby, leaves whose
 `persistent` flag is false, which a building's timber and a player's placed leaves never carry.
 And every log is checked against [block-ownership.md](block-ownership.md), which vetoes anything

--- a/src/main/java/com/quzzar/kithkyn/dev/TreeFellingVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/TreeFellingVerification.java
@@ -16,7 +16,9 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.entity.BeehiveBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -25,6 +27,8 @@ import net.neoforged.neoforge.event.tick.ServerTickEvent;
 /** Native block-entity, ownership and loot regression; opt in only in a disposable world. */
 @EventBusSubscriber(modid = Kithkyn.MODID)
 public final class TreeFellingVerification {
+  private static final int HIVE_CASES = 10;
+  private static final int CANOPY_CASES = 3;
   private static boolean ran;
   private static int tick;
 
@@ -34,7 +38,7 @@ public final class TreeFellingVerification {
   public static void tick(ServerTickEvent.Post event) {
     if (!Boolean.getBoolean("kithkyn.treeFelling.verify") || ran) return;
     if (++tick == 1) {
-      for (int mode = 0; mode < 10; mode++) {
+      for (int mode = 0; mode < HIVE_CASES + CANOPY_CASES; mode++) {
         int x = (-3000 + mode * 24) >> 4;
         for (int dx = -1; dx <= 1; dx++) for (int dz = -1; dz <= 1; dz++) {
           event.getServer().overworld().setChunkForced(x + dx, (-3000 >> 4) + dz, true);
@@ -46,15 +50,19 @@ public final class TreeFellingVerification {
     try {
       ServerLevel level = event.getServer().overworld();
       level.getGameRules().getRule(GameRules.RULE_RANDOMTICKING).set(0, event.getServer());
-      for (int mode = 0; mode < 10; mode++) verify(level, mode);
-      Kithkyn.LOGGER.info("[tree-felling-verify] RESULT PASS: 10 native tree/hive cases");
+      for (int mode = 0; mode < HIVE_CASES; mode++) verifyHive(level, mode);
+      verifyOwnedLogCannotHoldCanopy(level, HIVE_CASES);
+      verifyNaturalTreeKeepsSharedCanopy(level, HIVE_CASES + 1);
+      verifyProtectedLeavesRemain(level, HIVE_CASES + 2);
+      Kithkyn.LOGGER.info("[tree-felling-verify] RESULT PASS: {} native tree/hive/canopy cases",
+          HIVE_CASES + CANOPY_CASES);
     } catch (Exception | AssertionError failure) {
       Kithkyn.LOGGER.error("[tree-felling-verify] RESULT FAIL", failure);
     }
     event.getServer().halt(false);
   }
 
-  private static void verify(ServerLevel level, int mode) {
+  private static void verifyHive(ServerLevel level, int mode) {
     BlockPos log = new BlockPos(-3000 + mode * 24, 160, -3000);
     BlockPos hive = log.east();
     level.getEntitiesOfClass(Bee.class, new AABB(log).inflate(8)).forEach(Bee::discard);
@@ -107,6 +115,77 @@ public final class TreeFellingVerification {
     if (crafted) check(drops.stream().filter(drop -> drop.is(Items.BEEHIVE))
         .mapToInt(ItemStack::getCount).sum() == 1, "Hive loot missing or duplicated");
     Kithkyn.LOGGER.info("[tree-felling-verify] PASS mode={} released={} saved={}", mode, released, savedBees);
+  }
+
+  /** A village beam must not preserve the natural canopy of the tree beside it. */
+  private static void verifyOwnedLogCannotHoldCanopy(ServerLevel level, int mode) {
+    CanopyFixture fixture = canopyFixture(level, mode);
+    BlockPos buildingLog = fixture.leaves().getLast().east();
+    level.setBlock(buildingLog, Blocks.OAK_LOG.defaultBlockState(), 2);
+    PlacedBlockStore.get(level).markVillagePlaced(buildingLog);
+
+    TreeFelling.fell(level, fixture.trunk(), null, ItemStack.EMPTY);
+
+    check(level.getBlockState(buildingLog).is(Blocks.OAK_LOG), "Village beam was felled");
+    for (BlockPos leaf : fixture.leaves()) {
+      check(level.getBlockState(leaf).isAir(), "Village beam kept orphaned leaf at " + leaf);
+    }
+    Kithkyn.LOGGER.info("[tree-felling-verify] PASS owned log cannot hold felled canopy");
+  }
+
+  /** Leaves shared with another living natural tree still belong in the world. */
+  private static void verifyNaturalTreeKeepsSharedCanopy(ServerLevel level, int mode) {
+    CanopyFixture fixture = canopyFixture(level, mode);
+    BlockPos livingLog = fixture.leaves().getLast().east();
+    level.setBlock(livingLog, Blocks.OAK_LOG.defaultBlockState(), 2);
+
+    TreeFelling.fell(level, fixture.trunk(), null, ItemStack.EMPTY);
+
+    check(level.getBlockState(livingLog).is(Blocks.OAK_LOG), "Neighboring natural tree was felled");
+    for (BlockPos leaf : fixture.leaves()) {
+      check(level.getBlockState(leaf).is(Blocks.OAK_LEAVES),
+          "Shared living canopy was removed at " + leaf);
+    }
+    Kithkyn.LOGGER.info("[tree-felling-verify] PASS neighboring tree keeps shared canopy");
+  }
+
+  /** Persistent leaves and explicitly owned natural-state leaves are never canopy cleanup. */
+  private static void verifyProtectedLeavesRemain(ServerLevel level, int mode) {
+    CanopyFixture fixture = canopyFixture(level, mode);
+    BlockPos persistent = fixture.trunk().above(2);
+    BlockPos owned = fixture.trunk().above().west();
+    BlockState persistentLeaf = Blocks.OAK_LEAVES.defaultBlockState()
+        .setValue(LeavesBlock.PERSISTENT, true);
+    level.setBlock(persistent, persistentLeaf, 2);
+    level.setBlock(owned, Blocks.OAK_LEAVES.defaultBlockState(), 2);
+    PlacedBlockStore.get(level).markPlayerPlaced(owned);
+
+    TreeFelling.fell(level, fixture.trunk(), null, ItemStack.EMPTY);
+
+    check(level.getBlockState(persistent).is(Blocks.OAK_LEAVES), "Persistent leaf was removed");
+    check(level.getBlockState(owned).is(Blocks.OAK_LEAVES), "Player-owned leaf was removed");
+    Kithkyn.LOGGER.info("[tree-felling-verify] PASS protected leaves remain");
+  }
+
+  /** A minimal canopy spanning from a two-log trunk toward a possible support log. */
+  private static CanopyFixture canopyFixture(ServerLevel level, int mode) {
+    BlockPos trunk = new BlockPos(-3000 + mode * 24, 160, -3000);
+    PlacedBlockStore placed = PlacedBlockStore.get(level);
+    for (BlockPos pos : BlockPos.betweenClosed(trunk.offset(-3, -1, -3), trunk.offset(7, 4, 3))) {
+      placed.clearPlaced(pos);
+      level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2);
+    }
+    level.setBlock(trunk, Blocks.OAK_LOG.defaultBlockState(), 2);
+    level.setBlock(trunk.above(), Blocks.OAK_LOG.defaultBlockState(), 2);
+    List<BlockPos> leaves = List.of(
+        trunk.above(2), trunk.above(2).east(), trunk.above(2).east(2), trunk.above(2).east(3));
+    for (BlockPos leaf : leaves) {
+      level.setBlock(leaf, Blocks.OAK_LEAVES.defaultBlockState(), 2);
+    }
+    return new CanopyFixture(trunk, leaves);
+  }
+
+  private record CanopyFixture(BlockPos trunk, List<BlockPos> leaves) {
   }
 
   private static void check(boolean condition, String message) {

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/ChopStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/ChopStep.java
@@ -37,8 +37,9 @@ import net.minecraft.world.phys.Vec3;
  *
  * A worker strikes one log for a chop's worth of ticks; when it gives, the
  * whole connected tree comes down at once through {@link TreeFelling}, and
- * every log lands in the worker's pack. Leaves are left to decay on their own
- * schedule, as natural leaves do once their tree is gone.
+ * every log lands in the worker's pack. Natural canopy that no other living
+ * tree supports decays with the fell, dropping its loot on the ground; an
+ * owned building log cannot hold that severed canopy in place.
  *
  * <b>It only ever cuts real trees.</b> {@link TreeFelling#isFellableLog} holds
  * the two guards, a natural canopy nearby and nobody's ownership, that keep the

--- a/src/main/java/com/quzzar/kithkyn/village/TreeFelling.java
+++ b/src/main/java/com/quzzar/kithkyn/village/TreeFelling.java
@@ -31,8 +31,11 @@ import net.minecraft.world.level.levelgen.Heightmap;
  * connected to it comes away at once, a bounded flood fill over the trunk and
  * its branches, each log yielding its drops. Unowned bee nests or hives attached
  * to removed logs come down too, with normal bee release and Silk Touch loot.
- * The leaves are left to decay on
- * their own schedule, as natural leaves do once their tree is gone.
+ * Natural leaves that belonged to the removed logs decay with the fell. The
+ * cleanup deliberately ignores player- and village-owned logs as support, so
+ * a timber building cannot hold a severed canopy over a lumberjack's next
+ * sapling. Persistent or ownership-marked leaves remain, as does canopy still
+ * supported by another natural tree.
  *
  * <b>It only ever cuts real trees.</b> Two guards keep it off the village's
  * own timber and off anything a player built:
@@ -62,8 +65,18 @@ public final class TreeFelling {
   /** Most logs one fell removes: a ceiling for giant trees so the flood fill always ends. */
   private static final int TREE_LOG_CAP = 256;
 
+  /** Vanilla leaves live at most this many leaf steps from a supporting log. */
+  private static final int CANOPY_REACH = LeavesBlock.DECAY_DISTANCE - 1;
+
+  /** A ceiling for modded giant canopies so one fell always has bounded work. */
+  private static final int CANOPY_LEAF_CAP = 4096;
+
   /** One tree brought down: the log it was struck at, and what its logs dropped. */
   public record FelledTree(BlockPos struck, List<ItemStack> drops) {
+  }
+
+  /** One position in a bounded canopy/support walk and its distance from the start. */
+  private record CanopySearch(BlockPos pos, int distance) {
   }
 
   private TreeFelling() {
@@ -103,8 +116,9 @@ public final class TreeFelling {
    * struck that trunk, nothing came away, and the loop offered the same log
    * again; the lodge now ships a sapling, and the exemption stays so that
    * nothing anyone places against the stand can jam the loop. Otherwise
-   * identical: whole tree, drops returned, leaves left to decay. Attached hives
-   * still respect ownership, so a nearby apiary cannot be lost to stand work.
+   * identical: whole tree, drops returned, and its orphaned natural canopy
+   * decayed. Attached hives still respect ownership, so a nearby apiary cannot
+   * be lost to stand work.
    */
   public static List<ItemStack> fellStand(ServerLevel level, BlockPos struck, @Nullable Entity feller,
       ItemStack tool) {
@@ -122,12 +136,18 @@ public final class TreeFelling {
     BlockState soundFrom = null;
     LongOpenHashSet attachedHives = new LongOpenHashSet();
     PlacedBlockStore placed = PlacedBlockStore.get(level);
+    List<BlockPos> logs = new ArrayList<>();
     for (BlockPos pos : treeLogs(level, struck)) {
       BlockState state = level.getBlockState(pos);
       if (!state.is(BlockTags.LOGS_THAT_BURN) || state.hasBlockEntity()
           || (!stand && !BlockOwnership.mayFell(level, pos))) {
         continue;
       }
+      logs.add(pos);
+    }
+    List<BlockPos> canopy = canopyLeaves(level, logs, placed);
+    for (BlockPos pos : logs) {
+      BlockState state = level.getBlockState(pos);
       drops.addAll(Block.getDrops(state, level, pos, level.getBlockEntity(pos), feller, tool));
       if (soundFrom == null) {
         soundFrom = state;
@@ -144,12 +164,120 @@ public final class TreeFelling {
     for (long hive : attachedHives) {
       fellAttachedHive(level, BlockPos.of(hive), feller, tool, drops);
     }
+    decayOrphanedCanopy(level, canopy, placed);
     if (soundFrom != null) {
       level.playSound((Player) null, struck.getX(), struck.getY(), struck.getZ(),
           soundFrom.getSoundType().getBreakSound(), SoundSource.BLOCKS, 1.0F,
           level.getRandom().nextFloat() * 0.4F + 0.8F);
     }
     return drops;
+  }
+
+  /**
+   * Captures the natural leaves this tree supports before its logs disappear.
+   * This is the same six-direction distance model vanilla leaves use, bounded
+   * both by vanilla's maximum support distance and a hard leaf count. Owned or
+   * persistent leaves are barriers, not part of a natural canopy.
+   */
+  private static List<BlockPos> canopyLeaves(ServerLevel level, List<BlockPos> logs,
+      PlacedBlockStore placed) {
+    List<BlockPos> leaves = new ArrayList<>();
+    ArrayDeque<CanopySearch> frontier = new ArrayDeque<>();
+    LongOpenHashSet visited = new LongOpenHashSet();
+    for (BlockPos log : logs) {
+      BlockPos start = log.immutable();
+      if (visited.add(start.asLong())) {
+        frontier.add(new CanopySearch(start, 0));
+      }
+    }
+    while (!frontier.isEmpty() && leaves.size() < CANOPY_LEAF_CAP) {
+      CanopySearch current = frontier.poll();
+      if (current.distance() >= CANOPY_REACH) {
+        continue;
+      }
+      for (Direction direction : Direction.values()) {
+        BlockPos next = current.pos().relative(direction);
+        if (!visited.add(next.asLong()) || !level.hasChunkAt(next)) {
+          continue;
+        }
+        BlockState state = level.getBlockState(next);
+        if (!isNaturalLeaf(state, next, placed)) {
+          continue;
+        }
+        BlockPos leaf = next.immutable();
+        leaves.add(leaf);
+        int distance = current.distance() + 1;
+        if (distance < CANOPY_REACH) {
+          frontier.add(new CanopySearch(leaf, distance));
+        }
+      }
+    }
+    return leaves;
+  }
+
+  /**
+   * Forces only unsupported natural leaves through the ordinary decay result.
+   * Drops are spawned where each leaf stood, just as a vanilla random decay
+   * would spawn them, so saplings remain physical things for workers to pick up.
+   */
+  private static void decayOrphanedCanopy(ServerLevel level, List<BlockPos> canopy,
+      PlacedBlockStore placed) {
+    for (BlockPos leaf : canopy) {
+      BlockState state = level.getBlockState(leaf);
+      if (!isNaturalLeaf(state, leaf, placed)
+          || hasNaturalSupportOrUnknown(level, leaf, placed)) {
+        continue;
+      }
+      Block.dropResources(state, level, leaf);
+      level.removeBlock(leaf, false);
+    }
+  }
+
+  /** Natural, removable foliage rather than player or village decoration. */
+  private static boolean isNaturalLeaf(BlockState state, BlockPos pos, PlacedBlockStore placed) {
+    return state.is(BlockTags.LEAVES)
+        && state.hasProperty(LeavesBlock.PERSISTENT)
+        && !state.getValue(LeavesBlock.PERSISTENT)
+        && !placed.isPlayerPlaced(pos)
+        && !placed.isVillagePlaced(pos);
+  }
+
+  /**
+   * Whether another natural log can support this leaf through vanilla's leaf
+   * distance. Player- and village-owned logs are structures, so they do not
+   * preserve a canopy whose tree was felled. An unloaded neighbor is unknown
+   * and therefore preserves the leaf rather than risking another tree's canopy.
+   */
+  private static boolean hasNaturalSupportOrUnknown(ServerLevel level, BlockPos start,
+      PlacedBlockStore placed) {
+    ArrayDeque<CanopySearch> frontier = new ArrayDeque<>();
+    LongOpenHashSet visited = new LongOpenHashSet();
+    frontier.add(new CanopySearch(start, 0));
+    visited.add(start.asLong());
+    while (!frontier.isEmpty()) {
+      CanopySearch current = frontier.poll();
+      if (current.distance() >= CANOPY_REACH) {
+        continue;
+      }
+      for (Direction direction : Direction.values()) {
+        BlockPos next = current.pos().relative(direction);
+        if (!level.hasChunkAt(next)) {
+          return true;
+        }
+        BlockState state = level.getBlockState(next);
+        if (state.is(BlockTags.LOGS)
+            && !placed.isPlayerPlaced(next)
+            && !placed.isVillagePlaced(next)) {
+          return true;
+        }
+        int distance = current.distance() + 1;
+        if (distance < CANOPY_REACH && state.is(BlockTags.LEAVES)
+            && visited.add(next.asLong())) {
+          frontier.add(new CanopySearch(next.immutable(), distance));
+        }
+      }
+    }
+    return false;
   }
 
   /** Only hives touching a removed log come down; even stand felling preserves owned apiaries. */


### PR DESCRIPTION
## Summary

- decay unsupported natural canopy as part of tree felling
- ignore player- and village-owned structure logs as living canopy support
- preserve authored foliage and leaves supported by another natural tree
- cover ownership, shared-canopy, and protected-leaf behavior in the native verification harness

## Verification

- ./gradlew build --no-daemon
- isolated TreeFellingVerification: 13 cases passed
- git diff --check