### PR TITLE
Refuse template blocks outside the declared size

### DIFF
--- a/tools/structure/VillageTemplateExport.java
+++ b/tools/structure/VillageTemplateExport.java
@@ -14,7 +14,8 @@ import java.util.*;
  * exact tag types such as {@code Health:10.0f}, or a JSON object parsed as SNBT text (integers become
  * ints, decimals doubles, booleans bytes). Entries are appended to the template's entity list as
  * {@code pos}, {@code blockPos} (the floor of {@code pos}) and {@code nbt}, then pass through the same
- * hygiene as captured entities below.
+ * hygiene as captured entities below. Every block must lie inside {@code size}: one outside it
+ * fails the export rather than stretching the building's footprint in the world.
  */
 public final class VillageTemplateExport {
   static ListTag ints(int... values) {
@@ -118,7 +119,20 @@ public final class VillageTemplateExport {
               && palette.getCompound(block.getInt("state")).getString("Name").equals("minecraft:air");
         });
       }
-      root.put("size", ints(vector(spec.get("size"))));
+      int[] size = vector(spec.get("size"));
+      // A block outside the declared size is never intended: it stretches the building's
+      // footprint in the world (a gallery sign captured four cells in front of a mine
+      // pushed the whole mine back), so the export fails instead of shipping it.
+      for (Tag tag : blocks) {
+        ListTag position = ((CompoundTag)tag).getList("pos", Tag.TAG_INT);
+        for (int axis = 0; axis < 3; axis++) {
+          if (position.getInt(axis) < 0 || position.getInt(axis) >= size[axis]) {
+            throw new IllegalArgumentException("Block outside the declared size at " + position + " in "
+                + spec.get("output").getAsString() + ": crop it out, override it to air inside horizontal_bounds, or widen size");
+          }
+        }
+      }
+      root.put("size", ints(size));
       if (spec.has("entities")) {
         ListTag entities = root.getList("entities", Tag.TAG_COMPOUND);
         for (JsonElement value : spec.getAsJsonArray("entities")) {

--- a/tools/structure/desert-catalog-20260909.json
+++ b/tools/structure/desert-catalog-20260909.json
@@ -248,7 +248,7 @@
       "structure": "mine_desert_1",
       "manifest": "tools/structure/desert-services-20260909.json",
       "recipe": "mine_1",
-      "asset_sha256": "e313bddea3bf9be266c1a47d38788480656ff71c5a077e8e1b8b7b0fac19ea7d",
+      "asset_sha256": "f278bbd84c32383b90a566c2792ff714dfa1b1c62c14c292c9c835d68607b20d",
       "definition_sha256": "564cd6818c2c0450ce033229529f0e69624612e8f7b50432dea6ff1e041e05ad",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/desert_oasis/jobsite/pen.nbt",
@@ -461,6 +461,13 @@
         "mine_desert_1"
       ],
       "note": "Aaron edited a production copy in the gallery: a shared chest at the pit, two wall posts, a fence, a trapdoor and a lantern added. Re-exported in the same frame; the chest joins the shared containers."
+    },
+    {
+      "date": "2026-09-10",
+      "structures": [
+        "mine_desert_1"
+      ],
+      "note": "The evening re-export had carried the gallery row sign at (6, 0, -4), outside the template; scrubbed and the template rebuilt within its bounds."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `VillageTemplateExport.java` fails on any block outside the declared `size`: the Desert mine re-export had carried the gallery row sign at (6, 0, -4), which stretched the building's footprint and pushed every placed mine back.
- The Desert mine is re-exported clean (same capture, sign scrubbed, bounds enforced) and installed in both packs with a live reload; `tools/structure/desert-catalog-20260909.json` carries the new hash and a revision note.

## Test plan
- [x] The tool refuses the old plan with "Block outside the declared size at [6,0,-4]" and reproduces the clean mine byte for byte from the fixed plan
- [x] Live reload: 126 building definitions, no rejections
- [x] Placement verification for `mine_desert_1` running

🤖 Generated with [Claude Code](https://claude.com/claude-code)