### PR TITLE
Add the playable Jungle village catalog

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,9 @@ in it, and update it in the same change that moves what it describes.
 - [floodplain-village.md](floodplain-village.md): the approved Floodplain (mangrove swamp) local
   catalog from the Nilotic selection: roles, founding set, identity rules, the mud brick wall
   palette, authoring pipeline and verification.
+- [jungle-village.md](jungle-village.md): the approved playable Jungle catalog, including its
+  bedless center, four-home founding sprawl, routed mine and storehouse worksites, bamboo roofs,
+  repaired markets, Firewatch tower and timber perimeter.
 - [appearance.md](appearance.md): why villagers use the player model and not the vanilla
   villager model, the wide/slim model split by gender, and the client-side runtime skin
   compositor that bakes a villager's look from inherited skin, hair, and eye structures,

--- a/docs/building-spec.md
+++ b/docs/building-spec.md
@@ -1,10 +1,12 @@
 # Building spec: every building, variant, level, recipe, and unlock
 
-**Birch Forest integration, revised 2026-09-09:** [birch-village.md](birch-village.md) is the current
+**Regional integrations, revised 2026-09-10:** [birch-village.md](birch-village.md) is the current
 approved catalog for `birch_forest`. Its 23 templates and exact amenities supersede this
 document's older generic tier counts, founding contents and candidate choices for that family.
 In particular it has no tier-3 house/farm or higher center/storehouse/mine/church. The bakery
-and tavern are separate buildings, each with one worker bed and private storage.
+and tavern are separate buildings, each with one worker bed and private storage. The approved
+private catalogs for Desert, Badlands, Floodplain and Jungle are documented separately; Jungle's
+22-template catalog and four-home start are specified in [jungle-village.md](jungle-village.md).
 
 **The catalogue below enumerates 36 categories; 22 of them survived the cut.** The totals in
 this document count the full map of the possible, not the shipping set — see
@@ -17,8 +19,9 @@ at level 2, `watchtower` at level 2, `market` at levels 1 to 3), with real MASON
 FISHER, BAKER, BUTCHER and INNKEEPER occupations behind the workplaces. The old Village Life
 families (plains, taiga, snowy, savanna and the bundled desert set), which carried the
 level-3 houses, level-2 mines and level-3 farms this document once counted, were removed on
-2026-09-10. Desert and Badlands ship as private datapacks with their own enumerations
-([desert-village.md](desert-village.md), [badlands-village.md](badlands-village.md)).
+2026-09-10. Desert, Badlands, Floodplain and Jungle ship locally as private datapacks with their
+own enumerations ([desert-village.md](desert-village.md), [badlands-village.md](badlands-village.md),
+[floodplain-village.md](floodplain-village.md), [jungle-village.md](jungle-village.md)).
 
 **One occupation exists only as a name in these tables**: HERDER is not in the
 Occupation enum, and a definition naming one fails the codec
@@ -86,6 +89,14 @@ Starting beds and jobs come from those authored buildings. A bedless Jungle cent
 four separate one-person huts for its four founding workers. Centers with accommodation
 can keep it inside the center. Normal bed registration, job assignment and campfire arrivals
 apply; founding does not spawn a separate crew or simulate paid construction projects.
+
+A founding job may belong to the center while its physical workplace sits in another starting
+building. The center's `work_stations` entry declares `worksite_category`; the matching building
+declares a same-occupation position in `worksites`. A `worksites` entry is a destination only and
+never creates a second vacancy. Job location, work area and workplace storage resolve through that
+physical building. If no matching completed building exists, the worker keeps the center-owned job
+and waits. A routed miner station does not create a shaft below the center; the physical mine
+worksite owns the shaft geometry.
 
 ### Founding uses ordinary construction placement
 

--- a/docs/buildings.md
+++ b/docs/buildings.md
@@ -365,11 +365,12 @@ becoming one overloaded axis.
 
 ### Current runtime selection: 2026-09-10
 
-Four styles exist today, in this stable order: `birch_forest`, `desert`, `badlands`,
-`floodplain`. Birch Forest is the only catalog bundled in the jar and so the default: a blank
+Five styles exist today, in this stable order: `birch_forest`, `desert`, `badlands`,
+`floodplain`, `jungle`. Birch Forest is the only catalog bundled in the jar and so the default: a blank
 or unknown saved style reads as Birch. Desert ([desert-village.md](desert-village.md)),
 Badlands ([badlands-village.md](badlands-village.md)) and Floodplain
-([floodplain-village.md](floodplain-village.md)) are installed as private datapacks that
+([floodplain-village.md](floodplain-village.md)) and Jungle
+([jungle-village.md](jungle-village.md)) are installed as private datapacks that
 supply their own definitions and templates under the ids the code resolves; without its pack
 a style has no founding set and is never selected automatically. The old Village Life families
 (plains, taiga, snowy, savanna and the bundled desert set) were removed on 2026-09-10; see
@@ -386,7 +387,7 @@ reroll an existing village. An explicit style argument on the command still over
 
 Selection first honors `kithkyn:village_style/<style>` biome tags, so a datapack can map a
 vanilla or modded biome precisely without a second mapping format. If a biome has several
-explicit tags, the stable order is Birch Forest, Desert, Badlands, Floodplain. Only styles
+explicit tags, the stable order is Birch Forest, Desert, Badlands, Floodplain, Jungle. Only styles
 whose own center, mine, and storehouse definitions are loaded are automatic candidates.
 
 Conventional families then retain deterministic assignments, but only where a finished
@@ -398,7 +399,8 @@ catalog exists:
 | Mesa/badlands or savanna, including their tagged modded families and recognizable registry paths | Pueblo / Badlands |
 | Desert or sandy, excluding the mesa/badlands and savanna families above | Desert |
 | Mangrove: vanilla mangrove swamp through the `kithkyn:village_style/floodplain` tag, and untagged registry paths containing `mangrove` | Floodplain |
-| Every other conventional family (plains, forest, taiga, snowy, jungle, plain swamp and the rest) | No conventional mapping; the climate cluster below decides |
+| Jungle, including conventional Jungle tags and registry paths containing `jungle` | Jungle |
+| Every other conventional family (plains, forest, taiga, snowy, plain swamp and the rest) | No conventional mapping; the climate cluster below decides |
 
 Birch wins before broader family tags; an explicit style tag can override even a birch-named
 biome. This name heuristic is a compatibility fallback for mods that omit conventional tags,
@@ -406,7 +408,8 @@ not a substitute for those tags.
 
 The broad Pueblo assignment includes wooded badlands and savanna plateau for now. As more
 catalogs become playable, explicit style tags can separate those biomes without rerolling
-existing villages. The Jungle showcase is a building-selection pass, not an activated catalog.
+existing villages. Jungle is now a complete strict catalog: it does not borrow missing buildings
+from Birch or another regional family.
 
 A family with no conventional mapping uses its precipitation, base temperature, downfall, and
 conventional hot/dry/wet tags to choose a cluster. Only a hot, dry climate has a choice to

--- a/docs/jungle-village.md
+++ b/docs/jungle-village.md
@@ -1,0 +1,105 @@
+# Jungle village
+
+The Jungle catalog is the first playable raised-timber village. It uses the selected Tribal
+family, Aaron's edited tree homes and service buildings, the NH06.5 Firewatch tower, three
+repaired market tiers, stripped-bamboo roofs and the timber-and-bamboo perimeter. It is the
+fifth finished regional style after Birch Forest, Desert, Badlands and Floodplain
+([buildings.md](buildings.md), "Current runtime selection"). The style token is `jungle`.
+Vanilla jungle, bamboo jungle and sparse jungle select it; conventional jungle biome tags and
+recognizable modded biome names use it whenever its complete private catalog is loaded.
+
+## Selected buildings
+
+The public selection record is `tools/structure/jungle-selections-20260910.json`; the final
+catalog and immutable output hashes are recorded in
+`tools/structure/jungle-catalog-20260910.json`. The private datapack contains 22 definitions:
+
+| Id | Selected use | Beds and stations |
+| --- | --- | --- |
+| `village_center_jungle_1` | JA01.1 meeting point | No beds; quartermaster, builder, guard captain and miner vacancies |
+| `mine_jungle_1` | JA01.5 edited armorer | No vacancy; one physical miner worksite and two shared barrels |
+| `storehouse_jungle_1` | JA03.1 edited small house | No vacancy; one physical quartermaster worksite and three shared containers |
+| `lumberjack_jungle_1` | JA01.4 animal pen | Lumberjack and one shared chest |
+| `tavern_jungle_1` | JA01.6 butcher | Innkeeper and one shared barrel; no bed |
+| `fishery_jungle_1` | JA01.8 fisher | Fisher, one staff bed and one shared barrel |
+| `hunting_lodge_jungle_1` | JA02.1 fletcher | Hunter and one shared chest |
+| `stoneworks_jungle_1` | JA02.5 mason | Mason and one shared chest |
+| `butchery_jungle_1` | JA02.6 shepherd | Butcher, one staff bed and its personal chest |
+| `farm_jungle_1` | JA02.7 small farm | Farmer and one shared barrel |
+| `bakery_jungle_1` | JA02.8 edited small house | Baker and one shared barrel |
+| `church_jungle_1` | JA03.3 temple | Cleric and one shared chest |
+| `blacksmith_jungle_1` | JA03.5 weaponsmith | Blacksmith and one shared chest |
+| `watchtower_jungle_1` | NH06.5 Firewatch | Crossbow post, one guard bed and its personal chest |
+| `house_jungle_1` | JA02.9 small house 2 | One bed and personal chest |
+| `house_jungle_1__small_house_4` | JA03.2 small house 4 | One bed |
+| `house_jungle_2` | JA01.7 treehouse, standalone | Two single rooms with personal chests |
+| `house_jungle_2__large_house_1` | JA02.2 large house, standalone | Two single rooms with personal chests |
+| `couple_cottage_jungle_1` | JA02.3 leatherworker | One two-person couple room and personal chest |
+| `market_jungle_1`, `_2`, `_3` | repaired Jungle market tiers | One to three merchants and matching shared containers |
+
+There is one storehouse level, one watchtower level and no well. The four ordinary houses are
+alternatives rather than an upgrade chain; the two level-2 homes are standalone construction
+choices. Markets are the only upgrade chain. The market tents retain the established orange,
+cyan, red and white fabric instead of taking village colors.
+
+## Founding and physical worksites
+
+The center deliberately has no beds. Its founding set places the mine, the storehouse and four
+one-person homes through ordinary construction site search, producing natural sprawl with the
+same two-block spacing preference and inward-facing preference as later growth. Those four homes
+house the center's four starting workers.
+
+The quartermaster and miner vacancies remain owned by the center, while their physical work
+happens in the separately placed storehouse and mine. A `worksite_category` on each center post
+routes the worker to the nearest matching building; the target building declares a `worksites`
+position without creating a duplicate vacancy. Removing or rebuilding that target makes the
+workplace temporarily unavailable. The mine alone owns its three-block-wide shaft, which leaves
+the east wall two blocks from the worksite so the authored mouth, workstation footing and final
+surface step do not overlap.
+
+The bell is the meeting and arrival point. The campfire is a separate cooking and idle amenity;
+it does not redefine the village center.
+
+## Identity and walls
+
+Every authored white bed is a village-color slot. The two couple beds use the same primary
+color; the remaining beds use their declared primary or secondary slots. White banners become
+the village banner. Roof hay was replaced with stripped bamboo oriented along the original hay
+axis, so the village keeps its layered thatch silhouette without giving players roof-sized wheat
+stores.
+
+Walls use the shared terrain-following arid geometry with Jungle materials: jungle planks for
+the body and posts, bamboo mosaic for decks, stairs and slabs, jungle fences and trapdoors,
+stripped jungle wood for the gate frame, and standing torches in place of candle clusters. The
+four hanging gatehouse lanterns remain. There is one wall stage, priced in jungle logs.
+
+The naming profile describes a shaded settlement of raised timber rooms, bamboo roofs, broad
+leaves, open workshops and canopy watch platforms. Its fallback syllables are independent of
+the other regional styles.
+
+## Authoring and local installation
+
+`run/jungle-integration/prepare.py` reads the immutable capture record, crops the approved
+structures, neutralizes village identity slots, moves the butcher's inaccessible chest and the
+mine's embedded barrels, opens the mine mouth, and assembles
+`run/jungle-integration/datapack/`. Programmatically placed chests and barrels receive native
+block-entity data from `tools/structure/VillageTemplateExport.java`. The private pack is installed
+as `kithkyn-jungle` and kept with world backups; the public jar deliberately carries none of the
+third-party-derived templates ([structure-sourcing.md](structure-sourcing.md)). A manual sample
+can request `/kithkyn create-village ~ ~ ~ jungle`.
+
+## Verification
+
+Core tests cover biome selection, codec persistence, routed physical worksites, mine ownership,
+the Jungle wall palette and unchanged fallback behavior. Native checks run the private catalog
+through the shared reviewed-village, access and real-placement fixtures.
+
+The September 10 integration passed the complete access suite: 84 rotated structures, 224 real
+navigation routes, 44 room walks and sleeps, 36 personal-container deposits, 68 station walks,
+80 shared-container deposits and eight mine walks, with zero failed placements. The placement
+fixture passed 176 real-template placements through instant and incremental construction in all
+four rotations, including colors, frames, save receipts and upgrade preservation. A server
+restart retained all 176 buildings. The founding fixture passed 22 strict templates, all four
+center rotations, eight market upgrade fits, natural Jungle selection, four starting homes,
+four assigned workers, distinct bell and campfire locations, routed mine/storehouse work and
+codec reloads.

