### PR TITLE
Let a miner press sand into lining and gate a face that needs a seal

### DIFF
--- a/docs/desert-village.md
+++ b/docs/desert-village.md
@@ -99,3 +99,15 @@ village's existing staffed market and treasury. Two stacked evidence barrels bes
 rooftop cell are excluded from village storage and theft rules. See [castles.md](castles.md) for custody, inventory handling
 and ruler decisions. All four rotations passed physical access and role-allocation
 checks; the live private catalog now loads 201 total building definitions.
+
+## Mining in sand
+
+A desert shaft passes through nothing but sand for its first columns, and sand falls, so
+it is no lining. The miner presses four sand into a sandstone block by hand when the lining
+runs out (`MineSupportMaterials`), the same table-less press as the torch and bone meal
+crafts, so a desert shaft lines itself with what it digs; the bedtime restock draws sand
+from the stores when they hold no dirt or stone. A face whose fall would open an unsealed
+boundary is never broken with an empty pack: before this rule the seal failed and the
+same sand block was broken and reset without end (Aaron, 2026-09-10); the miner fans ribs
+for material instead and comes back to the face.
+

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -628,6 +628,15 @@ does not require the bucket, so a miner without one still makes the lining safe 
 reports that the enclosed water or lava is blocking progress. If a later break exposes a fresh
 breach, the next audit seals it before another bucket act.
 
+Lining is spent from the pack, dirt and stone first, and a shaft in sand country lines itself with
+what it digs: four sand press into a sandstone block by hand when the lining runs out, red sand
+into red sandstone (`MineSupportMaterials`), the same table-less press as the miner's torches and
+the farmer's bone meal, and the bedtime restock draws sand from the stores when they hold no dirt
+or stone. The seal comes before the break, so a face whose fall would open an unsealed boundary is
+never broken with an empty pack: the miner fans ribs for material and comes back to it. Before
+that rule the seal failed and the same sand block was broken and reset without end (a Desert mine,
+2026-09-10).
+
 The mine interior is the descending ramp plus every planned prospecting rib. A rib entrance is an
 intentional doorway through the ramp wall, so the lining pass never fills it back in. A flooded
 pocket is followed through both ramp and rib cells, and every six-direction transition from that

--- a/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
@@ -1898,6 +1898,20 @@ public class RealPerson extends Person {
         this.addItems(List.of(got));
       }
     }
