### PR TITLE
Record the storehouse re-edit

### DIFF
--- a/docs/floodplain-village.md
+++ b/docs/floodplain-village.md
@@ -22,7 +22,7 @@ definitions, all new ids, so the pack needs no filter:
 | --- | --- | --- | --- |
 | `village_center_floodplain_1` | Nilotic cartographer house with four white banners and the green carpet cross | 0 | quartermaster, builder, guard captain |
 | `mine_floodplain_1` | Nilotic armorer house with the authored pit floor | 0 | miner in the 3x3 pit; the ramp starts at the pit's middle column and leaves east under the wall |
-| `storehouse_floodplain_1` | small house draft with barrels, a note block and two authored allays | 0 | none; the quartermaster keeps the centre post |
+| `storehouse_floodplain_1` | small house draft with barrels, a note block, an open doorway and two authored allays | 0 | none; the quartermaster keeps the centre post |
 | `church_floodplain_1` | Nilotic temple | 0 | cleric |
 | `lumberjack_floodplain_1` | Nilotic farmer house | 1 | lumberjack on the jungle sapling |
 | `hunting_lodge_floodplain_1` | Nilotic fletcher house | 1 | hunter |
@@ -61,9 +61,11 @@ storage.
 Every house ships with the patchy earthen ground course Aaron laid under it (packed mud,
 mud, coarse dirt, rooted dirt) as its bottom layer, the way Desert ships its seating. The
 lumberjack's dead bush marker is exported as a jungle sapling on dirt: the wood loop refuses
-mangrove propagules because a grown mangrove leaves roots on the stand. The storehouse
-doorway trapdoor and the watchtower's ladder hatch are exported open, since the runtime opens
-doors and gates but never trapdoors; the guard climbs through the open hatch to the bunk.
+mangrove propagules because a grown mangrove leaves roots on the stand. The watchtower's ladder
+hatch is exported open, since the runtime opens doors and gates but never trapdoors; the guard
+climbs through the open hatch to the bunk. The storehouse has no doorway panel at all: Aaron
+removed it on a production copy placed in the gallery (row NA07) and trimmed the course corners,
+and that copy is the storehouse's source capture now.
 
 Walls are not exported. The runtime paints the shared arid wall geometry
 ([walls.md](walls.md)) in the floodplain palette: mud bricks for posts, deck, body, stairs

--- a/docs/structure-review.md
+++ b/docs/structure-review.md
@@ -1760,3 +1760,10 @@ well one block high (it sinks one), and the mine ramp starting at the pit's edge
 lumberjack also composts surplus saplings, and the quartermaster names the keeper. The site was founded again
 as Mavulena.
 
+### Storehouse re-edit: September 10
+
+A copy of the production floodplain storehouse was placed on its own pad in the Nilotic gallery (row NA07)
+for Aaron to edit. He removed the doorway trapdoor, so the doorway is open, and trimmed the earthen course
+corners. The copy was captured from a flushed snapshot and became the storehouse's source capture; the
+open-trapdoor export override is gone; the pack was rebuilt, checked and reinstalled live with a reload.
+

--- a/tools/structure/floodplain-catalog-20260910.json
+++ b/tools/structure/floodplain-catalog-20260910.json
@@ -168,11 +168,11 @@
       "source_mod": "t_and_t-neoforge-fabric-1.13.9+1.21.1.jar",
       "source_mod_structure": "data/kaisyn/structure/village/exclusives/nilotic/houses/nilotic_small_house_1.nbt",
       "asset": "run/floodplain-integration/datapack/data/kithkyn/structure/storehouse_floodplain_1.nbt",
-      "asset_sha256": "5f23186d9542ff59d1e0d3fc35f39f75794246d331478f746862f15e6179b3a6",
+      "asset_sha256": "89b3fa1e45252e4d0e6d77889146343d519c5aa14907f460b7c27ccc0a1f05dc",
       "definition": "run/floodplain-integration/datapack/data/kithkyn/kithkyn/buildings/storehouse_floodplain_1.json",
       "definition_sha256": "6f7e7acdca735d22b7531b28a9fe4ae2ffb56c50fb9514eec01508ac2e5334ee",
       "reviewed_capture": "run/nilotic-showcase/selection-20260910-floodplain/captures/NA02.4.nbt",
-      "reviewed_capture_sha256": "74a857c1c4e572bcd40a688180aa07cffa09bbc5b6d91db34db8628fab9eb305"
+      "reviewed_capture_sha256": "07b720e63b5257071e75ff4b1d0730f6d4d91d0451ca7a98234b8b44ed0cd419"
     },
     {
       "exhibit": "NA03.2",
@@ -384,5 +384,14 @@
       "lodge composting",
       "quartermaster names the keeper"
     ]
-  }
+  },
+  "revisions": [
+    {
+      "date": "2026-09-10",
+      "structures": [
+        "storehouse_floodplain_1"
+      ],
+      "note": "Aaron re-edited the storehouse on a production copy in the gallery (NA07.1): the doorway trapdoor removed so the doorway is open, the course corners trimmed. Re-captured and re-exported; the open-trapdoor override is gone."
+    }
+  ]
 }

