### PR TITLE
Add a seating check and raise the buildings it caught

### DIFF
--- a/docs/structure-authoring.md
+++ b/docs/structure-authoring.md
@@ -216,3 +216,14 @@ mouth in these original families; `mine_entrance` can override that frame), and 
 is placed so the two ramps never meet. The level-2 mine has been
 validated and rendered offline only; the gallery and a real upgrade in a live village are the
 checks still owed.
+
+## Seating check
+
+A template's layer 0 replaces the terrain's top block; `sink` buries that many more layers and
+`-1` lifts layer 0 onto the ground. The tell for a building seated one block low is a doorstep
+stair swallowed by the ground: a bottom-half stair in the layer that meets the surface. Run
+`tools/structure/seating-check.py <data-root>...` over a pack before activating it; a floor
+layer with such a stair wants `sink: -1`, while a farm's or plaza's edging stairs in a ground
+course are a judgement call. The Badlands storehouse, mine, bakery and tavern, the Desert
+small houses and couple cottage, and the Birch mine and second watchtower were raised this way
+on 2026-09-10; buildings already standing keep their seat.

--- a/src/main/resources/data/kithkyn/kithkyn/buildings/mine_birch_forest_1.json
+++ b/src/main/resources/data/kithkyn/kithkyn/buildings/mine_birch_forest_1.json
@@ -25,7 +25,7 @@
     "ORES",
     "FUEL"
   ],
-  "sink": 0,
+  "sink": -1,
   "entrance_facing": "west",
   "mine_entrance": {
     "facing": "east",

--- a/src/main/resources/data/kithkyn/kithkyn/buildings/watchtower_birch_forest_2.json
+++ b/src/main/resources/data/kithkyn/kithkyn/buildings/watchtower_birch_forest_2.json
@@ -44,7 +44,7 @@
     "PROTECTION",
     "RANGED_GUARD_POSTS"
   ],
-  "sink": 0,
+  "sink": -1,
   "village_identity": {
     "primary_blocks": [
       [

--- a/tools/structure/README.md
+++ b/tools/structure/README.md
@@ -28,6 +28,7 @@ themselves — they only transform files you point them at.
 | `validate.py` | Flag blocks that would drop on placement — bed and door halves, wall torches, gravity-affected stacks, carpet on nothing |
 | `navcheck.py` | Score how walkable a finished structure is for a villager |
 | `roof.py` | Fix roof-stair facing |
+| `seating-check.py` | Flag catalog buildings seated one block low: a bottom-half stair in the layer that meets the ground is a doorstep swallowed by the terrain |
 | `export-birch.py` | Derive the approved Birch assets from the immutable capture manifest, rebase amenities, and print new definitions as an apply_patch patch |
 | `VillageTemplateExport.java` | Native Minecraft NBT export preserving typed entity data, clearing gameplay inventories, neutralizing explicit identity slots, and carving declared air | An optional `entities` plan key adds authored livestock or allays to a template.
 

--- a/tools/structure/badlands-catalog-20260909.json
+++ b/tools/structure/badlands-catalog-20260909.json
@@ -263,7 +263,7 @@
       "asset": "run/badlands-integration/datapack/data/kithkyn/structure/storehouse_badlands_1.nbt",
       "asset_sha256": "5db23d691b64ac6b5fff93844d0e92fdd69a838e1db8785fe5a30055b726e403",
       "definition": "run/badlands-integration/datapack/data/kithkyn/kithkyn/buildings/storehouse_badlands_1.json",
-      "definition_sha256": "bd16c5352da04a6b745e5c8b38dffe0cae1d5a382353c1b6386f0c120b7cd60d",
+      "definition_sha256": "ed8c546fb189bf452c3796f521afb9e2c562001951f3f07ead201fbf682f5314",
       "reviewed_neutral": "run/pueblo-showcase/services-approved-20260909-183601/neutral/P08.7.nbt",
       "reviewed_neutral_sha256": "2b4f5fd74f7510004cb910a181ae3ee36bb85b43ff05b6c0381100314c7f85e1"
     },
@@ -375,7 +375,7 @@
       "asset": "run/badlands-integration/datapack/data/kithkyn/structure/bakery_badlands_1.nbt",
       "asset_sha256": "a6f0baab3495b81ad79bb297dcc31418108be8445c1b4449af81280c735b1b54",
       "definition": "run/badlands-integration/datapack/data/kithkyn/kithkyn/buildings/bakery_badlands_1.json",
-      "definition_sha256": "e3bd44bc63d37b048fbd157317111ebe3b714d504a32ef549ed62fc8154a428a",
+      "definition_sha256": "0bdc0a318f986b12faf3515c9643555fc11cf8180056dc3f7a039779b56a6c60",
       "reviewed_neutral": "run/pueblo-showcase/services-approved-20260909-183601/neutral/P09.5.nbt",
       "reviewed_neutral_sha256": "844a3ffd29b32ada9fe909fa61690269819facb3b3ab9add9abf4fcb175ef17c"
     },
@@ -389,7 +389,7 @@
       "asset": "run/badlands-integration/datapack/data/kithkyn/structure/tavern_badlands_1.nbt",
       "asset_sha256": "78822ed4342a3da19ad0cb62394eb7aa6f585479101efe97d06d86f81b87de03",
       "definition": "run/badlands-integration/datapack/data/kithkyn/kithkyn/buildings/tavern_badlands_1.json",
-      "definition_sha256": "c82b4efa5262b561f81ac73c13bd6b0b1b940c191761f3cdd81cf2384ead11ae",
+      "definition_sha256": "07d3d53797b71f27c7834f4443d53775daa835ff5f0eabf4c0fdc86e298ba9af",
       "reviewed_neutral": "run/pueblo-showcase/services-approved-20260909-183601/neutral/P08.2.nbt",
       "reviewed_neutral_sha256": "7e00da1934bb049f07ef7a2fe95bfce6b2ac2967275f965f023028e4954247f0"
     },
