### PR TITLE
Fetch lining from the stores by day when a shaft stands down

### DIFF
--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -632,7 +632,9 @@ Lining is spent from the pack, dirt and stone first, and a shaft in sand country
 what it digs: four sand press into a sandstone block by hand when the lining runs out, red sand
 into red sandstone (`MineSupportMaterials`), the same table-less press as the miner's torches and
 the farmer's bone meal, and the bedtime restock draws sand from the stores when they hold no dirt
-or stone. The seal comes before the break, so a face whose fall would open an unsealed boundary is
+or stone, and by day a shaft standing down for want of lining sends the miner to a chest holding
+dirt, stone or sand (`FetchMineSupportStep`, the miner's counterpart of the farmer's daytime bone
+meal fetch). The seal comes before the break, so a face whose fall would open an unsealed boundary is
 never broken with an empty pack: the miner fans ribs for material and comes back to it. Before
 that rule the seal failed and the same sand block was broken and reset without end (a Desert mine,
 2026-09-10).

--- a/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
@@ -85,6 +85,7 @@ import com.quzzar.kithkyn.entities.ai.goals.work.GradeStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.ClearBrushStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.CompostStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.FetchBonemealStep;
+import com.quzzar.kithkyn.entities.ai.goals.work.FetchMineSupportStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.PlantStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.StashBonemealStep;
 import com.quzzar.kithkyn.entities.ai.goals.ArmorerRepairPersonArmorGoal;
@@ -2709,6 +2710,9 @@ public class RealPerson extends Person {
       // Ahead of the work goal: a full pack is worth a trip before more digging.
       this.goalSelector.addGoal(3, new WorkLoopGoal<>(this, new HaulStep()));
       this.goalSelector.addGoal(4, new WorkLoopGoal<>(this, new MineStep()));
+      // Behind it: a shaft standing down for want of lining sends the miner to
+      // the stores for dirt, stone or sand rather than waiting on bedtime.
+      this.goalSelector.addGoal(5, new WorkLoopGoal<>(this, new FetchMineSupportStep()));
     }
     if (getOccupation() == Occupation.BUILDER) {
       // A lone builder does it all in one order: gathering the recipe, raising

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/FetchMineSupportStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/FetchMineSupportStep.java
@@ -1,0 +1,80 @@
+package com.quzzar.kithkyn.entities.ai.goals.work;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.quzzar.kithkyn.entities.RealPerson;
+import com.quzzar.kithkyn.village.Village;
+import com.quzzar.kithkyn.village.buildings.MineSupportMaterials;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Restocking the shaft's lining from the stores by day: a CARRY step, container
+ * to pack, and the daytime half of the miner's bedtime support restock.
+ *
+ * The bedtime restock fills the pack once a night; a shaft that runs out of
+ * lining before then stands down at a face it may not break without a seal
+ * ({@link MineStep}). In sand country that was a whole first day idle, since
+ * the pack held only sand and the builder's cleared sand sat in the stores.
+ * This walks to a chest holding dirt or stone, or the sand that presses into
+ * sandstone at the wall ({@link MineSupportMaterials}), and carries a working
+ * load back. It engages only when the pack holds no lining at all, so it never
+ * competes with the digging, and a village with nothing in store leaves it
+ * dormant, which is what a real shortage looks like.
+ */
+public final class FetchMineSupportStep implements BlockWorkStep {
+
+  /** Same helping as the bedtime restock takes; the pack is not a warehouse. */
+  private static final int PACK_TARGET = 32;
+
+  @Override
+  @Nullable
+  public BlockPos select(RealPerson person) {
+    Village village = person.getVillage();
+    if (village == null || person.isInventoryFull()
+        || MineSupportMaterials.held(person.personMainInv) > 0) {
+      return null;
+    }
+    return PackLogistics.chestHolding(person, village, wanted());
+  }
+
+  @Override
+  public boolean act(RealPerson person, BlockPos target) {
+    Container chest = PackLogistics.containerAt(person, target);
+    if (chest == null) {
+      return false; // the chest was taken out from under them
+    }
+    PackLogistics.pullWanted(person, chest, wanted(), person.getOccupation().name());
+    return false; // one visit per select: full or not, back to the shaft
+  }
+
+  /** Every lining item the shaft can place, then the sand kinds that press into one. */
+  private static List<ItemStack> wanted() {
+    List<ItemStack> wanted = new ArrayList<>();
+    for (Holder<Item> holder : BuiltInRegistries.ITEM.getTagOrEmpty(MineSupportMaterials.TAG)) {
+      wanted.add(new ItemStack(holder.value(), PACK_TARGET));
+    }
+    for (Item sand : MineSupportMaterials.pressableSand()) {
+      wanted.add(new ItemStack(sand, PACK_TARGET * MineSupportMaterials.SAND_PER_BLOCK));
+    }
+    return wanted;
+  }
+
+  @Override
+  public String describe() {
+    return "dirt, stone or sand for the shaft's lining";
+  }
+
+  @Override
+  public String activity() {
+    return "fetching lining for the mine from the stores";
+  }
+}


### PR DESCRIPTION
## Summary
- `FetchMineSupportStep`: the daytime counterpart of the miner's bedtime support restock. When the pack holds no lining at all, the miner walks to a chest holding dirt, stone or pressable sand and carries a working load back; registered behind `MineStep` so it never competes with digging.
- Docs: the worker loops note.

## Test plan
- [x] `./gradlew test`: 478 tests, 0 failures
- [x] House-access fixture for `mine_desert_1` on this build: RESULT PASS with the excavation check

🤖 Generated with [Claude Code](https://claude.com/claude-code)