### PR TITLE
Lock the Jungle mine floor revision

### DIFF
--- a/docs/jungle-village.md
+++ b/docs/jungle-village.md
@@ -17,7 +17,7 @@ catalog and immutable output hashes are recorded in
 | Id | Selected use | Beds and stations |
 | --- | --- | --- |
 | `village_center_jungle_1` | JA01.1 meeting point | No beds; quartermaster, builder, guard captain and miner vacancies |
-| `mine_jungle_1` | JA01.5 edited armorer | No vacancy; one physical miner worksite and two shared barrels |
+| `mine_jungle_1` | JA01.5 edited armorer | No vacancy; one sunken physical miner worksite and two shared barrels at the stair rim |
 | `storehouse_jungle_1` | JA03.1 edited small house | No vacancy; one physical quartermaster worksite and three shared containers |
 | `lumberjack_jungle_1` | JA01.4 animal pen | Lumberjack and one shared chest |
 | `tavern_jungle_1` | JA01.6 butcher | Innkeeper and one shared barrel; no bed |
@@ -53,9 +53,10 @@ The quartermaster and miner vacancies remain owned by the center, while their ph
 happens in the separately placed storehouse and mine. A `worksite_category` on each center post
 routes the worker to the nearest matching building; the target building declares a `worksites`
 position without creating a duplicate vacancy. Removing or rebuilding that target makes the
-workplace temporarily unavailable. The mine alone owns its three-block-wide shaft, which leaves
-the east wall two blocks from the worksite so the authored mouth, workstation footing and final
-surface step do not overlap.
+workplace temporarily unavailable. The mine alone owns its three-block-wide shaft. Its four-by-three
+pit is one block deep, with three stairs down its west side and both material barrels at that stair
+rim. The miner stands in the pit's west column; the eastward ramp mouth is one column inward and one
+block above that post, keeping the first descending cuts inside the pavilion.
 
 The bell is the meeting and arrival point. The campfire is a separate cooking and idle amenity;
 it does not redefine the village center.
@@ -80,8 +81,8 @@ the other regional styles.
 ## Authoring and local installation
 
 `run/jungle-integration/prepare.py` reads the immutable capture record, crops the approved
-structures, neutralizes village identity slots, moves the butcher's inaccessible chest and the
-mine's embedded barrels, opens the mine mouth, and assembles
+structures, neutralizes village identity slots, moves the butcher's inaccessible chest and applies
+the approved sunken mine-floor revision, then assembles
 `run/jungle-integration/datapack/`. Programmatically placed chests and barrels receive native
 block-entity data from `tools/structure/VillageTemplateExport.java`. The private pack is installed
 as `kithkyn-jungle` and kept with world backups; the public jar deliberately carries none of the
@@ -91,7 +92,8 @@ can request `/kithkyn create-village ~ ~ ~ jungle`.
 ## Verification
 
 Core tests cover biome selection, codec persistence, routed physical worksites, mine ownership,
-the Jungle wall palette and unchanged fallback behavior. Native checks run the private catalog
+the Jungle wall palette and unchanged fallback behavior. An opt-in private-asset test fixes the
+mine's pit, stair, barrel, worksite and mouth geometry. Native checks run the private catalog
 through the shared reviewed-village, access and real-placement fixtures.
 
 The September 10 integration passed the complete access suite: 84 rotated structures, 224 real
@@ -102,4 +104,7 @@ four rotations, including colors, frames, save receipts and upgrade preservation
 restart retained all 176 buildings. The founding fixture passed 22 strict templates, all four
 center rotations, eight market upgrade fits, natural Jungle selection, four starting homes,
 four assigned workers, distinct bell and campfire locations, routed mine/storehouse work and
-codec reloads.
+codec reloads. After the mine-floor revision, a focused native pass added four real excavation
+runs, eight routed-worksite access routes and eight instant/incremental construction placements
+across all four rotations. The exported template has zero blockstate mismatches against Aaron's
+flushed live capture.

--- a/docs/structure-review.md
+++ b/docs/structure-review.md
@@ -1788,9 +1788,11 @@ and miner route to non-vacancy physical worksites in those separate buildings. T
 real ownership error exposed by the center test: a routed miner post must not create a shaft under
 the civic building; only the physical mine owns and excavates that shaft.
 