@@ -431,7 +431,7 @@
       "asset": "run/badlands-integration/datapack/data/kithkyn/structure/mine_badlands_1.nbt",
       "asset_sha256": "f9c4d3ab15bda3776dea206cf02b90518b1a768f7a18e4c0b8dd689110224513",
       "definition": "run/badlands-integration/datapack/data/kithkyn/kithkyn/buildings/mine_badlands_1.json",
-      "definition_sha256": "14c3f856bfab631ab482e15903256773e37571c3783d55bc7200f4f8c0e0c540",
+      "definition_sha256": "45574cd0cc739c699cc900f7f38a0f0ca83f3afcdd9c45eae9c9f6f14a350442",
       "reviewed_neutral": "run/pueblo-showcase/workplaces-approved-20260909-181024/neutral/P11.5.nbt",
       "reviewed_neutral_sha256": "074f64976c569c3d9ab09664ac2658965913fc8d2b90c8151c154c72019baed1"
     }
@@ -454,5 +454,18 @@
     "catalog_update": "tools/structure/desert-temple-tower-adoption-20260910.json",
     "installed_files": 61
   },
-  "market_color_policy": "Market tent fabrics and decorative banners retain their original authored colors, independent of village identity; regional timber, masonry and plants may change."
+  "market_color_policy": "Market tent fabrics and decorative banners retain their original authored colors, independent of village identity; regional timber, masonry and plants may change.",
+  "revisions": [
+    {
+      "date": "2026-09-10",
+      "structures": [
+        "storehouse_badlands_1",
+        "mine_badlands_1",
+        "bakery_badlands_1",
+        "tavern_badlands_1"
+      ],
+      "change": "sink -1",
+      "note": "Seated one block low: a doorstep stair sat level with the ground (tools/structure/seating-check.py). Raised onto the ground; existing buildings keep their seat."
+    }
+  ]
 }

--- a/tools/structure/desert-catalog-20260909.json
+++ b/tools/structure/desert-catalog-20260909.json
@@ -33,7 +33,7 @@
       "manifest": "tools/structure/desert-houses-20260909.json",
       "recipe": "house_3",
       "asset_sha256": "ca1b3bee7c5f77e1c10f2db416135fe638506816bf114928408af50d525e51ee",
-      "definition_sha256": "393844ec2082a23110607a09ffbd8e0906e9bbd3cca978c1dad84fcf9656d68d",
+      "definition_sha256": "34206d6e0182a928ea97d28c532ab827b1866f3fdaf567852e4e901b9e4425f3",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/desert_oasis/house/big_2.nbt",
       "reviewed_neutral": "run/pueblo-showcase/desert-houses-approved-20260909-213200/neutral/D05.3.nbt",
@@ -69,7 +69,7 @@
       "manifest": "tools/structure/desert-houses-20260909.json",
       "recipe": "house_1",
       "asset_sha256": "2c4768383f08af13a46ed602561143d369dd7529c79681c133f8ad795e51ef07",
-      "definition_sha256": "bd12d30baa465f1dbbc742b261f72412aceabf2a0274d813f443ca46b019842f",
+      "definition_sha256": "6b0987ec78fbc24ac12cf1dfb5c7f82446c1d0900db054222426a8bd3ad4c265",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/desert_oasis/house/small_1.nbt",
       "reviewed_neutral": "run/pueblo-showcase/desert-houses-approved-20260909-213200/neutral/D05.6.nbt",
@@ -81,7 +81,7 @@
       "manifest": "tools/structure/desert-houses-20260909.json",
       "recipe": "house_1",
       "asset_sha256": "20b6be8658ce1c91f21eda4cbda0eb824ccfe329ac592de2afc66f15b7619d30",