+    // Sand country: the stores hold what the builder cleared, and four sand press
+    // into a block of lining at the wall (MineSupportMaterials), so sand fills
+    // the rest of the pack when the stores have no dirt or stone left.
+    for (Item sand : MineSupportMaterials.pressableSand()) {
+      if (wanted <= 0) {
+        return;
+      }
+      ItemStack got = this.getVillage().gatherItemStackFromVillage(
+          new ItemStack(sand, wanted * MineSupportMaterials.SAND_PER_BLOCK), depositToLoc);
+      if (!got.isEmpty()) {
+        wanted -= got.getCount() / MineSupportMaterials.SAND_PER_BLOCK;
+        this.addItems(List.of(got));
+      }
+    }
   }
 
   /**

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineStep.java
@@ -399,9 +399,14 @@ public final class MineStep implements BlockWorkStep {
       // pulling ore is gated on support to seal too (selectVein). Quarry support
       // instead - fan short ribs into the solid rock beside the ramp, which
       // needs none and drops plenty (selectFan) - and let the next sweep resume the
-      // bridge once the pack has refilled. Only support-gated work reroutes; a
-      // diggable face still digs, since breaking stone is itself a support source.
-      if ((this.placeFloor || this.placeSeal)
+      // bridge once the pack has refilled. Only support-gated work reroutes. A
+      // face is support-gated too when its fall would open the shaft to an
+      // unsealed boundary: the seal comes before the break, so an empty pack
+      // broke the same block and reset without end. Sand country made that
+      // permanent, since a sand face drops no lining (Aaron, 2026-09-10); a face
+      // whose boundary is already solid still digs, and breaking stone is itself
+      // a support source.
+      if ((this.placeFloor || this.placeSeal || needsSupportToBreak(person.level(), mouth, rotation))
           && MineSupportMaterials.held(person.personMainInv) == 0) {
         BlockPos fanStand = selectFan(person, mouth, rotation);
         if (fanStand != null) {
@@ -1102,6 +1107,16 @@ public final class MineStep implements BlockWorkStep {
 
   private BlockPos face(BlockPos mouth, Rotation rotation) {
     return mouth.offset(this.offset.rotate(rotation));
+  }
+
+  /**
+   * Whether breaking the next face would leave an open boundary to seal, read the
+   * way {@link #sealAround} will read it before the block comes down: a fluid
+   * beyond the exterior lining, or an open floor, wall or ceiling cell.
+   */
+  private boolean needsSupportToBreak(Level level, BlockPos mouth, Rotation rotation) {
+    return openExteriorBoundary(level, mouth, rotation, this.offset, false) != null
+        || openBoundary(level, mouth, rotation, face(mouth, rotation), this.offset) != null;
   }
 
   /**

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/MineSupportMaterials.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/MineSupportMaterials.java
@@ -2,6 +2,9 @@ package com.quzzar.kithkyn.village.buildings;
 
 import java.util.ArrayList;
 import java.util.List;
+import net.minecraft.world.item.Items;
+import java.util.Set;
+import java.util.Map;
 
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
@@ -12,8 +15,23 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 
-/** Dirt and stone blocks a miner can spend on floors, walls, and ceilings. */
+/**
+ * Dirt and stone blocks a miner can spend on floors, walls, and ceilings, and the
+ * sand that presses into them. A desert shaft passes through nothing but sand for
+ * its first columns, and sand falls, so it is no lining; four sand pack into one
+ * sandstone block and red sand into red sandstone, and the miner packs them by
+ * hand when the lining runs out, the same table-less press as the torch and bone
+ * meal crafts. Sand therefore counts as support four to the block, real dirt or
+ * stone is spent first, and the pack keeps its sand until a seal actually needs it.
+ */
 public final class MineSupportMaterials {
+
+  /** Vanilla's press: four sand to a sandstone block. */
+  public static final int SAND_PER_BLOCK = 4;
+
+  private static final Map<Item, Item> PRESSES = Map.of(
+      Items.SAND, Items.SANDSTONE,
+      Items.RED_SAND, Items.RED_SANDSTONE);
 
   public static final TagKey<Item> TAG = TagKey.create(Registries.ITEM,
       ResourceLocation.fromNamespaceAndPath("kithkyn", "mine_support_materials"));
@@ -26,6 +44,7 @@ public final class MineSupportMaterials {
     return !stack.isEmpty() && stack.getItem() instanceof BlockItem && stack.is(TAG);
   }
 
+  /** Support blocks in hand, counting sand at four to the block. */
   public static int held(Container container) {
     int total = 0;
     for (int slot = 0; slot < container.getContainerSize(); slot++) {
@@ -34,10 +53,16 @@ public final class MineSupportMaterials {
         total += stack.getCount();
       }
     }
+    for (Item sand : PRESSES.keySet()) {
+      total += container.countItem(sand) / SAND_PER_BLOCK;
+    }
     return total;
   }
 
-  /** Takes mixed support blocks, preserving each actual block the miner carries. */
+  /**
+   * Takes mixed support blocks, preserving each actual block the miner carries,
+   * then presses sand into sandstone for whatever is still short.
+   */
   public static List<ItemStack> take(Container container, int amount) {
     List<ItemStack> taken = new ArrayList<>();
     int left = amount;
@@ -50,10 +75,41 @@ public final class MineSupportMaterials {
       left -= piece.getCount();
       taken.add(piece);
     }
+    while (left > 0) {
+      ItemStack pressed = pressOne(container);
+      if (pressed.isEmpty()) {
+        break;
+      }
+      taken.add(pressed);
+      left--;
+    }
     if (!taken.isEmpty()) {
       container.setChanged();
     }
     return taken;
+  }
+
+  /** One block pressed from four sand of one kind, or empty when no kind has four. */
+  private static ItemStack pressOne(Container container) {
+    for (Map.Entry<Item, Item> press : PRESSES.entrySet()) {
+      if (container.countItem(press.getKey()) < SAND_PER_BLOCK) {
+        continue;
+      }
+      int toSpend = SAND_PER_BLOCK;
+      for (int slot = 0; slot < container.getContainerSize() && toSpend > 0; slot++) {
+        ItemStack stack = container.getItem(slot);
+        if (stack.is(press.getKey())) {
+          toSpend -= stack.split(toSpend).getCount();
+        }
+      }
+      return new ItemStack(press.getValue());
+    }
+    return ItemStack.EMPTY;
+  }
+
+  /** The sand kinds a miner presses into support, for restocking a short pack. */
+  public static Set<Item> pressableSand() {
+    return PRESSES.keySet();
   }
 
   public static ItemStack takeOne(Container container) {

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/MineSupportMaterialsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/MineSupportMaterialsTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.gson.JsonParser;
 
+import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
@@ -22,6 +23,31 @@ class MineSupportMaterialsTest {
         MineSupportMaterials.blockState(new ItemStack(Items.DIRT)));
     assertEquals(Blocks.DEEPSLATE.defaultBlockState(),
         MineSupportMaterials.blockState(new ItemStack(Items.DEEPSLATE)));
+  }
+
+  /** Item tags are not bound in a unit test, so dirt and stone are exercised natively; sand needs no tag. */
+  @Test
+  void sandPressesIntoSandstoneFourToTheBlock() {
+    SimpleContainer pack = new SimpleContainer(9);
+    pack.setItem(0, new ItemStack(Items.SAND, 9));
+    assertEquals(2, MineSupportMaterials.held(pack), "two blocks' worth of sand");
+    assertEquals(Items.SANDSTONE, MineSupportMaterials.takeOne(pack).getItem());
+    assertEquals(5, pack.countItem(Items.SAND));
+    assertEquals(Items.SANDSTONE, MineSupportMaterials.takeOne(pack).getItem());
+    assertEquals(1, pack.countItem(Items.SAND));
+    assertTrue(MineSupportMaterials.takeOne(pack).isEmpty(), "three sand are no block yet");
+    assertEquals(0, MineSupportMaterials.held(pack));
+  }
+
+  @Test
+  void redSandPressesIntoRedSandstone() {
+    SimpleContainer pack = new SimpleContainer(3);
+    pack.setItem(0, new ItemStack(Items.RED_SAND, 2));
+    pack.setItem(2, new ItemStack(Items.RED_SAND, 2));
+    ItemStack pressed = MineSupportMaterials.takeOne(pack);
+    assertEquals(Items.RED_SANDSTONE, pressed.getItem());
+    assertEquals(Blocks.RED_SANDSTONE.defaultBlockState(), MineSupportMaterials.blockState(pressed));
+    assertTrue(pack.isEmpty(), "both part stacks were spent");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `MineSupportMaterials`: four sand press into a sandstone block (red sand into red sandstone) when real lining runs out; `held` counts sand four to the block, so the vein and floor gates see it as support.
- `MineStep`: a face whose fall would open an unsealed boundary is support-gated like floors and linings when the pack holds nothing, so the miner fans ribs for material instead of breaking and resetting the same block forever (the Mavirel desert mine).
- `RealPerson.restockMineSupports`: the bedtime restock draws sand from the stores when they hold no dirt or stone.
- Docs: worker loops and the desert village note the rule. Tests cover the press.

## Test plan
- [x] `./gradlew test`: 478 tests, 0 failures
- [x] House-access fixture for `mine_desert_1` on the fix build: RESULT PASS including the excavation check (the gate leaves a solid-boundary face diggable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)