--- a/tools/structure/nilotic-selections-20260910.json
+++ b/tools/structure/nilotic-selections-20260910.json
@@ -82,7 +82,7 @@
     "market_restyle": "cut sandstone to mud bricks, sandstone stairs to mud brick stairs, acacia fences to spruce, acacia logs to mangrove, potted cactus and dead bush to fern; wool, carpets and banners kept as identity slots",
     "market_edit": "Aaron removed one extra orange carpet from the market drafts; captures refreshed afterwards",
     "wall_palette": {
-      "status": "decided 2026-09-10, applied to the NA05 drafts",
+      "status": "approved by Aaron 2026-09-10 after one hand correction; the five sections are captured in the selection record",
       "body": "minecraft:mud_bricks for posts, deck, wall body and tower shell (every stripped oak log / oak plank cell)",
       "steps_and_slabs": "minecraft:mud_brick_stairs / minecraft:mud_brick_slab keep the authored facing and half",
       "railing": "minecraft:mud_brick_wall in place of every fence (mud brick walls, not mangrove fences)",
@@ -90,7 +90,8 @@
       "frame": "minecraft:muddy_mangrove_roots on the gatehouse uprights (x 6 and 10, z 1 and 3, y < 5) and the y 5 beams, mirroring the chiseled stone trim of the arid WallPalette",
       "light": "minecraft:brown_candle clusters (candles = 2 + floorMod(31x + 17z + y, 3), lit) wherever a standing lantern stood; inward roof lanterns removed like the arid palette",
       "hanging_lanterns": "the four lanterns hanging under the gatehouse arch stay lanterns",
-      "runtime": "becomes the FLOODPLAIN case of WallPalette.forStyle once the floodplain VillageStyle lands"
+      "runtime": "becomes the FLOODPLAIN case of WallPalette.forStyle once the floodplain VillageStyle lands",
+      "post_tops": "a log standing on end at y 5 (the post tops at x 5 and x 16, z 2) is a post, not a beam, and stays mud bricks; only the lying logs of the roof rim and the four uprights are roots, as isGateFrame classifies them"
     }
   },
   "buildings": [
@@ -1413,34 +1414,34 @@
       "source_mod_structure": "data/kaisyn/structure/village/exclusives/nilotic/houses/nilotic_small_house_1.nbt",
       "source_mod_structure_sha256": "c3c852df1031b0bde7dd7d790f3812bbfbaad443ed6e86b534a63e51145d2005",
       "source_capture": "run/nilotic-showcase/selection-20260910-floodplain/captures/NA02.4.nbt",
-      "source_capture_sha256": "74a857c1c4e572bcd40a688180aa07cffa09bbc5b6d91db34db8628fab9eb305",
+      "source_capture_sha256": "07b720e63b5257071e75ff4b1d0730f6d4d91d0451ca7a98234b8b44ed0cd419",
       "gallery_origin": [
-        6623,
-        230,
-        1039
+        6576,
+        231,
+        1205
       ],
       "capture_from": [
-        6621,
-        229,
-        1037
+        6574,
+        230,
+        1203
       ],
       "capture_to": [
-        6631,
-        275,
-        1047
+        6584,
+        244,
+        1213
       ],
       "solid_bounds_relative_to_gallery_origin": [
         [
-          -1,
-          7
+          0,
+          6
         ],
         [
           -1,
           4
         ],
         [
-          -1,
-          7
+          0,
+          6
         ]
       ],
       "copy_of_exhibit": "NA02.1",
@@ -1492,33 +1493,8 @@
         "coloured_blocks": {}
       },
       "notes": [
-        "replaced again on Aaron's request for a smaller base; ground course re-laid"
+        "Re-captured 2026-09-10 evening from the NA07.1 production copy after Aaron trimmed the course corners and removed the doorway trapdoor; the doorway is open."
       ],
-      "gallery_furniture": {
-        "sea_lanterns": [
-          [
-            -1,
-            -1,
-            -1
-          ],
-          [
-            7,
-            -1,
-            -1
-          ],
-          [
-            -1,
-            -1,
-            7
-          ],
-          [
-            7,
-            -1,
-            7
-          ]
-        ],
-        "note": "Apron corner lighting from the gallery; exclude at export."
-      },
       "allay_delivery_points": [
         [
           2,


### PR DESCRIPTION
## Summary
- The floodplain storehouse's source capture is Aaron's edited production copy from gallery row NA07: doorway trapdoor removed (open doorway), earthen course corners trimmed.
- The open-trapdoor export override is dropped; the selection record and the catalog record carry the new capture and asset hashes.

## Test plan
- [x] `check.py`: 20 definitions and templates
- [x] Native placement (8 placements, four rotations) and access (4 rotated structures, 12 routes) for `storehouse_floodplain_1`
- [x] Pack reinstalled on the live world with a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)