-      "definition_sha256": "b9ab975d89b2af5f4250a86c7153298daf5229485170bd2802ce1186345f8a8a",
+      "definition_sha256": "058226e0a4810d8a6d4d77d215aeab1e9c38f7c1725c9a81da0baf888a3db327",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/desert_oasis/house/small_2.nbt",
       "reviewed_neutral": "run/pueblo-showcase/desert-houses-approved-20260909-213200/neutral/D05.7.nbt",
@@ -93,7 +93,7 @@
       "manifest": "tools/structure/desert-houses-20260909.json",
       "recipe": "house_1",
       "asset_sha256": "058846d69f754b3d8ef395fca6947f75c440f9391ba60b77074a11e727301983",
-      "definition_sha256": "401a5330f1c4effdf39b88a99ac112576d2d8a69d2a3d0d92b0d988b8f3a0db1",
+      "definition_sha256": "cc1168318a5ef61b90de8dff92ab99fd6ace589fa0517036d2da95bfd3f5744b",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/desert_oasis/house/small_3.nbt",
       "reviewed_neutral": "run/pueblo-showcase/desert-houses-approved-20260909-213200/neutral/D05.8.nbt",
@@ -105,7 +105,7 @@
       "manifest": "tools/structure/desert-houses-20260909.json",
       "recipe": "house_1",
       "asset_sha256": "86c1578049d828afd6a4c5820be44469fe0684d022541ef0d13a777928832260",
-      "definition_sha256": "68016692f2ccad7ab0bb0ffa18902c3e9569bf27ead1ea12220a3c9df89d915d",
+      "definition_sha256": "fa1aa3f9eef60cd6bb50cbd932a99e22742a74d0870173c162910a5fbcfb02fd",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/desert_oasis/house/small_4.nbt",
       "reviewed_neutral": "run/pueblo-showcase/desert-houses-approved-20260909-213200/neutral/D06.1.nbt",
@@ -117,7 +117,7 @@
       "manifest": "tools/structure/desert-houses-20260909.json",
       "recipe": "house_1",
       "asset_sha256": "4788c299ffb0e3ca973945bd0fa0636df440859ba365e648fe97f086b1b5f04b",
-      "definition_sha256": "730ffdf7396ce3f75dd1068ad7520b5d6c931a3c9cf8737c4ec221ce864d9577",
+      "definition_sha256": "56694afecf6b816dbbf5573c15fe71f490bf7c5b0bd97268611901e38b0f218e",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/desert_oasis/house/small_5.nbt",
       "reviewed_neutral": "run/pueblo-showcase/desert-houses-approved-20260909-213200/neutral/D06.2.nbt",
@@ -129,7 +129,7 @@
       "manifest": "tools/structure/desert-houses-20260909.json",
       "recipe": "house_1",
       "asset_sha256": "55f13c127f8f1e3630c16699f9b9fdcd8c20eeecae5e094b479f5fa049ef39ca",
-      "definition_sha256": "c4137bd4edd1558e0f74a829892b0b9caa784343a8aa8748b7ebd2d1c9c41a44",
+      "definition_sha256": "1b1ec0ec0e45d5d05420ad75a2763a43309de894cf41a77e8f2a99766160b130",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/desert_oasis/house/small_6.nbt",
       "reviewed_neutral": "run/pueblo-showcase/desert-houses-approved-20260909-213200/neutral/D06.3.nbt",
@@ -318,7 +318,7 @@
       "manifest": "tools/structure/desert-tavern-adoption-20260910.json",
       "recipe": "couple_cottage_1",
       "asset_sha256": "6bf1519d79a6460b15385e14bf96934aca04e7e00f9631ceb83c6cd8da695483",
-      "definition_sha256": "0fb1f8624dbacee8a0dd7c8a0577bd1d30e33908535bbdcd85ac95d82f361af3",
+      "definition_sha256": "38268c9aab8348c348136cda95b46432b20e47eb8c3c12baeb492edb83332d56",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/desert_oasis/house/big_1.nbt",
       "reviewed_neutral": "run/desert-integration/tavern-adoption-20260910/neutral/D05.2.nbt",
@@ -437,5 +437,22 @@
     "latest_castle_update": "run/castle-merchant-20260910/deployment.json"
   },
   "recipe_catalog": "src/main/resources/data/kithkyn/kithkyn/construction_recipes",