-The final mine uses a three-block-wide eastward mouth, offset two blocks from its worksite so its
-surface workstation, opening and final ramp headroom do not compete for one cell. Its two material
-barrels and the butcher's personal chest moved to reachable positions. The native exporter now
+Aaron's final mine edit adds a four-by-three pit one block beneath the pavilion, three jungle stairs
+down its west side and two material barrels at the stair rim. The miner's post is in the pit's west
+column; its three-block-wide eastward mouth sits one column inward and one block above the post, so
+the first descending cuts remain under the pavilion. The butcher's personal chest also moved to a
+reachable position. The native exporter now
 writes block-entity data for chests and barrels created by export overrides, so strict template
 loading sees the same containers as physical access does.
 
@@ -1802,3 +1804,9 @@ rotations, the market upgrades, natural Jungle selection, the four starting home
 village identity and codec reloads. The public record is
 `tools/structure/jungle-catalog-20260910.json`; implementation and operating details are in
 [jungle-village.md](jungle-village.md).
+
+The approved mine-floor revision was then checked separately in every rotation. Four real mining
+loops opened the intended first descending step without crossing either authored entrance edge;
+eight routed-worksite walks covered both barrels plus mine descent and return; and eight instant or
+incremental construction placements retained the revised template. The production NBT has zero
+blockstate differences from the flushed gallery capture.

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/JunglePlacementAssetsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/JunglePlacementAssetsTest.java
@@ -1,0 +1,83 @@
+package com.quzzar.kithkyn.village.buildings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/** Authored pit and entrance contracts for the private Jungle mine. */
+@EnabledIfEnvironmentVariable(named = "KITHKYN_JUNGLE_DATAPACK", matches = ".+")
+class JunglePlacementAssetsTest {
+  private static Path data() {
+    return Path.of(System.getenv("KITHKYN_JUNGLE_DATAPACK"), "data", "kithkyn");
+  }
+
+  @Test
+  void mineKeepsTheApprovedSunkenWorkFloor() throws Exception {
+    JsonObject definition = JsonParser.parseString(Files.readString(
+        data().resolve("kithkyn/buildings/mine_jungle_1.json"))).getAsJsonObject();
+    assertEquals(0, definition.get("sink").getAsInt());
+
+    var worksite = definition.getAsJsonArray("worksites").get(0).getAsJsonObject().getAsJsonArray("pos");
+    assertEquals(1, worksite.get(0).getAsInt());
+    assertEquals(0, worksite.get(1).getAsInt());
+    assertEquals(2, worksite.get(2).getAsInt());
+
+    JsonObject entrance = definition.getAsJsonObject("mine_entrance");
+    assertEquals("east", entrance.get("facing").getAsString());
+    assertEquals(3, entrance.get("width").getAsInt());
+    assertEquals(1, entrance.getAsJsonArray("offset").get(0).getAsInt());
+    assertEquals(1, entrance.getAsJsonArray("offset").get(1).getAsInt());
+    assertEquals(0, entrance.getAsJsonArray("offset").get(2).getAsInt());
+
+    CompoundTag template = NbtIo.readCompressed(
+        data().resolve("structure/mine_jungle_1.nbt"), NbtAccounter.unlimitedHeap());
+    var size = template.getList("size", Tag.TAG_INT);
+    assertEquals(6, size.getInt(0));
+    assertEquals(6, size.getInt(1));
+    assertEquals(5, size.getInt(2));
+    var palette = template.getList("palette", Tag.TAG_COMPOUND);
+    Map<Long, CompoundTag> cells = new HashMap<>();
+    for (Tag value : template.getList("blocks", Tag.TAG_COMPOUND)) {
+      CompoundTag block = (CompoundTag) value;
+      var pos = block.getList("pos", Tag.TAG_INT);
+      long key = new BlockPos(pos.getInt(0), pos.getInt(1), pos.getInt(2)).asLong();
+      assertTrue(cells.put(key, block) == null, "Duplicate template cell " + pos);
+    }
+
+    assertBlock(cells, palette, 0, 0, 0, "minecraft:barrel");
+    assertBlock(cells, palette, 0, 0, 4, "minecraft:barrel");
+    for (int z = 1; z <= 3; z++) {
+      assertBlock(cells, palette, 0, 0, z, "minecraft:jungle_stairs");
+    }
+    for (int x = 1; x <= 4; x++) {
+      for (int z = 1; z <= 3; z++) {
+        assertBlock(cells, palette, x, 0, z, "minecraft:air");
+      }
+    }
+    assertBlock(cells, palette, 1, 0, 2, "minecraft:air");
+    assertBlock(cells, palette, 2, 1, 2, "minecraft:air");
+    assertBlock(cells, palette, 2, 2, 2, "minecraft:air");
+  }
+
+  private static void assertBlock(Map<Long, CompoundTag> cells, net.minecraft.nbt.ListTag palette,
+      int x, int y, int z, String expected) {
+    long key = new BlockPos(x, y, z).asLong();
+    CompoundTag block = cells.get(key);
+    assertTrue(block != null, "Missing template cell " + new BlockPos(x, y, z));
+    assertEquals(expected, palette.getCompound(block.getInt("state")).getString("Name"),
+        new BlockPos(x, y, z).toString());
+  }
+}

