### PR TITLE
Treat a mangrove's stilt roots as the tree's wood

### DIFF
--- a/docs/floodplain-village.md
+++ b/docs/floodplain-village.md
@@ -67,6 +67,10 @@ climbs through the open hatch to the bunk. The storehouse has no doorway panel a
 removed it on a production copy placed in the gallery (row NA07) and trimmed the course corners,
 and that copy is the storehouse's source capture now.
 
+Mangrove stilt roots count as vegetation everywhere: felled with their trunk, cleared by the
+lumberjack's sweep when left standing, and removed by builders, walls and grading through
+the `kithkyn:clearable` tag. Muddy mangrove roots are ground, graded like dirt.
+
 Walls are not exported. The runtime paints the shared arid wall geometry
 ([walls.md](walls.md)) in the floodplain palette: mud bricks for posts, deck, body, stairs
 and slabs, mud brick walls as railings, jungle trapdoors, muddy mangrove roots on the

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -555,6 +555,11 @@ bedtime restock leaves the pack short and the village stores hold bones, the far
 brain is offered a grind through the shared `CraftOffer` press
 ([llm-brain.md](llm-brain.md)), so skeleton drops end up as crops too.
 
+A mangrove's stilt roots are part of the tree to the village: the felling helper takes them down
+with the trunk, the lumberjack's sweep clears a root cluster left standing, and the
+`kithkyn:clearable` tag lists them so builders, walls and grading treat them as vegetation
+rather than the rock ledge the survey once mistook them for.
+
 The lumberjack runs the same step on the lodge's own composter with a `TIMBER` diet: every
 felled canopy drops more saplings than one stand needs, and the pack's saplings past the four
 kept for replanting go into the composter, whose bone meal `BonemealStep` then spends on the

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/ChopStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/ChopStep.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
  * tree supports decays with the fell, dropping its loot on the ground; an
  * owned building log cannot hold that severed canopy in place.
  *