-  "market_color_policy": "Market tent fabrics and decorative banners retain their original authored colors, independent of village identity; regional timber, masonry and plants may change."
+  "market_color_policy": "Market tent fabrics and decorative banners retain their original authored colors, independent of village identity; regional timber, masonry and plants may change.",
+  "revisions": [
+    {
+      "date": "2026-09-10",
+      "structures": [
+        "couple_cottage_desert_1",
+        "house_desert_1",
+        "house_desert_1__small_house_2",
+        "house_desert_1__small_house_3",
+        "house_desert_1__small_house_4",
+        "house_desert_1__small_house_5",
+        "house_desert_1__small_house_6",
+        "house_desert_3"
+      ],
+      "change": "sink -1",
+      "note": "Seated one block low: a doorstep stair sat level with the ground (tools/structure/seating-check.py). Raised onto the ground; existing buildings keep their seat."
+    }
+  ]
 }

--- a/tools/structure/seating-check.py
+++ b/tools/structure/seating-check.py
@@ -1,0 +1,66 @@
+"""Flag catalog buildings that are probably seated one block too low.
+
+A template's layer 0 replaces the terrain's top block; ``sink`` buries that many
+more layers and ``-1`` lifts layer 0 onto the ground (BuildingInfo.getSink).
+The tell Aaron uses in the world is a flight of steps swallowed by the ground:
+a bottom-half stair in the seated layer sits level with the surface, so the
+step leads nowhere. This reads every definition of the given packs (a datapack
+root or the bundled resources) and lists the buildings whose seated layer holds
+such stairs, with what else that layer is made of, so a person can tell an
+entrance step from a farm's edging.
+
+Usage: seating-check.py <data-root> [<data-root> ...]
+  where a data root is the directory holding kithkyn/buildings and structure,
+  e.g. run/world/datapacks/kithkyn-badlands/data/kithkyn or src/main/resources/data/kithkyn
+"""
+from collections import Counter
+from pathlib import Path
+import json
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from nbt import read
+
+GROUND_BLOCKS = {'minecraft:' + name for name in (
+    'dirt', 'coarse_dirt', 'rooted_dirt', 'grass_block', 'podzol', 'mycelium', 'dirt_path', 'farmland', 'moss_block',
+    'mud', 'packed_mud', 'muddy_mangrove_roots', 'sand', 'red_sand', 'gravel', 'clay', 'water', 'snow_block')}
+
+
+def seated_layer(structure, sink):
+    """The blocks of the layer that meets the surface: the blocks at y == sink."""
+    palette = structure['palette']
+    return [(block['pos'], palette[block['state']]) for block in structure['blocks']
+            if block['pos'][1] == sink and palette[block['state']]['Name'] != 'minecraft:air']
+
+
+def looks_like_ground(layer):
+    """A course of earth, sand or crops rather than a floor: most of the layer is ground-like."""
+    ground = sum(1 for _, state in layer if state['Name'] in GROUND_BLOCKS)
+    return layer and ground * 10 >= len(layer) * 7
+
+
+def check(root):
+    root = Path(root)
+    findings = []
+    for definition in sorted((root / 'kithkyn/buildings').glob('*.json')):
+        info = json.loads(definition.read_text())
+        template = root / 'structure' / (info['structure'] + '.nbt')
+        if not template.exists():
+            continue
+        sink = info.get('sink', 0)
+        layer = seated_layer(read(template), sink)
+        stairs = [pos for pos, state in layer if state['Name'].endswith('_stairs')
+                  and state.get('Properties', {}).get('half') == 'bottom']
+        if not stairs:
+            continue
+        makeup = Counter(state['Name'].split(':')[1] for _, state in layer).most_common(3)
+        findings.append((info['structure'], sink, len(stairs), len(layer), looks_like_ground(layer), makeup))
+    return findings
+
+
+if __name__ == '__main__':
+    for root in sys.argv[1:]:
+        print('==', root)
+        for structure, sink, steps, size, ground, makeup in check(root):
+            verdict = 'ground course with edging; judge by eye' if ground else 'STEPS BURIED: probably one block too low'
+            print(f'  {structure:<36} sink {sink:>2}  {steps:>2} buried stair(s) in a layer of {size:>3}  {makeup}  -> {verdict}')


### PR DESCRIPTION
## Summary
- `tools/structure/seating-check.py`: lists catalog buildings whose seated layer holds a bottom-half stair, the tell for a building seated one block low; ground courses with edging are marked for a judgement by eye.
- Birch `mine_birch_forest_1` and `watchtower_birch_forest_2` get `sink: -1`.
- The Badlands storehouse, mine, bakery and tavern and the Desert small houses (all six) and couple cottage were raised the same way in their private packs and reloaded live; `tools/structure/badlands-catalog-20260909.json` and `desert-catalog-20260909.json` carry the new definition hashes and a revision note.
- `docs/structure-authoring.md` gains a "Seating check" section.

## Test plan
- [x] `./gradlew test`: 470 tests, 0 failures
- [x] Live reload after the pack edits: 104 building definitions, no rejections

🤖 Generated with [Claude Code](https://claude.com/claude-code)