--- a/docs/structure-review.md
+++ b/docs/structure-review.md
@@ -1304,8 +1304,8 @@ routes remain. The markets retain the existing raised barrels, open entrances, s
 and primary/secondary cloth slots. These are vanilla-block adaptations and need no extra mods.
 
 Native readback matched all **2,194** preview blocks. The wall overview, gate detail, and
-three market tiers were rendered and visually reviewed. This verifies placement, not new Jungle
-founding or worker navigation. No Jungle runtime catalog is activated. The editable assets,
+three market tiers were rendered and visually reviewed. This stage verified placement, before
+Jungle founding and worker navigation were implemented. The editable assets,
 source hashes, definitions and verification are recorded in
 `tools/structure/jungle-workshop-20260910.json`.
 
@@ -1512,8 +1512,8 @@ without recipe rejection. This is a working-tree deployment, not a Git commit or
 | --- | --- |
 | Pueblo/Mesa and Desert catalogs, selected Desert tavern/temple/towers and arid walls | Verified and locally deployed; earlier entries saying these await deployment are historical. |
 | Unstructured structure gallery | Placed, verified and available for review. |
-| Jungle buildings, three market tiers and one wall tier | Choices and edited captures saved; bamboo and torch changes approved and applied. |
-| Playable Jungle villages | Outstanding: production catalog/identity export, four founding homes, center-owned miner linked to the separate mine, worker access and full founding verification. No additional building selection is required to proceed. |
+| Jungle buildings, three market tiers and one wall tier | Verified as a complete private catalog; bamboo, market repairs and torch-lit timber walls are applied. |
+| Playable Jungle villages | Complete: four-home founding sprawl, center-owned miner and quartermaster routed to separate worksites, identity export, access, construction, restart and natural-founding checks all pass. |
 | Castle authoring | Edited fort, room/bed/container intentions, banners and tent colors captured and visually reviewed. |
 | Castle gameplay | Not buildable yet. Navigation and role reservations need implementation/verification; eligibility, pricing, ruler succession and jail/release rules remain design work. Ruler and jail implementation was explicitly deferred by Aaron. |
 
@@ -1568,7 +1568,8 @@ Mesa east, with tiers 1, 2 and 3 from north to south. The Jungle workshop remain
 Current assets, native results, immutable user-edit captures and viewed screenshots are
 recorded in `tools/structure/market-review-20260910.json`. Earlier market entries describing
 removed rails, slab counters or village-colored awnings are superseded by this review.
-Jungle remains an authoring collection pending its production/founding integration.
+At this point in the review, Jungle remained an authoring collection pending its later
+production/founding integration.
 
 The market repair passed `check build` with 433 tests, zero failures and zero skips, then
 was deployed to the local server and Prism client. Both use SHA-256
@@ -1637,8 +1638,8 @@ export; raw captures keep the player’s placed bed colors.
 
 The selected Jungle collection now has **19 buildings, 11 beds and eight general-home
 beds**. All 21 selected/candidate capture hashes and selected bed/container coordinates
-were revalidated. Four single-bed founding huts remain the starting layout. Production
-Jungle integration and native resident/guard access verification remain outstanding.
+were revalidated. Four single-bed founding huts remain the starting layout. At the time of
+this capture, production integration and native resident/guard access verification remained.
 See `tools/structure/jungle-selections-20260910.json` and the tower comparison manifest
 for the authoritative selection and latest captures.
 
@@ -1776,3 +1777,27 @@ with the ramp mouth one column in. The Desert mine gained a shared chest at the 
 posts, a fence, a trapdoor and a lantern, exported in its existing frame. Both were captured from a flushed
 snapshot, re-exported, checked and installed in their packs.
 
+### Jungle catalog verified: September 10
+
+The approved Jungle selection is now a playable private catalog with 22 definitions: nineteen
+selected buildings and the three repaired market tiers. Its bedless center owns the founding
+quartermaster, builder, captain and miner vacancies. The starting planner places a mine, a
+storehouse and four one-bed homes with ordinary growth placement, while the center's quartermaster
+and miner route to non-vacancy physical worksites in those separate buildings. This also fixed a
+real ownership error exposed by the center test: a routed miner post must not create a shaft under
+the civic building; only the physical mine owns and excavates that shaft.
+
+The final mine uses a three-block-wide eastward mouth, offset two blocks from its worksite so its
+surface workstation, opening and final ramp headroom do not compete for one cell. Its two material
+barrels and the butcher's personal chest moved to reachable positions. The native exporter now
+writes block-entity data for chests and barrels created by export overrides, so strict template
+loading sees the same containers as physical access does.
+
+All five native checks pass. The access fixture walked 84 rotations and 224 routes, including every
+bed, personal container, workstation, shared container and mine descent/return. The construction
+fixture passed 176 instant and incremental placements across four rotations; a full server restart
+retained all 176. The reviewed-village fixture passed 22 strict templates, all four founding
+rotations, the market upgrades, natural Jungle selection, the four starting homes, routed worksites,
+village identity and codec reloads. The public record is
+`tools/structure/jungle-catalog-20260910.json`; implementation and operating details are in
+[jungle-village.md](jungle-village.md).