--- a/tools/structure/jungle-catalog-20260910.json
+++ b/tools/structure/jungle-catalog-20260910.json
@@ -103,21 +103,21 @@
       "level": 1,
       "recipe": "mine_1",
       "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_armorer_1.nbt",
-      "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA01.5.nbt",
-      "source_capture_sha256": "1548682f0faae3f6dff805ea887829f9761fa755c83b143de4e2ea49b0e9f723",
+      "source_capture": "run/jungle-review-20260910/current-edit-capture/jungle_mine_edit.nbt",
+      "source_capture_sha256": "1191a88470e70edc11efe2de71e10e3eee1d17d8f2991767315dd4531af06b33",
       "gallery_origin": [
-        4972,
-        230,
-        1010
+        4924,
+        229,
+        920
       ],
       "crop": [
-        4,
-        0,
-        4
+        2,
+        1,
+        3
       ],
       "size": [
-        5,
-        5,
+        6,
+        6,
         5
       ],
       "beds": 0,
@@ -126,9 +126,18 @@
         "MINER"
       ],
       "asset": "run/jungle-integration/datapack/data/kithkyn/structure/mine_jungle_1.nbt",
-      "asset_sha256": "3c33aa6ab338540b6a98191d5f1559cb5daf0b5f4b08fa2a33374676f93c8786",
+      "asset_sha256": "70868db7facac1a0a0d86386b2a718ce14c37e0fe3835ebdd2b3a8174affbe5e",
       "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/mine_jungle_1.json",
-      "definition_sha256": "6481a1a955766bb931b8e95a9eb95fee1ef8cd27f557a7b9acb7478572dd3c1d"
+      "definition_sha256": "7e1d363e1d74e35db037ccd3a8409e6ac61cc8a87c55ca1299856b78c6287cd3",
+      "revision_verification": {
+        "status": "passed",
+        "exact_capture_state_mismatches": 0,
+        "asset_contract_test": "JunglePlacementAssetsTest",
+        "rotations": 4,
+        "construction_placements": 8,
+        "production_access_routes": 8,
+        "excavation_runs": 4
+      }
     },
     {
       "exhibit": "JA01.6",

--- a/tools/structure/jungle-selections-20260910.json
+++ b/tools/structure/jungle-selections-20260910.json
@@ -214,7 +214,7 @@
         1018
       ],
       "role": "mine",
-      "status": "captured_pending_production_authoring",
+      "status": "approved_and_deployed",
       "capacity": {
         "beds": 0,
         "single_beds": 0,
@@ -282,7 +282,16 @@
               0,
               4
             ]
-          ]
+          ],
+          "verification": {
+            "status": "passed",
+            "exact_capture_state_mismatches": 0,
+            "asset_contract_test": "JunglePlacementAssetsTest",
+            "rotations": 4,
+            "construction_placements": 8,
+            "production_access_routes": 8,
+            "excavation_runs": 4
+          }
         }
       ]
     },


### PR DESCRIPTION
The approved Jungle mine pit was already deployed, but the public production catalog still pointed at the previous five-block template. This updates the catalog to the captured six-by-six-by-five asset, records the worksite and shaft verification, and documents the sunken floor behavior.

It also adds an opt-in asset contract for the private datapack. The revised mine passed the full Gradle build, four native excavation runs, eight routed-worksite access routes, and eight instant/incremental placements across all four rotations.
