### PR TITLE
Record the mine re-edits

### DIFF
--- a/docs/floodplain-village.md
+++ b/docs/floodplain-village.md
@@ -21,7 +21,7 @@ definitions, all new ids, so the pack needs no filter:
 | Id | Source exhibit | Beds | Stations |
 | --- | --- | --- | --- |
 | `village_center_floodplain_1` | Nilotic cartographer house with four white banners and the green carpet cross | 0 | quartermaster, builder, guard captain |
-| `mine_floodplain_1` | Nilotic armorer house with the authored pit floor | 0 | miner in the 3x3 pit; the ramp starts at the pit's middle column and leaves east under the wall |
+| `mine_floodplain_1` | Nilotic armorer house with the authored pit floor, four columns long with an open doorway | 0 | miner at the pit's west column; the ramp mouth is one column in, so three columns of descent stay inside the pit before it leaves east under the wall |
 | `storehouse_floodplain_1` | small house draft with barrels, a note block, an open doorway and two authored allays | 0 | none; the quartermaster keeps the centre post |
 | `church_floodplain_1` | Nilotic temple | 0 | cleric |
 | `lumberjack_floodplain_1` | Nilotic farmer house | 1 | lumberjack on the jungle sapling |

--- a/docs/structure-review.md
+++ b/docs/structure-review.md
@@ -1767,3 +1767,12 @@ for Aaron to edit. He removed the doorway trapdoor, so the doorway is open, and 
 corners. The copy was captured from a flushed snapshot and became the storehouse's source capture; the
 open-trapdoor export override is gone; the pack was rebuilt, checked and reinstalled live with a reload.
 
+### Mine re-edits: September 10
+
+Production copies of the floodplain and Desert mines were placed in the Nilotic gallery (rows NA08 and NA09)
+for Aaron to edit. The floodplain pit grew one column west so the ramp has three columns of descent inside
+the building, its door went, and a step leads down into the pit; the miner stands at the pit's west column
+with the ramp mouth one column in. The Desert mine gained a shared chest at the pit floor plus two wall
+posts, a fence, a trapdoor and a lantern, exported in its existing frame. Both were captured from a flushed
+snapshot, re-exported, checked and installed in their packs.
+

--- a/tools/structure/desert-catalog-20260909.json
+++ b/tools/structure/desert-catalog-20260909.json
@@ -248,12 +248,13 @@
       "structure": "mine_desert_1",
       "manifest": "tools/structure/desert-services-20260909.json",
       "recipe": "mine_1",
-      "asset_sha256": "e11bfa04c42db054ff8718eb6cb8619f97fbd5b0e057d43f80f161263236b86f",
-      "definition_sha256": "7b31f00cfd3075ca568db848ca6061472ab9e68bfcb95ec1f7285ce46201cf59",
+      "asset_sha256": "e313bddea3bf9be266c1a47d38788480656ff71c5a077e8e1b8b7b0fac19ea7d",
+      "definition_sha256": "564cd6818c2c0450ce033229529f0e69624612e8f7b50432dea6ff1e041e05ad",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/desert_oasis/jobsite/pen.nbt",
       "reviewed_neutral": "run/pueblo-showcase/desert-services-approved-20260909-224600/neutral/D07.5.nbt",
-      "reviewed_neutral_sha256": "03f655e6ea03523213276482eb33a87c424759a7717d7b33d5bb32dd44ab8638"
+      "reviewed_neutral_sha256": "03f655e6ea03523213276482eb33a87c424759a7717d7b33d5bb32dd44ab8638",
+      "reviewed_edit": "run/nilotic-showcase gallery row NA09 (production copy edited by Aaron, 2026-09-10)"
     },
     {
       "exhibit": "D07.2",
@@ -453,6 +454,13 @@
       ],
       "change": "sink -1",
       "note": "Seated one block low: a doorstep stair sat level with the ground (tools/structure/seating-check.py). Raised onto the ground; existing buildings keep their seat."
+    },
+    {
+      "date": "2026-09-10",
+      "structures": [
+        "mine_desert_1"
+      ],
+      "note": "Aaron edited a production copy in the gallery: a shared chest at the pit, two wall posts, a fence, a trapdoor and a lantern added. Re-exported in the same frame; the chest joins the shared containers."
     }
   ]
 }

--- a/tools/structure/floodplain-catalog-20260910.json
+++ b/tools/structure/floodplain-catalog-20260910.json
@@ -28,11 +28,11 @@
       "source_mod": "t_and_t-neoforge-fabric-1.13.9+1.21.1.jar",
       "source_mod_structure": "data/kaisyn/structure/village/exclusives/nilotic/houses/nilotic_armorer_1.nbt",
       "asset": "run/floodplain-integration/datapack/data/kithkyn/structure/mine_floodplain_1.nbt",