--- a/src/main/java/com/quzzar/kithkyn/dev/ApprovedHouseVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/ApprovedHouseVerification.java
@@ -483,10 +483,32 @@ public final class ApprovedHouseVerification {
     consolidation = null;
     transferStarted = -1;
     if (visit.kind() == VisitKind.STATION) {
-      village.assignJob(walker.getUUID(), new JobAssignment(walker.getUUID(), visit.occupation(),
-          building.getUUID(), visit.stationIndex()));
-      walker.setOccupation(visit.occupation());
-      walker.issueStartingKit();
+      // Each authored post belongs to a different worker. Start each trip at
+      // the shared entrance instead of chaining one probe between adjacent
+      // posts and accumulating its previous arrival tolerance.
+      ApprovedStructureAccess.moveTo(walker, entrance);
+      long localStation = new ArrayList<>(building.getInfo().getWorkLocations().keySet()).get(visit.stationIndex());
+      String physicalCategory = building.getInfo().getWorksiteCategory(localStation);
+      GuardRole guardRole = building.getInfo().getGuardRole(visit.stationIndex());
+      JobAssignment existing = village.getJobAssignment(walker.getUUID());
+      // A center-only access fixture has no founding companions. Use a neutral
+      // probe for ordinary stations so a builder cannot grade or build paths
+      // while the same body is still checking later stations. Founding proves
+      // real job and routed-worksite behavior; fixed crossbow posts still need
+      // their actual equipment and duty here.
+      if (existing != null) {
+        walker.setOccupation(existing.getOccupation());
+        walker.issueStartingKit();
+      } else if (physicalCategory == null && visit.occupation() == Occupation.GUARD
+          && guardRole == GuardRole.CROSSBOW_POST) {
+        village.assignJob(walker.getUUID(), new JobAssignment(walker.getUUID(), visit.occupation(),
+            building.getUUID(), visit.stationIndex()));
+        walker.setOccupation(visit.occupation());
+        walker.issueStartingKit();
+      } else {
+        village.releaseJob(walker.getUUID());
+        walker.setOccupation(Occupation.WANDERER);
+      }
       ApprovedStructureAccess.enableWalking(walker);
       if (visit.occupation() == Occupation.GUARD
           && building.getInfo().getGuardRole(visit.stationIndex()) == GuardRole.CROSSBOW_POST) {
@@ -548,7 +570,13 @@ public final class ApprovedHouseVerification {
         walker.getNavigation().stop();
       }
     }
-    boolean arrived = walker.onGround() && walker.distanceToSqr(Vec3.atBottomCenterOf(approach)) <= 0.75D
+    // Coordinate navigation deliberately accepts a node within one block of
+    // its target. That is sufficient for a shaft return once the miner is on
+    // the surface beside the authored entrance; requiring the exact block
+    // center makes an otherwise complete return loop forever.
+    double arrivalDistance = visit.kind() == VisitKind.MINE_RETURN ? 4.0D : 0.75D;
+    boolean arrived = walker.onGround()
+        && walker.distanceToSqr(Vec3.atBottomCenterOf(approach)) <= arrivalDistance
         && Math.abs(walker.getY() - approach.getY()) < 0.51D;
     if (visit.kind() == VisitKind.SHARED_CONTAINER) {
       arrived &= handArrival;
@@ -606,7 +634,15 @@ public final class ApprovedHouseVerification {
         + walker.position().subtract(Vec3.atLowerCornerOf(ORIGIN)) + " toward " + approach.subtract(ORIGIN)
         + "; " + movementDetails());
     if (ticks % 10 == 0 || walker.getNavigation().isDone()) {
-      walker.getNavigation().moveTo(walker.getNavigation().createPath(approach, 0), 0.6D);
+      if (visit.kind() == VisitKind.MINE_DESCENT || visit.kind() == VisitKind.MINE_RETURN) {
+        // Production work goals use the coordinate overload, where
+        // PersonPathNavigation advances the shaft one validated ramp hop at a
+        // time. Calling createPath directly here would bypass that mine hook.
+        walker.getNavigation().moveTo(
+            approach.getX() + 0.5D, approach.getY(), approach.getZ() + 0.5D, 0.6D);
+      } else {
+        walker.getNavigation().moveTo(walker.getNavigation().createPath(approach, 0), 0.6D);
+      }
     }
   }
 

--- a/src/main/java/com/quzzar/kithkyn/dev/BadlandsVillageVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/BadlandsVillageVerification.java
@@ -19,6 +19,7 @@ import com.quzzar.kithkyn.village.buildings.Building;
 import com.quzzar.kithkyn.village.buildings.BuildingInfo;
 import com.quzzar.kithkyn.village.buildings.BuildingUpgrade;
 import com.quzzar.kithkyn.village.buildings.Buildings;
+import com.quzzar.kithkyn.village.buildings.MineShaft;
 import com.quzzar.kithkyn.village.buildings.VillageStyle;
 
 import net.minecraft.core.BlockPos;
@@ -45,7 +46,7 @@ import net.neoforged.neoforge.event.tick.ServerTickEvent;
 /**
  * Shared private-catalog checks for the reviewed regional villages. Opt in with
  * the legacy Badlands flag or {@code -Dkithkyn.reviewedVillage.style=<style>}
- * for desert or floodplain; each catalog's authored numbers live in its
+ * for desert, floodplain or Jungle; each catalog's authored numbers live in its
  * {@link Catalog} record so the checks read facts rather than guess them.
  */
 @EventBusSubscriber(modid = Kithkyn.MODID)
@@ -82,6 +83,9 @@ public final class BadlandsVillageVerification {
         new String[][] {{id("market", 1), id("market", 2)}, {id("market", 2), id("market", 3)},
             {id("farm", 1), id("farm", 2)}},
         6, 5, 4, 1, 3, 0, 0, new BlockPos(4, 1, 2), null, 1, Biomes.MANGROVE_SWAMP);
+    case JUNGLE -> new Catalog("[jungle-verify]", 22, 4, 6, new int[] {2, 2, 0}, Map.of(), List.of(), false,
+        new String[][] {{id("market", 1), id("market", 2)}, {id("market", 2), id("market", 3)}},
+        7, 4, 4, 1, 4, 0, 0, new BlockPos(3, 1, 5), new BlockPos(2, 2, 5), 1, Biomes.JUNGLE);
     case BIRCH_FOREST -> null;
   };
   private static final String PREFIX = CATALOG == null ? "[reviewed-village-verify]" : CATALOG.prefix();
@@ -156,7 +160,11 @@ public final class BadlandsVillageVerification {
         == VillageStyle.FLOODPLAIN, "Mangrove swamp must select Floodplain");
     check(VillageStyle.fromBiome(registry.getHolderOrThrow(Biomes.SWAMP), 0L, BlockPos.ZERO, everything)
         == VillageStyle.FLOODPLAIN, "Plain swamp is hot and wet and builds floodplain until it has a catalog of its own");
-    Kithkyn.LOGGER.info("{} BIOMES PASS: six Pueblo biomes, sandy Desert, both Birch biomes and mangrove Floodplain", PREFIX);
+    for (var biome : List.of(Biomes.JUNGLE, Biomes.BAMBOO_JUNGLE, Biomes.SPARSE_JUNGLE)) {
+      check(VillageStyle.fromBiome(registry.getHolderOrThrow(biome), 0L, BlockPos.ZERO, everything)
+          == VillageStyle.JUNGLE, "Jungle coverage missing " + biome.location());
+    }
+    Kithkyn.LOGGER.info("{} BIOMES PASS: Pueblo, Desert, Birch, Floodplain and all three Jungle biomes", PREFIX);
   }
 
   private static void verifyCatalogue(ServerLevel level) {
@@ -377,6 +385,13 @@ public final class BadlandsVillageVerification {
         && village.getBedAssignmentsView().size() == CATALOG.foundingJobs()
         && village.getUnassignedBeds().size() == CATALOG.foundingBeds() - CATALOG.foundingJobs(),
         "Founding workers did not receive distinct beds");
+    if (STYLE == VillageStyle.JUNGLE) {
+      verifyRoutedWorksite(village, residents, Occupation.MINER, "mine");
+      verifyRoutedWorksite(village, residents, Occupation.QUARTERMASTER, "storehouse");
+      Building mine = village.getBuildings().stream()
+          .filter(building -> building.getInfo().getCategory().equals("mine")).findFirst().orElseThrow();
+      check(MineShaft.of(mine).size() == 1, "Jungle physical mine lost its one shaft frame");
+    }
     Building store = village.getBuildings().stream().filter(building -> building.getName().equals(id("storehouse", 1)))
         .findFirst().orElseThrow();
     BlockPos storage = world(store, BlockPos.of(store.getInfo().getContainerLocations().getFirst()));
@@ -413,6 +428,19 @@ public final class BadlandsVillageVerification {
           && after.getInfo().getCoupleBeds().equals(before.getInfo().getCoupleBeds()), "Reload changed room metadata");
     }
     residents.forEach(net.minecraft.world.entity.Entity::discard);