- * <b>It only ever cuts real trees.</b> {@link TreeFelling#isFellableLog} holds
+ * <b>It only ever cuts real trees.</b> {@link TreeFelling#isFellableWood} holds
  * the two guards, a natural canopy nearby and nobody's ownership, that keep the
  * axe off the village's own timber and off anything a player built; the flood
  * fill re-checks every log, so a wild tree overhanging a roof drops its own
@@ -225,7 +225,7 @@ public final class ChopStep implements WorkStep<ChopStep.Cut> {
 
     BlockState state = person.level().getBlockState(target);
     boolean trimming = state.is(BlockTags.LEAVES);
-    if (!state.is(BlockTags.LOGS_THAT_BURN) && !trimming) {
+    if (!TreeFelling.isWood(state) && !trimming) {
       return false; // somebody else got the log, or a leaf already fell away
     }
 
@@ -399,12 +399,12 @@ public final class ChopStep implements WorkStep<ChopStep.Cut> {
       for (int y = -WOODLAND_VERTICAL_RADIUS; y <= WOODLAND_VERTICAL_RADIUS; ++y) {
         for (int z = -radius; z <= radius; ++z) {
           cursor.setWithOffset(around, x, y, z);
-          if (!TreeFelling.isFellableLog(level, cursor)) {
+          if (!TreeFelling.isFellableWood(level, cursor)) {
             continue;
           }
           long key = cursor.asLong();
           if (!baseOf.containsKey(key)) {
-            List<BlockPos> logs = TreeFelling.treeLogs(level, cursor.immutable());
+            List<BlockPos> logs = TreeFelling.treeWood(level, cursor.immutable());
             long base = lowestOf(logs).asLong();
             for (BlockPos log : logs) {
               baseOf.put(log.asLong(), base);

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/ForageChopStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/ForageChopStep.java
@@ -65,7 +65,7 @@ public final class ForageChopStep implements BlockWorkStep {
       for (int y = -VERTICAL_RANGE; y <= VERTICAL_RANGE; y++) {
         for (int z = -RANGE; z <= RANGE; z++) {
           cursor.setWithOffset(here, x, y, z);
-          if (!TreeFelling.isFellableLog(level, cursor)) {
+          if (!TreeFelling.isFellableWood(level, cursor)) {
             continue;
           }
           double distance = cursor.distSqr(here);

--- a/src/main/java/com/quzzar/kithkyn/village/TreeFelling.java
+++ b/src/main/java/com/quzzar/kithkyn/village/TreeFelling.java
@@ -21,6 +21,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.entity.BeehiveBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -87,12 +88,17 @@ public final class TreeFelling {
    * with a natural canopy near it, that nobody placed. Unloaded chunks are
    * never paged in to answer; a position in one is simply not fellable.
    */
-  public static boolean isFellableLog(ServerLevel level, BlockPos pos) {
+  public static boolean isFellableWood(ServerLevel level, BlockPos pos) {
     return level.hasChunkAt(pos)
-        && level.getBlockState(pos).is(BlockTags.LOGS_THAT_BURN)
+        && isWood(level.getBlockState(pos))
         && !level.getBlockState(pos).hasBlockEntity()
         && BlockOwnership.mayFell(level, pos)
         && hasNaturalCanopy(level, pos);
+  }
+
+  /** A log, or the stilt roots a mangrove stands on: the wood of a tree, felled together. */
+  public static boolean isWood(BlockState state) {
+    return state.is(BlockTags.LOGS_THAT_BURN) || state.is(Blocks.MANGROVE_ROOTS);
   }
 
   /**
@@ -137,9 +143,9 @@ public final class TreeFelling {
     LongOpenHashSet attachedHives = new LongOpenHashSet();
     PlacedBlockStore placed = PlacedBlockStore.get(level);
     List<BlockPos> logs = new ArrayList<>();
-    for (BlockPos pos : treeLogs(level, struck)) {
+    for (BlockPos pos : treeWood(level, struck)) {
       BlockState state = level.getBlockState(pos);
-      if (!state.is(BlockTags.LOGS_THAT_BURN) || state.hasBlockEntity()
+      if (!isWood(state) || state.hasBlockEntity()
           || (!stand && !BlockOwnership.mayFell(level, pos))) {
         continue;
       }
@@ -321,11 +327,74 @@ public final class TreeFelling {
     // The heightmap's value is the first air above the tallest block in the column.
     int top = level.getHeight(Heightmap.Types.WORLD_SURFACE, x, z) - 1;
     for (int y = top; y >= minimumY; y--) {
-      if (isFellableLog(level, cursor.set(x, y, z))) {
+      if (isFellableWood(level, cursor.set(x, y, z))) {
         BlockPos struck = cursor.immutable();
         felled.add(new FelledTree(struck, fell(level, struck, null, ItemStack.EMPTY)));
       }
     }
+  }
+
+  /** How far from a tree's own trunk columns its roots are taken; mangrove root systems touch. */
+  private static final int ROOT_REACH = 3;
+
+  /**
+   * The wood of one tree: its connected logs, then the mangrove roots those
+   * logs stand on within {@link #ROOT_REACH} of a trunk column. Started on a
+   * root with no log above it (a cluster left when the trunk came down), the
+   * roots within reach of that root are the tree.
+   */
+  public static List<BlockPos> treeWood(ServerLevel level, BlockPos start) {
+    List<BlockPos> logs = treeLogs(level, start);
+    List<BlockPos> seeds = logs.isEmpty() ? List.of(start) : logs;
+    List<BlockPos> wood = new ArrayList<>(logs);
+    wood.addAll(treeRoots(level, seeds));
+    return wood;
+  }
+
+  /** Mangrove roots reachable through roots from the seeds, each within reach of a seed column. */
+  private static List<BlockPos> treeRoots(ServerLevel level, List<BlockPos> seeds) {
+    List<BlockPos> roots = new ArrayList<>();
+    ArrayDeque<BlockPos> frontier = new ArrayDeque<>();
+    LongOpenHashSet visited = new LongOpenHashSet();
+    for (BlockPos seed : seeds) {
+      visited.add(seed.asLong());
+      frontier.add(seed);
+    }
+    while (!frontier.isEmpty() && roots.size() < TREE_LOG_CAP) {
+      BlockPos pos = frontier.poll();
+      if (!level.hasChunkAt(pos)) {
+        continue;
+      }
+      boolean root = level.getBlockState(pos).is(Blocks.MANGROVE_ROOTS);
+      if (root) {
+        roots.add(pos);
+      } else if (!seeds.contains(pos)) {
+        continue; // only roots, and the seeds themselves, lead on
+      }
+      for (int dx = -1; dx <= 1; dx++) {
+        for (int dy = -1; dy <= 1; dy++) {
+          for (int dz = -1; dz <= 1; dz++) {
+            if (dx == 0 && dy == 0 && dz == 0) {
+              continue;
+            }
+            BlockPos next = pos.offset(dx, dy, dz);
+            if (withinReach(next, seeds) && visited.add(next.asLong())) {
+              frontier.add(next);
+            }
+          }
+        }
+      }
+    }
+    return roots;
+  }
+
+  private static boolean withinReach(BlockPos pos, List<BlockPos> seeds) {
+    for (BlockPos seed : seeds) {
+      if (Math.abs(pos.getX() - seed.getX()) <= ROOT_REACH && Math.abs(pos.getZ() - seed.getZ()) <= ROOT_REACH) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/main/resources/data/kithkyn/tags/block/clearable.json
+++ b/src/main/resources/data/kithkyn/tags/block/clearable.json
@@ -20,6 +20,7 @@
     "minecraft:bamboo",
     "minecraft:cactus",
     "minecraft:snow",
-    "minecraft:moss_carpet"
+    "minecraft:moss_carpet",
+    "minecraft:mangrove_roots"
   ]
 }


### PR DESCRIPTION
## Summary
- `TreeFelling.treeWood` returns a tree's logs plus the mangrove roots within three blocks of a trunk column; `fell` takes them down with the trunk, and `isFellableWood` lets the lumberjack's sweep pick up a root cluster left standing. `ChopStep` acts on roots as wood.
- `kithkyn:clearable` names `minecraft:mangrove_roots`, so site clearing, wall raising and grading treat stilt roots as vegetation.
- Docs: worker loops and the floodplain village note the rule.

## Test plan
- [x] `./gradlew test`: 470 tests, 0 failures
- [x] Native tree felling verification: RESULT PASS, 13 tree/hive/canopy cases, on a mangrove swamp world

🤖 Generated with [Claude Code](https://claude.com/claude-code)