-      "asset_sha256": "0ccb8540bf93b76078dbab52543fbe468b530b6479410b1165c7ffde28bd3813",
+      "asset_sha256": "6b3c69fb1fcc5268ef2c62b3b1093260227f0c6ac86f4052ac9a7333fd8f9103",
       "definition": "run/floodplain-integration/datapack/data/kithkyn/kithkyn/buildings/mine_floodplain_1.json",
-      "definition_sha256": "7c21e894fbe10f5a290362685b2ac3c3b37c2b4078f48839d06bc9880cd9e6dd",
+      "definition_sha256": "8a169912c066d9e340e0efdf4b813fb014cdcd5688809a2829af7c71c2b33f8d",
       "reviewed_capture": "run/nilotic-showcase/selection-20260910-floodplain/captures/NA01.2.nbt",
-      "reviewed_capture_sha256": "e0e431c2d95541390431579ad67c5f17c306ceedfc2c64022e251e0c6c2d2371"
+      "reviewed_capture_sha256": "753aeb973aa7eaabecfcdba580b30449e78231b155a3f5ad0670fcc45adb6ed1"
     },
     {
       "exhibit": "NA01.4",
@@ -392,6 +392,13 @@
         "storehouse_floodplain_1"
       ],
       "note": "Aaron re-edited the storehouse on a production copy in the gallery (NA07.1): the doorway trapdoor removed so the doorway is open, the course corners trimmed. Re-captured and re-exported; the open-trapdoor override is gone."
+    },
+    {
+      "date": "2026-09-10",
+      "structures": [
+        "mine_floodplain_1"
+      ],
+      "note": "Aaron re-edited the mine on a production copy in the gallery (NA08.1): the pit is four columns long, the door is gone and a step leads down into the pit. The miner stands at the pit's west column and the ramp mouth is one column in, so three columns of descent stay inside the pit."
     }
   ]
 }

--- a/tools/structure/nilotic-selections-20260910.json
+++ b/tools/structure/nilotic-selections-20260910.json
@@ -205,34 +205,34 @@
       "source_mod_structure": "data/kaisyn/structure/village/exclusives/nilotic/houses/nilotic_armorer_1.nbt",
       "source_mod_structure_sha256": "90cea19d28a163acc3b1bae2020a979fa2727738269d0c23ae42ef51420abf9d",
       "source_capture": "run/nilotic-showcase/selection-20260910-floodplain/captures/NA01.2.nbt",
-      "source_capture_sha256": "e0e431c2d95541390431579ad67c5f17c306ceedfc2c64022e251e0c6c2d2371",
+      "source_capture_sha256": "753aeb973aa7eaabecfcdba580b30449e78231b155a3f5ad0670fcc45adb6ed1",
       "gallery_origin": [
-        6591,
-        230,
-        1010
+        6576,
+        231,
+        1232
       ],
       "capture_from": [
-        6589,
-        229,
-        1008
+        6574,
+        230,
+        1230
       ],
       "capture_to": [
-        6601,
-        275,
-        1020
+        6586,
+        245,
+        1242
       ],
       "solid_bounds_relative_to_gallery_origin": [
         [
-          -1,
-          9
+          0,
+          8
         ],
         [
           -1,
           6
         ],
         [
-          -1,
-          9
+          0,
+          8
         ]
       ],
       "role": "mine",
@@ -273,33 +273,8 @@
         "coloured_blocks": {}
       },
       "notes": [
-        "Aaron rebuilt this live as the mine; the former armorer role moves to NA02.3"
-      ],
-      "gallery_furniture": {
-        "sea_lanterns": [
-          [
-            -1,
-            -1,
-            -1
-          ],
-          [
-            9,
-            -1,
-            -1
-          ],
-          [
-            -1,
-            -1,
-            9
-          ],
-          [
-            9,
-            -1,
-            9
-          ]
-        ],
-        "note": "Apron corner lighting from the gallery; exclude at export."
-      }
+        "Re-captured 2026-09-10 evening from the NA08.1 production copy: Aaron widened the pit one column west, removed the door and set a step down into the pit."
+      ]
     },
     {
       "exhibit": "NA01.4",


### PR DESCRIPTION
## Summary
- Floodplain mine: Aaron's edited production copy (gallery row NA08) is the source capture; the pit is four columns long with an open doorway and a step down into it; the miner stands at the pit's west column and the ramp mouth is one column in, so three columns of descent stay inside the building.
- Desert mine: Aaron's edited copy (row NA09) re-exported in its existing frame with a shared chest at the pit floor added to the definition's containers.
- Selection and catalog records carry the new hashes; the review log and floodplain doc note the edits.

## Test plan
- [x] `check.py`: 20 floodplain definitions and templates
- [x] Native placement for `mine_floodplain_1` (8 placements, four rotations); access and founding running
- [x] Native placement and access for `mine_desert_1` running

🤖 Generated with [Claude Code](https://claude.com/claude-code)