+  }
+
+  private static void verifyRoutedWorksite(Village village, List<ApprovedStructureAccess.Person> residents,
+      Occupation occupation, String category) {
+    ApprovedStructureAccess.Person worker = residents.stream()
+        .filter(person -> person.getOccupation() == occupation).findFirst().orElseThrow();
+    Building owner = village.getBuilding(village.getJobAssignment(worker.getUUID()).getBuildingUUID());
+    Building physical = com.quzzar.kithkyn.village.LocationManager.getJobBuilding(worker);
+    check(owner != null && owner.equals(village.getTownCenter()), occupation + " vacancy left the Jungle center");
+    check(physical != null && physical.getInfo().getCategory().equals(category),
+        occupation + " did not route to its physical " + category);
+    check(!com.quzzar.kithkyn.village.LocationManager.getJobLocation(worker).equals(BlockPos.ZERO),
+        occupation + " physical station did not resolve");
   }
 
   private static void verifyBedIdentity(ServerLevel level, Village village, Building building, BlockPos local) {

--- a/src/main/java/com/quzzar/kithkyn/village/LocationManager.java
+++ b/src/main/java/com/quzzar/kithkyn/village/LocationManager.java
@@ -30,6 +30,45 @@ import net.minecraft.world.level.block.entity.HopperBlockEntity;
 import net.minecraft.world.level.block.entity.RandomizableContainerBlockEntity;
 
 public class LocationManager {
+
+    private record ResolvedWorkplace(Building building, BlockPos station) {}
+
+    @Nullable
+    private static ResolvedWorkplace resolveWorkplace(Village village, JobAssignment job) {
+        Building owner = village.getBuilding(job.getBuildingUUID());
+        if(owner == null || owner.getInfo() == null || village.isBeingRebuilt(owner.getUUID())){ return null; }
+
+        int entryIndex = 0;
+        for(Entry<Long, Occupation> entry : owner.getInfo().getWorkLocations().entrySet()) {
+            if(entry.getValue() == job.getOccupation() && entryIndex == job.getStationIndex()) {
+                Building physical = owner;
+                long physicalStation = entry.getKey();
+                String category = owner.getInfo().getWorksiteCategory(entry.getKey());
+                if(category != null) {
+                    physical = village.getBuildings().stream()
+                        .filter(candidate -> candidate.getInfo() != null)
+                        .filter(candidate -> category.equals(candidate.getInfo().getCategory()))
+                        .filter(candidate -> !village.isBeingRebuilt(candidate.getUUID()))
+                        .min(java.util.Comparator
+                            .comparingDouble((Building candidate) -> BlockPos.of(candidate.getCenterLocation())
+                                .distSqr(BlockPos.of(owner.getCenterLocation())))
+                            .thenComparing(candidate -> candidate.getUUID().toString()))
+                        .orElse(null);
+                    if(physical == null || physical.getInfo() == null) { return null; }
+                    physicalStation = physical.getInfo().getWorksiteLocations().entrySet().stream()
+                        .filter(worksite -> worksite.getValue() == job.getOccupation())
+                        .map(Entry::getKey)
+                        .findFirst().orElse(Long.MIN_VALUE);
+                    if(physicalStation == Long.MIN_VALUE) { return null; }
+                }
+                BlockPos station = BlockPos.of(physical.getOriginLocation())
+                    .offset(BlockPos.of(physicalStation).rotate(physical.getRotation()));
+                return new ResolvedWorkplace(physical, station);
+            }
+            entryIndex++;
+        }
+        return null;
+    }
     
     public static BlockPos getJobLocation(RealPerson person){
 
@@ -42,21 +81,8 @@ public class LocationManager {
         WallPost wallPost = village.getWallPost(job);
         if(wallPost != null){ return wallPost.position(); }
 
-        Building building = village.getBuilding(job.getBuildingUUID());
-        if(building == null){ return BlockPos.ZERO; }
-        // A workplace being rebuilt one level up has no usable station: the
-        // worker keeps the job and waits at the campfire until it is ready.
-        if(village.isBeingRebuilt(job.getBuildingUUID())){ return BlockPos.ZERO; }
-
-        int foundCount = 0;
-        for(Entry<Long, Occupation> entry : building.getInfo().getWorkLocations().entrySet()) {
-            if(entry.getValue() == job.getOccupation()){
-                if(foundCount == job.getStationIndex()){
-                    return BlockPos.of(building.getOriginLocation()).offset(BlockPos.of(entry.getKey()).rotate(building.getRotation()));
-                }
-            }
-            foundCount++;
-        }
+        ResolvedWorkplace workplace = resolveWorkplace(village, job);
+        if(workplace != null){ return workplace.station(); }
         Kithkyn.LOGGER.debug("Couldn't find job index");
         return BlockPos.ZERO;
 
@@ -137,7 +163,8 @@ public class LocationManager {
         JobAssignment job = village.getJobAssignment(person.getUUID());
         if(job == null){ return null; }
         
-        return village.getBuilding(job.getBuildingUUID());
+        ResolvedWorkplace workplace = resolveWorkplace(village, job);
+        return workplace == null ? null : workplace.building();
 
     }
 
@@ -153,10 +180,11 @@ public class LocationManager {
         if(village == null){ return null; }
 
         JobAssignment job = village.getJobAssignment(person.getUUID());
-        if(job == null || village.isBeingRebuilt(job.getBuildingUUID())){ return null; }
+        if(job == null){ return null; }
 
-        Building building = village.getBuilding(job.getBuildingUUID());
-        if(building == null){ return null; }
+        ResolvedWorkplace workplace = resolveWorkplace(village, job);
+        if(workplace == null){ return null; }
+        Building building = workplace.building();
 
         if(!(person.level() instanceof ServerLevel level)){ return null; }
         BoundingBox local = BuildingUpgrade.footprintOf(level, building);

--- a/src/main/java/com/quzzar/kithkyn/village/VillageNamer.java
+++ b/src/main/java/com/quzzar/kithkyn/village/VillageNamer.java
@@ -151,6 +151,13 @@ public final class VillageNamer {
           List.of("Nilora", "Kemwari", "Sefuna", "Abaresh"),
           List.of("Nil", "Kem", "Sef", "Aba", "Mer", "Tam", "Wad", "Osa"),
           List.of("ora", "ari", "wari", "una", "esh", "ai", "oma", "eni"));
+      case JUNGLE -> new NamingProfile(
+          "A shaded settlement woven through dense jungle: raised timber rooms, bamboo roofs,"
+              + " rope bridges, broad leaves, open workshops and watch platforms above the canopy."
+              + " Bright, rhythmic invented names with a lively tropical sound.",
+          List.of("Taluma", "Olanui", "Mavira", "Kesalo"),
+          List.of("Talu", "Ola", "Mavi", "Kesa", "Nalu", "Ira", "Vela", "Suma"),
+          List.of("ma", "nui", "vira", "alo", "ara", "eli", "una", "ori"));
     };
   }
 

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/BuildingInfo.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/BuildingInfo.java
@@ -63,13 +63,26 @@ public class BuildingInfo {
     ).apply(inst, MineEntrance::new));
   }
 
-  /** A work station inside a building: a position (relative to the structure origin) plus the job worked there. */
-  public record WorkStation(BlockPos pos, Occupation occupation, java.util.Optional<GuardRole> guardDuty) {
+  /**
+   * A job post owned by this building. A post can route its worker to a separately
+   * placed physical worksite while the vacancy remains part of the civic building.
+   */
+  public record WorkStation(BlockPos pos, Occupation occupation, java.util.Optional<GuardRole> guardDuty,
+      java.util.Optional<String> worksiteCategory) {
     public static final Codec<WorkStation> CODEC = RecordCodecBuilder.create(inst -> inst.group(
         BlockPos.CODEC.fieldOf("pos").forGetter(WorkStation::pos),
         KithkynCodecs.forEnum(Occupation.class).fieldOf("occupation").forGetter(WorkStation::occupation),
-        KithkynCodecs.forEnum(GuardRole.class).optionalFieldOf("guard_duty").forGetter(WorkStation::guardDuty)
+        KithkynCodecs.forEnum(GuardRole.class).optionalFieldOf("guard_duty").forGetter(WorkStation::guardDuty),
+        Codec.STRING.optionalFieldOf("worksite_category").forGetter(WorkStation::worksiteCategory)
     ).apply(inst, WorkStation::new));
+  }
+
+  /** A physical working position that does not itself create a job vacancy. */
+  public record Worksite(BlockPos pos, Occupation occupation) {
+    public static final Codec<Worksite> CODEC = RecordCodecBuilder.create(inst -> inst.group(
+        BlockPos.CODEC.fieldOf("pos").forGetter(Worksite::pos),
+        KithkynCodecs.forEnum(Occupation.class).fieldOf("occupation").forGetter(Worksite::occupation)
+    ).apply(inst, Worksite::new));
   }
 
   /** Explicit room storage, bound to an authored bed rather than guessed across floors. */
@@ -125,15 +138,17 @@ public class BuildingInfo {
           .forGetter(info -> java.util.Optional.ofNullable(info.workerBeds)),
       Codec.BOOL.optionalFieldOf("standalone", false).forGetter(BuildingInfo::isStandalone),
       Codec.STRING.listOf().optionalFieldOf("starting_buildings", List.of()).forGetter(BuildingInfo::getStartingBuildings),
+      Worksite.CODEC.listOf().optionalFieldOf("worksites", List.of()).forGetter(BuildingInfo::worksites),
       RoomReservation.CODEC.listOf().optionalFieldOf("room_reservations", List.of()).forGetter(BuildingInfo::getRoomReservations),
       CastleLayout.CODEC.optionalFieldOf("castle").forGetter(info -> java.util.Optional.ofNullable(info.castleLayout))
-  ).apply(inst, (info, places, bedContainers, coupleBeds, workerBeds, standalone, startingBuildings, rooms, castle) -> {
+  ).apply(inst, (info, places, bedContainers, coupleBeds, workerBeds, standalone, startingBuildings, worksites, rooms, castle) -> {
     info.gatheringPlaces = places;
     info.bedContainers = bedContainers.orElse(null);
     info.coupleBeds = coupleBeds.orElse(null);
     info.workerBeds = workerBeds.orElse(null);
     info.standalone = standalone;
     info.startingBuildings = List.copyOf(startingBuildings);
+    worksites.forEach(worksite -> info.worksiteLocs.put(worksite.pos().asLong(), worksite.occupation()));
     info.roomReservations = List.copyOf(rooms);
     info.castleLayout = castle.orElse(null);
     return info;
@@ -150,6 +165,7 @@ public class BuildingInfo {
     workStations.forEach(station -> {
       info.addWorkLocation(station.pos().getX(), station.pos().getY(), station.pos().getZ(), station.occupation());
       station.guardDuty().ifPresent(duty -> info.guardRoles.put(station.pos().asLong(), duty));
+      station.worksiteCategory().ifPresent(worksite -> info.worksiteCategories.put(station.pos().asLong(), worksite));
     });
     containers.forEach(pos -> info.addContainerLocation(pos.getX(), pos.getY(), pos.getZ()));
     personalContainers.forEach(pos -> info.addPersonalContainerLocation(pos.getX(), pos.getY(), pos.getZ()));
@@ -171,6 +187,8 @@ public class BuildingInfo {
   // Insertion-ordered: JobAssignment station indexes rely on a stable iteration order.
   private LinkedHashMap<Long, Occupation> workLocs;
   private final Map<Long, GuardRole> guardRoles = new LinkedHashMap<>();
+  private final Map<Long, String> worksiteCategories = new LinkedHashMap<>();
+  private final LinkedHashMap<Long, Occupation> worksiteLocs = new LinkedHashMap<>();
   @javax.annotation.Nullable
   private List<BedContainers> bedContainers;
   @javax.annotation.Nullable
@@ -408,6 +426,12 @@ public class BuildingInfo {
     for (var entry : guardRoles.entrySet()) {
       if (workLocs.get(entry.getKey()) != Occupation.GUARD) return "guard_duty requires a GUARD station";
     }
+    if (worksiteCategories.values().stream().anyMatch(String::isBlank)) {
+      return "worksite_category cannot be blank";
+    }
+    if (worksiteLocs.keySet().stream().anyMatch(workLocs::containsKey)) {
+      return "a position cannot be both a job vacancy and a physical worksite";
+    }
     if (bedContainers != null) {
       java.util.Set<BlockPos> mappedBeds = new java.util.HashSet<>();
       java.util.Set<Long> mappedContainers = new java.util.HashSet<>();
@@ -575,6 +599,17 @@ public class BuildingInfo {
     return workLocs;
   }
 
+  /** Physical work positions that do not add jobs to the village labor pool. */
+  public Map<Long, Occupation> getWorksiteLocations() {
+    return worksiteLocs;
+  }
+
+  /** Optional target category for the job post at this exact local position. */
+  @javax.annotation.Nullable
+  public String getWorksiteCategory(long station) {
+    return worksiteCategories.get(station);
+  }
+
   /**
    * Village storage: every chest here that any worker may fetch from or fill.
    * A home's own chest is not among them ({@link #getPersonalContainerLocations}).
@@ -659,7 +694,13 @@ public class BuildingInfo {
   private List<WorkStation> workStations() {
     return workLocs.entrySet().stream()
         .map(entry -> new WorkStation(BlockPos.of(entry.getKey()), entry.getValue(),
-            java.util.Optional.ofNullable(guardRoles.get(entry.getKey())))).toList();
+            java.util.Optional.ofNullable(guardRoles.get(entry.getKey())),
+            java.util.Optional.ofNullable(worksiteCategories.get(entry.getKey())))).toList();
+  }
+
+  private List<Worksite> worksites() {
+    return worksiteLocs.entrySet().stream()
+        .map(entry -> new Worksite(BlockPos.of(entry.getKey()), entry.getValue())).toList();
   }
 
   private List<BlockPos> containerPositions() {

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/MineShaft.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/MineShaft.java
@@ -291,7 +291,14 @@ public final class MineShaft {
       return List.of();
     }
     List<MineShaft> out = new ArrayList<>();
-    for (Map.Entry<Long, Occupation> station : info.getWorkLocations().entrySet()) {
+    java.util.LinkedHashMap<Long, Occupation> stations = new java.util.LinkedHashMap<>();
+    info.getWorkLocations().forEach((position, occupation) -> {
+      if (info.getWorksiteCategory(position) == null) {
+        stations.put(position, occupation);
+      }
+    });
+    stations.putAll(info.getWorksiteLocations());
+    for (Map.Entry<Long, Occupation> station : stations.entrySet()) {
       if (station.getValue() != Occupation.MINER) {
         continue;
       }

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/VillageStyle.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/VillageStyle.java
@@ -25,8 +25,8 @@ import net.neoforged.neoforge.common.Tags;
  * Every style is a strict catalog: a village raises only what its own family
  * authored and never borrows another family's building to fill a gap. Birch
  * Forest is the one bundled catalog and so the default; Desert, Badlands and
- * Floodplain arrive through private datapacks (docs/desert-village.md,
- * docs/badlands-village.md, docs/floodplain-village.md), so they are only
+ * Floodplain and Jungle arrive through private datapacks (docs/desert-village.md,
+ * docs/badlands-village.md, docs/floodplain-village.md, docs/jungle-village.md), so they are only
  * automatic candidates while their founding sets are loaded.
  *
  * Explicit datapack style tags take precedence over conventional biome families.
@@ -34,7 +34,7 @@ import net.neoforged.neoforge.common.Tags;
  * the world seed and founding site, not the world's mutable random stream.
  */
 public enum VillageStyle {
-  BIRCH_FOREST, DESERT, BADLANDS, FLOODPLAIN;
+  BIRCH_FOREST, DESERT, BADLANDS, FLOODPLAIN, JUNGLE;
 
   /**
    * What a blank or unknown saved style reads as, the answer for every climate
@@ -137,7 +137,7 @@ public enum VillageStyle {
 
   /**
    * The conventional families that map to a finished catalog. Every other
-   * family (plains, forest, taiga, snowy, jungle, swamp and the rest) has no
+   * family (plains, forest, taiga, snowy, swamp and the rest) has no
    * catalog of its own and falls through to the climate clusters.
    */
   @Nullable
@@ -156,6 +156,9 @@ public enum VillageStyle {
     }
     if (tagged.test(Tags.Biomes.IS_DESERT) || tagged.test(Tags.Biomes.IS_SANDY)) {
       return DESERT;
+    }
+    if (tagged.test(Tags.Biomes.IS_JUNGLE) || path.contains("jungle")) {
+      return JUNGLE;
     }
     // The floodplain catalog is the mangrove family: vanilla mangrove swamp
     // carries the explicit style tag, and a modded mangrove biome is still

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/WallPalette.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/WallPalette.java
@@ -24,6 +24,9 @@ record WallPalette(Block post, Block deck, Block stairs, Block slab,
       case FLOODPLAIN -> new WallPalette(
           Blocks.MUD_BRICKS, Blocks.MUD_BRICKS, Blocks.MUD_BRICK_STAIRS,
           Blocks.MUD_BRICK_SLAB, Blocks.MUD_BRICK_WALL, Blocks.JUNGLE_TRAPDOOR);
+      case JUNGLE -> new WallPalette(
+          Blocks.JUNGLE_PLANKS, Blocks.BAMBOO_MOSAIC, Blocks.BAMBOO_MOSAIC_STAIRS,
+          Blocks.BAMBOO_MOSAIC_SLAB, Blocks.JUNGLE_FENCE, Blocks.JUNGLE_TRAPDOOR);
     };
   }
 
@@ -35,6 +38,7 @@ record WallPalette(Block post, Block deck, Block stairs, Block slab,
     if (this.post == Blocks.SMOOTH_SANDSTONE) return Blocks.CHISELED_SANDSTONE;
     if (this.post == Blocks.SMOOTH_RED_SANDSTONE) return Blocks.CHISELED_RED_SANDSTONE;
     if (this.post == Blocks.MUD_BRICKS) return Blocks.MUDDY_MANGROVE_ROOTS;
+    if (this.post == Blocks.JUNGLE_PLANKS) return Blocks.STRIPPED_JUNGLE_WOOD;
     return this.post;
   }
 
@@ -43,6 +47,7 @@ record WallPalette(Block post, Block deck, Block stairs, Block slab,
     Block candle = this.post == Blocks.SMOOTH_SANDSTONE ? Blocks.CANDLE
         : this.post == Blocks.SMOOTH_RED_SANDSTONE ? Blocks.ORANGE_CANDLE
         : this.post == Blocks.MUD_BRICKS ? Blocks.BROWN_CANDLE : null;
+    if (this.post == Blocks.JUNGLE_PLANKS) return Blocks.TORCH.defaultBlockState();
     if (candle == null) return Blocks.LANTERN.defaultBlockState();
     int count = 2 + Math.floorMod(31 * position.getX() + 17 * position.getZ()
         + position.getY(), 3);

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/WallSegmentCatalog.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/WallSegmentCatalog.java
@@ -28,7 +28,7 @@ public interface WallSegmentCatalog {
   static WallSegmentCatalog forStyle(VillageStyle style) {
     return switch (style) {
       case BIRCH_FOREST -> BuiltInWallSegmentCatalog.BIRCH_FOREST;
-      case DESERT, BADLANDS, FLOODPLAIN -> BuiltInWallSegmentCatalog.ARID;
+      case DESERT, BADLANDS, FLOODPLAIN, JUNGLE -> BuiltInWallSegmentCatalog.ARID;
     };
   }
 }

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/WallTier.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/WallTier.java
@@ -24,6 +24,7 @@ public enum WallTier {
       case BADLANDS -> Items.RED_SANDSTONE;
       case BIRCH_FOREST -> Items.COBBLESTONE;
       case FLOODPLAIN -> Items.MUD_BRICKS;
+      case JUNGLE -> Items.JUNGLE_LOG;
     };
   }
 

--- a/src/main/resources/data/kithkyn/tags/worldgen/biome/village_style/jungle.json
+++ b/src/main/resources/data/kithkyn/tags/worldgen/biome/village_style/jungle.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:jungle",
+    "minecraft:bamboo_jungle",
+    "minecraft:sparse_jungle"
+  ]
+}

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/PhysicalWorksiteTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/PhysicalWorksiteTest.java
@@ -1,0 +1,93 @@
+package com.quzzar.kithkyn.village.buildings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonParser;
+import com.mojang.serialization.JsonOps;
+import com.quzzar.kithkyn.village.Occupation;
+import java.util.Map;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Rotation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class PhysicalWorksiteTest {
+  @AfterEach
+  void clearRegistry() {
+    Buildings.reload(Map.of());
+  }
+
+  @Test
+  void routedPostsAndNonVacancyWorksitesSurviveTheDefinitionCodec() {
+    BuildingInfo center = definition("""
+        {"structure":"village_center_jungle_1","work_stations":[
+          {"pos":[4,1,4],"occupation":"MINER","worksite_category":"mine"}
+        ]}
+        """);
+    BuildingInfo mine = definition("""
+        {"structure":"mine_jungle_1","worksites":[
+          {"pos":[2,0,4],"occupation":"MINER"}
+        ],"mine_entrance":{"facing":"south","offset":[0,0,1],"width":3}}
+        """);
+
+    assertEquals("mine", center.getWorksiteCategory(center.getWorkLocations().keySet().iterator().next()));
+    assertTrue(mine.getWorkLocations().isEmpty(), "A physical worksite must not create another job vacancy");
+    assertEquals(Occupation.MINER, mine.getWorksiteLocations().values().iterator().next());
+
+    BuildingInfo restored = BuildingInfo.CODEC.parse(JsonOps.INSTANCE,
+        BuildingInfo.CODEC.encodeStart(JsonOps.INSTANCE, mine).getOrThrow()).getOrThrow();
+    assertEquals(mine.getWorksiteLocations(), restored.getWorksiteLocations());
+  }
+
+  @Test
+  void aPhysicalMineWorksiteOwnsTheSameShaftFrameAsAnOrdinaryMinePost() {
+    BuildingInfo mine = definition("""
+        {"structure":"mine_jungle_1","worksites":[
+          {"pos":[2,0,4],"occupation":"MINER"}
+        ],"mine_entrance":{"facing":"south","offset":[0,0,1],"width":3}}
+        """);
+    Buildings.reload(Map.of(mine.getName(), mine));
+    Building building = new Building(new BlockPos(100, 64, 200), mine.getName(), Rotation.CLOCKWISE_90);
+
+    MineShaft shaft = MineShaft.of(building).getFirst();
+    assertEquals(new BlockPos(95, 64, 202), shaft.mouth());
+    assertEquals(1, shaft.radius());
+    assertEquals(BlockPos.asLong(2, 0, 4), shaft.rootStation());
+  }
+
+  @Test
+  void aRoutedMinerVacancyDoesNotExcavateItsCivicBuilding() {
+    BuildingInfo center = definition("""
+        {"structure":"village_center_jungle_1","work_stations":[
+          {"pos":[4,1,4],"occupation":"MINER","worksite_category":"mine"}
+        ]}
+        """);
+    Buildings.reload(Map.of(center.getName(), center));
+    Building building = new Building(new BlockPos(100, 64, 200), center.getName(), Rotation.NONE);
+
+    assertTrue(MineShaft.of(building).isEmpty(), "The separate mine building must own the routed shaft");
+  }
+
+  @Test
+  void malformedPhysicalWorksiteMetadataIsRejected() {
+    BuildingInfo blankRoute = definition("""
+        {"structure":"village_center_jungle_1","work_stations":[
+          {"pos":[4,1,4],"occupation":"MINER","worksite_category":""}
+        ]}
+        """);
+    assertEquals("worksite_category cannot be blank", blankRoute.validate());
+
+    BuildingInfo duplicatePosition = definition("""
+        {"structure":"mine_jungle_1",
+         "work_stations":[{"pos":[2,0,4],"occupation":"MINER"}],
+         "worksites":[{"pos":[2,0,4],"occupation":"MINER"}]}
+        """);
+    assertEquals("a position cannot be both a job vacancy and a physical worksite",
+        duplicatePosition.validate());
+  }
+
+  private static BuildingInfo definition(String json) {
+    return BuildingInfo.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(json)).getOrThrow();
+  }
+}

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/VillageStyleTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/VillageStyleTest.java
@@ -38,7 +38,7 @@ class VillageStyleTest {
   @Test
   void bundledBirchLeadsTheEnumAndIsWhatUnknownSavedStylesReadAs() {
     assertEquals(List.of(VillageStyle.BIRCH_FOREST, VillageStyle.DESERT, VillageStyle.BADLANDS,
-        VillageStyle.FLOODPLAIN), List.of(VillageStyle.values()));
+        VillageStyle.FLOODPLAIN, VillageStyle.JUNGLE), List.of(VillageStyle.values()));
     assertEquals(VillageStyle.BIRCH_FOREST, VillageStyle.DEFAULT);
     assertEquals(VillageStyle.BIRCH_FOREST, VillageStyle.fromId(""));
     assertEquals(VillageStyle.BIRCH_FOREST, VillageStyle.fromId("plains"));
@@ -108,7 +108,7 @@ class VillageStyleTest {
   void unfinishedConventionalFamiliesBuildBirchRatherThanARemovedCatalog() {
     List<TagKey<Biome>> unfinished = List.of(Tags.Biomes.IS_PLAINS, Tags.Biomes.IS_FOREST,
         Tags.Biomes.IS_DECIDUOUS_TREE, Tags.Biomes.IS_SWAMP, Tags.Biomes.IS_TAIGA,
-        Tags.Biomes.IS_CONIFEROUS_TREE, Tags.Biomes.IS_MOUNTAIN, Tags.Biomes.IS_JUNGLE);
+        Tags.Biomes.IS_CONIFEROUS_TREE, Tags.Biomes.IS_MOUNTAIN);
     for (long seed = 0; seed < 20; seed++) {
       for (TagKey<Biome> tag : unfinished) {
         assertFamily(tag, VillageStyle.BIRCH_FOREST, seed);
@@ -119,6 +119,17 @@ class VillageStyleTest {
       assertEquals(VillageStyle.BIRCH_FOREST,
           VillageStyle.select(Tags.Biomes.IS_ICY::equals, "ice_spikes", 0.0F, true, 0.5F, seed, ALL_STYLES));
     }
+  }
+
+  @Test
+  void jungleFamiliesUseJungleOnlyWhenItsFoundingCatalogIsLoaded() {
+    assertEquals(VillageStyle.JUNGLE,
+        VillageStyle.select(Tags.Biomes.IS_JUNGLE::equals, "jungle", 0.95F, true, 0.9F, 7L, ALL_STYLES));
+    assertEquals(VillageStyle.JUNGLE,
+        VillageStyle.select(NO_TAGS, "sparse_jungle_hills", 0.95F, true, 0.8F, 7L, ALL_STYLES));
+    assertEquals(VillageStyle.FLOODPLAIN,
+        VillageStyle.select(Tags.Biomes.IS_JUNGLE::equals, "jungle", 0.95F, true, 0.9F, 7L,
+            style -> style == VillageStyle.FLOODPLAIN));
   }
 
   @Test

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/WallPaletteTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/WallPaletteTest.java
@@ -115,4 +115,39 @@ class WallPaletteTest {
   void everyVillageHasOnlyOneWallStage() {
     assertArrayEquals(new WallTier[] {WallTier.WOOD}, WallTier.values());
   }
+
+  @Test
+  void jungleWallsUseTimberBambooAndTorches() {
+    var ring = WallRoute.aroundBox(0, 48, 0, 48);
+    var gates = Set.of(BlockPos.asLong(24, 0, 0), BlockPos.asLong(48, 0, 24),
+        BlockPos.asLong(24, 0, 48), BlockPos.asLong(0, 0, 24));
+    var style = VillageStyle.JUNGLE;
+    var wall = new WallProject(ring, gates, Collections.nCopies(ring.size(), 64), WallTier.WOOD, style);
+    int timber = 0, bamboo = 0, frames = 0, torches = 0, hanging = 0;
+    for (var cell : wall.plannedBlocks()) {
+      var state = cell.desiredState(wall.getTier(), style);
+      if (cell.piece() == WallBlockPlan.Piece.BODY || cell.piece() == WallBlockPlan.Piece.POST) {
+        assertTrue(state.is(Blocks.JUNGLE_PLANKS));
+        timber++;
+      } else if (cell.piece() == WallBlockPlan.Piece.WALKWAY || cell.piece() == WallBlockPlan.Piece.SLAB
+          || cell.piece().name().startsWith("STEP_")) {
+        assertTrue(state.is(Blocks.BAMBOO_MOSAIC) || state.is(Blocks.BAMBOO_MOSAIC_SLAB)
+            || state.is(Blocks.BAMBOO_MOSAIC_STAIRS));
+        bamboo++;
+      } else if (cell.piece() == WallBlockPlan.Piece.GATE_FRAME_POST
+          || cell.piece() == WallBlockPlan.Piece.GATE_FRAME_BEAM) {
+        assertTrue(state.is(Blocks.STRIPPED_JUNGLE_WOOD));
+        frames++;
+      } else if (cell.piece() == WallBlockPlan.Piece.LANTERN) {
+        assertTrue(state.is(Blocks.TORCH));
+        torches++;
+      } else if (cell.piece() == WallBlockPlan.Piece.LANTERN_HANGING) {
+        assertTrue(state.is(Blocks.LANTERN));
+        hanging++;
+      }
+    }
+    assertTrue(timber > 0 && bamboo > 0 && frames > 0 && torches > 0);
+    assertEquals(16, hanging);
+    assertEquals(Items.JUNGLE_LOG, WallTier.WOOD.material(style));
+  }
 }

--- a/tools/structure/VillageTemplateExport.java
+++ b/tools/structure/VillageTemplateExport.java
@@ -78,8 +78,9 @@ public final class VillageTemplateExport {
           JsonObject edit = value.getAsJsonObject();
           ListTag position = ints(vector(edit.get("pos")));
           blocks.removeIf(tag -> ((CompoundTag)tag).get("pos").equals(position));
+          String blockName = edit.get("name").getAsString();
           CompoundTag state = new CompoundTag();
-          state.putString("Name", edit.get("name").getAsString());
+          state.putString("Name", blockName);
           CompoundTag properties = new CompoundTag();
           edit.getAsJsonObject("properties").entrySet().forEach(property ->
               properties.putString(property.getKey(), property.getValue().getAsString()));
@@ -87,7 +88,14 @@ public final class VillageTemplateExport {
           int stateIndex = palette.indexOf(state);
           if (stateIndex < 0) { palette.add(state); stateIndex = palette.size() - 1; }
           CompoundTag block = new CompoundTag();
-          block.put("pos", position); block.putInt("state", stateIndex); blocks.add(block);
+          block.put("pos", position);
+          block.putInt("state", stateIndex);
+          if (Set.of("minecraft:barrel", "minecraft:chest", "minecraft:trapped_chest").contains(blockName)) {
+            CompoundTag blockEntity = new CompoundTag();
+            blockEntity.putString("id", blockName);
+            block.put("nbt", blockEntity);
+          }
+          blocks.add(block);
         }
       }
       if (spec.has("horizontal_bounds")) {

--- a/tools/structure/jungle-catalog-20260910.json
+++ b/tools/structure/jungle-catalog-20260910.json
@@ -1,0 +1,788 @@
+{
+  "status": "verified_private_catalog",
+  "variant": "jungle",
+  "production_datapack": "run/jungle-integration/datapack",
+  "selection_record": "tools/structure/jungle-selections-20260910.json",
+  "description": "Nineteen approved Jungle buildings plus three repaired market tiers.",
+  "wall": "Runtime Jungle timber and bamboo wall palette with standing torches.",
+  "founding": {
+    "center": "village_center_jungle_1",
+    "buildings": 7,
+    "beds": 4,
+    "jobs": [
+      "QUARTERMASTER",
+      "BUILDER",
+      "GUARD/CAPTAIN",
+      "MINER"
+    ],
+    "companions": [
+      "mine_jungle_1",
+      "storehouse_jungle_1",
+      "house_jungle_1",
+      "house_jungle_1__small_house_4",
+      "house_jungle_1",
+      "house_jungle_1__small_house_4"
+    ]
+  },
+  "buildings": [
+    {
+      "exhibit": "JA01.1",
+      "structure": "village_center_jungle_1",
+      "category": "village_center",
+      "level": 1,
+      "recipe": "village_center_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/town_centers/jungle_meeting_point_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA01.1.nbt",
+      "source_capture_sha256": "d9df05aeba28d63319211f1490d78473d23161bbfe8a9e56761daeeb727043c7",
+      "gallery_origin": [
+        4896,
+        230,
+        1010
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        11,
+        3,
+        11
+      ],
+      "beds": 0,
+      "stations": [
+        "QUARTERMASTER",
+        "BUILDER",
+        "GUARD",
+        "MINER"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/village_center_jungle_1.nbt",
+      "asset_sha256": "065b11bca6a9e43ce6138c8b19a6a54f86da66897600502dca1d77db3967bf09",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/village_center_jungle_1.json",
+      "definition_sha256": "8836341835707eafd69302a217ff72b5349c68b12e3e84bfab32045e92b22e55"
+    },
+    {
+      "exhibit": "JA01.4",
+      "structure": "lumberjack_jungle_1",
+      "category": "lumberjack",
+      "level": 1,
+      "recipe": "lumberjack_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_animal_pen_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA01.4.nbt",
+      "source_capture_sha256": "9f8dc0a86de6cb1f7ba36a543d34ee3648f7b0f59c186d62cc6e949a47961692",
+      "gallery_origin": [
+        4956,
+        230,
+        1010
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        8,
+        4,
+        11
+      ],
+      "beds": 0,
+      "stations": [
+        "LUMBERJACK"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/lumberjack_jungle_1.nbt",
+      "asset_sha256": "9ee39b0616c4f80e7a4df9641103d307fb6a987b25c1cc4d97004928b212cec5",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/lumberjack_jungle_1.json",
+      "definition_sha256": "e782e47477a41318f9ad135a809433c9beddb8ed89b58b91a5b10381d69f78b7"
+    },
+    {
+      "exhibit": "JA01.5",
+      "structure": "mine_jungle_1",
+      "category": "mine",
+      "level": 1,
+      "recipe": "mine_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_armorer_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA01.5.nbt",
+      "source_capture_sha256": "1548682f0faae3f6dff805ea887829f9761fa755c83b143de4e2ea49b0e9f723",
+      "gallery_origin": [
+        4972,
+        230,
+        1010
+      ],
+      "crop": [
+        4,
+        0,
+        4
+      ],
+      "size": [
+        5,
+        5,
+        5
+      ],
+      "beds": 0,
+      "stations": [],
+      "worksites": [
+        "MINER"
+      ],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/mine_jungle_1.nbt",
+      "asset_sha256": "3c33aa6ab338540b6a98191d5f1559cb5daf0b5f4b08fa2a33374676f93c8786",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/mine_jungle_1.json",
+      "definition_sha256": "6481a1a955766bb931b8e95a9eb95fee1ef8cd27f557a7b9acb7478572dd3c1d"
+    },
+    {
+      "exhibit": "JA01.6",
+      "structure": "tavern_jungle_1",
+      "category": "tavern",
+      "level": 1,
+      "recipe": "tavern_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_butcher_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA01.6.nbt",
+      "source_capture_sha256": "e26e0f26ddf0d04b3381b20601e2976fec36c4802e122ff526f0c2112e95fe9d",
+      "gallery_origin": [
+        4986,
+        230,
+        1010
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        10,
+        9,
+        7
+      ],
+      "beds": 0,
+      "stations": [
+        "INNKEEPER"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/tavern_jungle_1.nbt",
+      "asset_sha256": "80ed8fca18b88ca032491846c74ca6d6d4f39c04dde645f8440a6dd3f1ffefce",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/tavern_jungle_1.json",
+      "definition_sha256": "4f23a6a7d1dbb662d937f76d8833e2fb0dbe85c02764285854c0bc86440a4089"
+    },
+    {
+      "exhibit": "JA01.7",
+      "structure": "house_jungle_2",
+      "category": "house",
+      "level": 2,
+      "recipe": "house_2",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_cartographer_1.nbt",
+      "source_capture": "run/jungle-tower-review-20260910/adoption/captures/JA01.7-comparison.nbt",
+      "source_capture_sha256": "05c30865d6dea51d3d7b3074a75d53336866fc068833a76169c748061f7f4cb2",
+      "gallery_origin": [
+        5258,
+        230,
+        944
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        14,
+        22,
+        12
+      ],
+      "beds": 2,
+      "stations": [],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/house_jungle_2.nbt",
+      "asset_sha256": "2870bdbf62f5e3be4fe81d133051fa8523cf22bd0ac3627a261f0f8863d3fefb",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/house_jungle_2.json",
+      "definition_sha256": "db0e827d53a5e9e325a1712560459301355bad6670376e7bbf55dc0f1f3f774d"
+    },
+    {
+      "exhibit": "NH06.5",
+      "structure": "watchtower_jungle_1",
+      "category": "watchtower",
+      "level": 1,
+      "recipe": "watchtower_1",
+      "source_mod_structure": "data/nova_structures/structure/firewatch_tower/firewatch_jungle.nbt",
+      "source_capture": "run/jungle-tower-review-20260910/adoption/captures/NH06.5-comparison.nbt",
+      "source_capture_sha256": "6c1c76f367d032226942bef0db8161bc88e4d4090f9257c9821a88446bf9b391",
+      "gallery_origin": [
+        5292,
+        230,
+        944
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        9,
+        18,
+        9
+      ],
+      "beds": 1,
+      "stations": [
+        "GUARD"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/watchtower_jungle_1.nbt",
+      "asset_sha256": "8b7ed01e77550b3bb8b7fef025dea3a880c0e53eb8cc4900fe8e1ad1754b4149",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/watchtower_jungle_1.json",
+      "definition_sha256": "586e319a407b209a35f2243eb5aa25de0f6db21a54c1c879b57ac0f2ec5d9fbb"
+    },
+    {
+      "exhibit": "JA01.8",
+      "structure": "fishery_jungle_1",
+      "category": "fishery",
+      "level": 1,
+      "recipe": "fishery_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_fisher_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA01.8.nbt",
+      "source_capture_sha256": "75709284e8d942de4916bc601a744ccf358c55f4c39448ad90259454479385a1",
+      "gallery_origin": [
+        5026,
+        230,
+        1010
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        8,
+        8,
+        13
+      ],
+      "beds": 1,
+      "stations": [
+        "FISHER"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/fishery_jungle_1.nbt",
+      "asset_sha256": "2b63a01dc7dde2c3df5ad7637b72951e00d520bbc623d9b6f7a1ec761434724c",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/fishery_jungle_1.json",
+      "definition_sha256": "1537356c0e95ea9718e4f05cbb8c54e6092ca7d18d43f31af5be0b232b3a7208"
+    },
+    {
+      "exhibit": "JA02.1",
+      "structure": "hunting_lodge_jungle_1",
+      "category": "hunting_lodge",
+      "level": 1,
+      "recipe": "hunting_lodge_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_fletcher_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA02.1.nbt",
+      "source_capture_sha256": "430f6a04f5968cf6f8579a6de8c064f41c9262e788c4782b3c8bc3a0491f2d03",
+      "gallery_origin": [
+        4896,
+        230,
+        1043
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        8,
+        8,
+        9
+      ],
+      "beds": 0,
+      "stations": [
+        "HUNTER"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/hunting_lodge_jungle_1.nbt",
+      "asset_sha256": "7d2c316330f25f7162a402365cdc9b0449ed8a14d11ffad8fbfc1a0c232cfea3",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/hunting_lodge_jungle_1.json",
+      "definition_sha256": "84dd78a9479a92baa2b2e87bc9580a7f87338d8c1a335703436c9afcc749f387"
+    },
+    {
+      "exhibit": "JA02.2",
+      "structure": "house_jungle_2__large_house_1",
+      "category": "house",
+      "level": 2,
+      "recipe": "house_2",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_large_house_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA02.2.nbt",
+      "source_capture_sha256": "eae1934cc3c0f7e1b91e8b61b3df2b1bedffcc468e78837133878f81b3dc85ad",
+      "gallery_origin": [
+        4912,
+        230,
+        1043
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        8,
+        8,
+        7
+      ],
+      "beds": 2,
+      "stations": [],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/house_jungle_2__large_house_1.nbt",
+      "asset_sha256": "ac5207b0d271e7301d386e802fba05150af0ac505fc6c70ad5cc19baf8dcf491",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/house_jungle_2__large_house_1.json",
+      "definition_sha256": "b6f9e0e7270ad01e27fd905cd7747efd5914835bee6f4d49e760eeb41cc5d19c"
+    },
+    {
+      "exhibit": "JA02.3",
+      "structure": "couple_cottage_jungle_1",
+      "category": "couple_cottage",
+      "level": 1,
+      "recipe": "couple_cottage_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_leatherworker_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA02.3.nbt",
+      "source_capture_sha256": "0cb3d721d30bf31294109ec0949162a39712d7d3a4b398120959be9612bff642",
+      "gallery_origin": [
+        4928,
+        230,
+        1043
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        11,
+        17,
+        12
+      ],
+      "beds": 2,
+      "stations": [],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/couple_cottage_jungle_1.nbt",
+      "asset_sha256": "27acc3e4b04f3ca51a6418dfd8d0c37f67e0546700b2d37c16c3a4c7f566cc35",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/couple_cottage_jungle_1.json",
+      "definition_sha256": "3ad0957820034cc0e4a753cf62db372c003df05ef03fc15bc9393dadadbeb032"
+    },
+    {
+      "exhibit": "JA02.5",
+      "structure": "stoneworks_jungle_1",
+      "category": "stoneworks",
+      "level": 1,
+      "recipe": "stoneworks_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_mason_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA02.5.nbt",
+      "source_capture_sha256": "48a5e7b05a6c197f84d09ade36da06ef06ff6e9503afe9d138e126e1d5f9a26d",
+      "gallery_origin": [
+        4969,
+        230,
+        1043
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        9,
+        6,
+        9
+      ],
+      "beds": 0,
+      "stations": [
+        "MASON"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/stoneworks_jungle_1.nbt",
+      "asset_sha256": "0b05a3f6e12523b4962bdd7aa0512e15b734ac06eac5a9b4da2662a24b628ccd",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/stoneworks_jungle_1.json",
+      "definition_sha256": "e80b454c69bd355d011e9c5b068b65920e41f59401e2450842fe841343fadb70"
+    },
+    {
+      "exhibit": "JA02.6",
+      "structure": "butchery_jungle_1",
+      "category": "butchery",
+      "level": 1,
+      "recipe": "butchery_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_shepherd_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA02.6.nbt",
+      "source_capture_sha256": "f145f97f476593ca26ad16cf7129a1850cdeaf61833e4dfb6aac480ae7bab11b",
+      "gallery_origin": [
+        4986,
+        230,
+        1043
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        8,
+        6,
+        11
+      ],
+      "beds": 1,
+      "stations": [
+        "BUTCHER"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/butchery_jungle_1.nbt",
+      "asset_sha256": "2c840977eda33e879a72924277dcef6e66776effd14b91df46502dbcaf868171",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/butchery_jungle_1.json",
+      "definition_sha256": "a66eac239434e21eb9f1aa647671abffdda64f2223dd98672dc78d771f0f9f1a"
+    },
+    {
+      "exhibit": "JA02.7",
+      "structure": "farm_jungle_1",
+      "category": "farm",
+      "level": 1,
+      "recipe": "farm_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_small_farm_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA02.7.nbt",
+      "source_capture_sha256": "8f39a275028a678e773801a9db61e1b123873e510e133d9ad765d173e4156ddd",
+      "gallery_origin": [
+        5002,
+        230,
+        1043
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        12,
+        3,
+        11
+      ],
+      "beds": 0,
+      "stations": [
+        "FARMER"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/farm_jungle_1.nbt",
+      "asset_sha256": "62a6b628bb56bc0834f3f815f3c6989057d59163e77732c7116d1a6698fa1e03",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/farm_jungle_1.json",
+      "definition_sha256": "60689590bd8ad5e96fb21efd65b23cfa7cd5cc7488f78986556e5f25144a67de"
+    },
+    {
+      "exhibit": "JA02.8",
+      "structure": "bakery_jungle_1",
+      "category": "bakery",
+      "level": 1,
+      "recipe": "bakery_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_small_house_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA02.8.nbt",
+      "source_capture_sha256": "7b5f7e9e5c7fb9ab525b3a4498bb973c7fbb0e50e6e95988932cad030ec6bb4d",
+      "gallery_origin": [
+        5023,
+        230,
+        1043
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        7,
+        7,
+        7
+      ],
+      "beds": 0,
+      "stations": [
+        "BAKER"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/bakery_jungle_1.nbt",
+      "asset_sha256": "af3bd34e32e7bc32728defb064d4544015329e5074ad9ed82f2abd3208c3d409",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/bakery_jungle_1.json",
+      "definition_sha256": "6ccfa8740b1ec38797116202759ab3b13b001f3d74cd4d4b7398e9f0fd357f75"
+    },
+    {
+      "exhibit": "JA02.9",
+      "structure": "house_jungle_1",
+      "category": "house",
+      "level": 1,
+      "recipe": "house_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_small_house_2.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA02.9.nbt",
+      "source_capture_sha256": "63451f7045ce6307e387eaab61a1a40eb470e3ecc78e03589a316e0642c2b400",
+      "gallery_origin": [
+        5038,
+        230,
+        1043
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        7,
+        7,
+        7
+      ],
+      "beds": 1,
+      "stations": [],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/house_jungle_1.nbt",
+      "asset_sha256": "afa87cd3d00a9a72fc0eaa8f0a8247364629482c90b969cdb3443439f550c612",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/house_jungle_1.json",
+      "definition_sha256": "0e6da9f85cfb6282e697de00c687c29b11f797b2743138de60edbf8b51d99022"
+    },
+    {
+      "exhibit": "JA03.1",
+      "structure": "storehouse_jungle_1",
+      "category": "storehouse",
+      "level": 1,
+      "recipe": "storehouse_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_small_house_3.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA03.1.nbt",
+      "source_capture_sha256": "67a86e0cd2847f5007cf8ebef94ee1b64cd450cf082a7b09f9e098b4097d34d7",
+      "gallery_origin": [
+        4896,
+        230,
+        1078
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        8,
+        5,
+        7
+      ],
+      "beds": 0,
+      "stations": [],
+      "worksites": [
+        "QUARTERMASTER"
+      ],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/storehouse_jungle_1.nbt",
+      "asset_sha256": "ac3ca85398f48fcc490f79155466585066e49e6db49bbc1d358d5d3a099276d2",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/storehouse_jungle_1.json",
+      "definition_sha256": "135ebe3f4a3dbe30134b943054f1b7ce799f300a516162c845fb0457e3fd0be3"
+    },
+    {
+      "exhibit": "JA03.2",
+      "structure": "house_jungle_1__small_house_4",
+      "category": "house",
+      "level": 1,
+      "recipe": "house_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_small_house_4.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA03.2.nbt",
+      "source_capture_sha256": "00be3aec61fe7b9964c3bb8ead237609bcece24d7aad4e83a8f2f1158a31979b",
+      "gallery_origin": [
+        4912,
+        230,
+        1078
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        7,
+        6,
+        7
+      ],
+      "beds": 1,
+      "stations": [],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/house_jungle_1__small_house_4.nbt",
+      "asset_sha256": "42b8c76e4f4478824b8460d73058323eb47b143c322f6c3e6e32fa8913c646f7",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/house_jungle_1__small_house_4.json",
+      "definition_sha256": "b1caa52513f0a4f484c34c1a57ccc4e0d7ac65f39a5887f1a2c0441c95baa6e7"
+    },
+    {
+      "exhibit": "JA03.3",
+      "structure": "church_jungle_1",
+      "category": "church",
+      "level": 1,
+      "recipe": "church_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_temple_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA03.3.nbt",
+      "source_capture_sha256": "f3a7cfc8b23aa14fb174bf531b3d51cd263dbca20a029b322893128fb01f0186",
+      "gallery_origin": [
+        4927,
+        230,
+        1078
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        7,
+        12,
+        12
+      ],
+      "beds": 0,
+      "stations": [
+        "CLERIC"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/church_jungle_1.nbt",
+      "asset_sha256": "dbce3b21580c554e543a6f1ae57af07b8061b6f76540b842661933b0ab6d6091",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/church_jungle_1.json",
+      "definition_sha256": "c6103a4c0ce8a36eaa0b636cdbc5ec464ee1503571e350a93650eb1aebf4dd8e"
+    },
+    {
+      "exhibit": "JA03.5",
+      "structure": "blacksmith_jungle_1",
+      "category": "blacksmith",
+      "level": 1,
+      "recipe": "blacksmith_1",
+      "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_weaponsmith_1.nbt",
+      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA03.5.nbt",
+      "source_capture_sha256": "cdc2c6211a88a1d4cea502ca166e0eb5525234b9ac45551748a02d3f57079fb3",
+      "gallery_origin": [
+        4960,
+        230,
+        1078
+      ],
+      "crop": [
+        2,
+        0,
+        2
+      ],
+      "size": [
+        12,
+        6,
+        8
+      ],
+      "beds": 0,
+      "stations": [
+        "BLACKSMITH"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/blacksmith_jungle_1.nbt",
+      "asset_sha256": "053d903b5b97e72f1978b75e27ea6d1f392feec00f097ccc736a1774ea8ed9e0",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/blacksmith_jungle_1.json",
+      "definition_sha256": "6fa6853abbcca2bcb2315a0be9532ff57bc4f46a25370281fc504e502a5bd858"
+    },
+    {
+      "exhibit": "MARKET.1",
+      "structure": "market_jungle_1",
+      "category": "market",
+      "level": 1,
+      "recipe": "market_1",
+      "source_capture": "run/market-repair-20260910/pack/data/kithkyn/structure/market_jungle_1.nbt",
+      "source_capture_sha256": "68876b38420002f335f56c1193b4d05fe4aed7605b82b6ed21ec701b3c481d34",
+      "crop": [
+        0,
+        0,
+        0
+      ],
+      "size": [
+        16,
+        6,
+        17
+      ],
+      "beds": 0,
+      "stations": [
+        "MERCHANT"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/market_jungle_1.nbt",
+      "asset_sha256": "68876b38420002f335f56c1193b4d05fe4aed7605b82b6ed21ec701b3c481d34",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/market_jungle_1.json",
+      "definition_sha256": "82153b50f91a7e12f083a8f581f325910128afe146a4c24f218c8c09a61cfdde"
+    },
+    {
+      "exhibit": "MARKET.2",
+      "structure": "market_jungle_2",
+      "category": "market",
+      "level": 2,
+      "recipe": "market_2",
+      "source_capture": "run/market-repair-20260910/pack/data/kithkyn/structure/market_jungle_2.nbt",
+      "source_capture_sha256": "e50fe2ae7576b9fd5794953ddd66c1b04bf7f6539077eabb0af4a2f3a17b1235",
+      "crop": [
+        0,
+        0,
+        0
+      ],
+      "size": [
+        23,
+        6,
+        17
+      ],
+      "beds": 0,
+      "stations": [
+        "MERCHANT",
+        "MERCHANT"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/market_jungle_2.nbt",
+      "asset_sha256": "e50fe2ae7576b9fd5794953ddd66c1b04bf7f6539077eabb0af4a2f3a17b1235",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/market_jungle_2.json",
+      "definition_sha256": "6218f3a07efa70523b9c4b83623740feb6b63a283285ebfeab80c3191b537b22"
+    },
+    {
+      "exhibit": "MARKET.3",
+      "structure": "market_jungle_3",
+      "category": "market",
+      "level": 3,
+      "recipe": "market_3",
+      "source_capture": "run/market-repair-20260910/pack/data/kithkyn/structure/market_jungle_3.nbt",
+      "source_capture_sha256": "9d1d3a097f64b7e16b835e7f08c92c7a34b14de8a11c74b6036dd78cf57f79fe",
+      "crop": [
+        0,
+        0,
+        0
+      ],
+      "size": [
+        23,
+        6,
+        25
+      ],
+      "beds": 0,
+      "stations": [
+        "MERCHANT",
+        "MERCHANT",
+        "MERCHANT"
+      ],
+      "worksites": [],
+      "asset": "run/jungle-integration/datapack/data/kithkyn/structure/market_jungle_3.nbt",
+      "asset_sha256": "9d1d3a097f64b7e16b835e7f08c92c7a34b14de8a11c74b6036dd78cf57f79fe",
+      "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/market_jungle_3.json",
+      "definition_sha256": "9a959caa54711fed140dac02b0caef24d25452c3ec77c32f1dc986a14d7e0d89"
+    }
+  ],
+  "source_policy": "Locally approved playable datapack, excluded from public distribution. Source provenance is retained; written redistribution permission is not asserted.",
+  "verification": {
+    "access": {
+      "rotated_structures": 84,
+      "routes": 224,
+      "room_walks_and_sleeps": 44,
+      "personal_deposits": 36,
+      "station_walks": 68,
+      "shared_deposits": 80,
+      "mine_walks": 8,
+      "failed_placements": 0
+    },
+    "placement": {
+      "real_template_placements": 176,
+      "paths": [
+        "instant",
+        "incremental"
+      ],
+      "rotations": 4
+    },
+    "restart": {
+      "saved_buildings": 176
+    },
+    "founding": {
+      "strict_templates": 22,
+      "housing_alternatives": 4,
+      "upgrade_fits": 8,
+      "rotations": 4,
+      "beds": 4,
+      "jobs": 4
+    }
+  },
+  "runtime_sha256": "027bb63bf53c3b250801c1e1e44fc8a75410f5fa32b19ed4a8773621f2f69942"
+}

--- a/tools/structure/jungle-catalog-20260910.json
+++ b/tools/structure/jungle-catalog-20260910.json
@@ -1,5 +1,5 @@
 {
-  "status": "verified_private_catalog",
+  "status": "verified_and_locally_deployed",
   "variant": "jungle",
   "production_datapack": "run/jungle-integration/datapack",
   "selection_record": "tools/structure/jungle-selections-20260910.json",
@@ -784,5 +784,13 @@
       "jobs": 4
     }
   },
-  "runtime_sha256": "027bb63bf53c3b250801c1e1e44fc8a75410f5fa32b19ed4a8773621f2f69942"
+  "runtime_sha256": "027bb63bf53c3b250801c1e1e44fc8a75410f5fa32b19ed4a8773621f2f69942",
+  "deployment": {
+    "date": "2026-09-10",
+    "commit": "a594958ea1870c0ce8f31a5a1d79bf3ce7d3b02f",
+    "release": "20260910-193529-jungle-village",
+    "datapack": "run/world/datapacks/kithkyn-jungle",
+    "building_definitions_loaded": 126,
+    "world_backup": "before-jungle-village-20260910-193529"
+  }
 }


### PR DESCRIPTION
The Jungle family was documented as an intended direction but could not found a playable village. This adds conventional Jungle biome selection, the reviewed 22-building private catalog contract, the approved timber-and-bamboo wall palette, and ordinary-growth placement for the mine, storehouse, and four starting homes.

The bedless center keeps the four founding jobs while its miner and quartermaster resolve separate physical worksites. The native exporter now supplies block-entity NBT for overridden containers, and the access verifier exercises production mine waypoints without false failures at Minecraft's valid navigation stopping distance.

The public jar contains the runtime and biome tag only. The reviewed third-party-derived Jungle templates remain in the local private datapack with their provenance record.

Validation:

- `./gradlew clean build` — passed (476 tests, 7 skipped)
- Native founding verification — 22 strict templates, 4 housing alternatives, 8 upgrade fits, all 4 rotations and codec reloads, natural biome selection, 4 beds, and 4 positions
- Native access verification — 84 rotations, 224 routes, 44 room walks/sleeps, 36 personal deposits, 68 station walks, 80 shared deposits, and 8 mine walks
- Native placement/restart verification — 176 placements across instant/incremental paths and all rotations; all 176 survived restart
