### PR TITLE
Seal a leak wherever it is and plug water without a bucket

### DIFF
--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -616,9 +616,14 @@ work, and nightfall clear the line and start the next cast with a fresh wait.
 
 The miner is neither: it sweeps a pattern outward and downward from its work station, digging a
 real shaft, treating lava and water and bedrock and wrong-tool as obstacles. Air and fluid at the
-shaft's outer floor, walls, or ceiling are sealing work first. The miner closes every reachable
-breach one block at a time before clearing liquid. A bucket-holder then drains the connected water
-that is reachable from the dry side, exposing any farther boundary for the next sealing pass. The bucket
+shaft's outer floor, walls, or ceiling are sealing work first. The miner closes every breach one
+block at a time before clearing liquid, from wherever he stands in the shaft: whether a cell beside
+a leak can be stood on is not modelled, because a leak at the far edge of a lake never had one and
+a miner with dirt in hand should simply plug it (Aaron, 2026-09-11). Without a bucket the water
+itself is plugged the same way, source by source, nearest the face first, and the plugs are
+quarried back out as ordinary rock once the pocket is dry, so a bucketless village still tunnels
+through a pond or a lake bed at the cost of its lining. A bucket-holder drains the connected water
+that is reachable from the dry side instead, exposing any farther boundary for the next sealing pass. The bucket
 moves into the off hand before that act, swings from the off hand, remains visible for a short
 beat, and then returns to the pack. It is a reusable tool, never filled or consumed. Bailing
 is still possible with food or another item in the off hand: equipping the bucket exchanges the

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineFluidPolicy.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineFluidPolicy.java
@@ -1,31 +1,35 @@
 package com.quzzar.kithkyn.entities.ai.goals.work;
 
-/** Pure ordering rule for a flooded stretch of shaft. */
+/**
+ * Pure ordering rule for a flooded stretch of shaft. A leak is sealed as soon
+ * as the miner has lining to seal it with, wherever it is; water is drained
+ * with a bucket, or plugged with lining and quarried back out without one.
+ */
 final class MineFluidPolicy {
 
   enum Action {
     SEAL,
-    BULKHEAD,
     BAIL,
+    PLUG,
     BLOCKED
   }
 
   private MineFluidPolicy() {
   }
 
-  static Action next(boolean boundaryOpen, boolean boundaryReachable,
-      boolean bulkheadReachable, boolean waterReachable, boolean hasBucket) {
-    if (boundaryOpen) {
-      if (boundaryReachable) {
-        return Action.SEAL;
-      }
-      if (bulkheadReachable) {
-        return Action.BULKHEAD;
-      }
-      // Draining reachable water exposes the rest of the boundary. Filling the
-      // mine interior instead eventually walls the miner off from that leak.
-      return waterReachable && hasBucket ? Action.BAIL : Action.BLOCKED;
+  static Action next(boolean boundaryOpen, boolean waterFound, boolean hasBucket, boolean hasSupport) {
+    if (boundaryOpen && hasSupport) {
+      // Every leak first, or drained and plugged water refills from it.
+      return Action.SEAL;
     }
-    return hasBucket ? Action.BAIL : Action.BLOCKED;
+    if (!waterFound) {
+      return Action.BLOCKED;
+    }
+    if (hasBucket) {
+      // With a leak still open and nothing to seal it, draining exposes the rest
+      // of the boundary for a later restock; a closed pocket simply drains.
+      return Action.BAIL;
+    }
+    return hasSupport ? Action.PLUG : Action.BLOCKED;
   }
 }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineStep.java
@@ -652,10 +652,7 @@ public final class MineStep implements BlockWorkStep {
       this.pendingFloodInside = null;
       return null;
     }
-    BlockPos stand = nearestMineStand(person, mouth, rotation, this.pendingFloodInside);
-    if (stand == null) {
-      return null; // another floor or drain pass may still be needed first
-    }
+    BlockPos stand = standAnywhere(person, mouth, rotation, this.pendingFloodInside);
     this.offset = this.pendingFloodInside;
     this.block = person.level().getBlockState(face(mouth, rotation)).getBlock();
     this.placeFloor = false;
@@ -1391,16 +1388,9 @@ public final class MineStep implements BlockWorkStep {
   }
 
   private record BoundaryBreach(BlockPos inside, BlockPos boundary, @Nullable BlockPos stand) {
-
-    boolean reachable() {
-      return stand != null;
-    }
   }
 
-  private record Bulkhead(BlockPos inside, BlockPos cell, BlockPos stand) {
-  }
-
-  private record ReachableWater(BlockPos inside, BlockPos cell, BlockPos stand) {
+  private record ReachableWater(BlockPos inside, BlockPos cell, @Nullable BlockPos stand) {
   }
 
   /**
@@ -1428,7 +1418,7 @@ public final class MineStep implements BlockWorkStep {
         BlockPos breachLocal = breach.subtract(mouth).rotate(inverse(rotation));
         BlockPos stand = nearestMineStand(person, mouth, rotation, breachLocal);
         BoundaryBreach candidate = new BoundaryBreach(local, breach, stand);
-        if (candidate.reachable()) {
+        if (candidate.stand() != null) {
           return candidate;
         }
         if (firstUnreachable == null) {
@@ -1474,34 +1464,14 @@ public final class MineStep implements BlockWorkStep {
   }
 
   /**
-   * A flooded rib whose outside source cannot be reached is closed at the
-   * doorway instead. The target remains part of the planned mine topology, so
-   * this is deliberately narrower than ordinary boundary sealing: only a rib
-   * doorway may be sacrificed, never a cell in the descending ramp.
-   */
-  @Nullable
-  private Bulkhead reachableRibBulkhead(RealPerson person, BlockPos mouth,
-      Rotation rotation, @Nullable BoundaryBreach breach) {
-    if (breach == null || !inRib(breach.inside())) {
-      return null;
-    }
-    BlockPos doorway = topology.ribDoorway(breach.inside());
-    BlockPos cell = mouth.offset(doorway.rotate(rotation));
-    if (!isLiquid(person.level(), cell)) {
-      return null;
-    }
-    BlockPos stand = nearestMineStand(person, mouth, rotation, doorway);
-    return stand == null ? null : new Bulkhead(doorway, cell, stand);
-  }
-
-  /**
-   * Water the miner can drain from the connected side of an otherwise
-   * unreachable leak. Only ramp water is considered: a flooded rib has its
-   * narrower doorway bulkhead, and lava remains an honest stop.
+   * The next water of the connected pocket to work. With a bucket, ramp water
+   * the miner can stand beside to bail; a flooded rib is left to its lining and
+   * lava remains an honest stop. Without one, the nearest water to the face in
+   * ramp or rib, to be plugged from wherever the miner stands.
    */
   @Nullable
   private ReachableWater reachableWater(RealPerson person, BlockPos mouth,
-      Rotation rotation, BlockPos start) {
+      Rotation rotation, BlockPos start, boolean toBail) {
     Level level = person.level();
     Deque<BlockPos> frontier = new ArrayDeque<>();
     Set<BlockPos> seen = new HashSet<>();
@@ -1512,6 +1482,9 @@ public final class MineStep implements BlockWorkStep {
       BlockPos world = mouth.offset(local.rotate(rotation));
       if (!isDugSpace(local) || !level.getBlockState(world).is(Blocks.WATER)) {
         continue;
+      }
+      if (!toBail) {
+        return new ReachableWater(local, world, null);
       }
       if (onRamp(local)) {
         BlockPos stand = nearestMineStand(person, mouth, rotation, local);
@@ -1760,8 +1733,8 @@ public final class MineStep implements BlockWorkStep {
     }
     BlockPos start = face.subtract(mouth).rotate(inverse(rotation));
     BoundaryBreach boundary = openBoundaryAroundFluidPocket(person, mouth, rotation, start);
-    if (boundary != null && boundary.reachable()) {
-      return false; // the world changed on the walk; seal this reachable edge first
+    if (boundary != null && MineSupportMaterials.held(person.personMainInv) > 0) {
+      return false; // the world changed on the walk; seal this edge first
     }
     if (!showBucket(person)) {
       return false;
@@ -2016,45 +1989,61 @@ public final class MineStep implements BlockWorkStep {
     return RampScan.WORK;
   }
 
-  /** Select reachable lining or draining work for the current flooded cell. */
+  /**
+   * Select lining, draining or plugging work for the current flooded cell. A
+   * leak is sealed whether or not a cell beside it can be stood on: the
+   * miner's reach is not modelled for lining, since a leak at the far edge of
+   * a lake never had a cell beside it and a miner with dirt in hand should
+   * simply plug it (Aaron, 2026-09-11). Without a bucket the water itself is
+   * plugged the same way, source by source, nearest the face first; the plugs
+   * are quarried back out as ordinary rock once the pocket is dry.
+   */
   private RampScan selectFluidWork(RealPerson person, BlockPos mouth, Rotation rotation) {
     BoundaryBreach breach = openBoundaryAroundFluidPocket(person, mouth, rotation, this.offset);
-    Bulkhead bulkhead = breach != null && !breach.reachable()
-        ? reachableRibBulkhead(person, mouth, rotation, breach)
-        : null;
-    ReachableWater reachableWater = breach != null && !breach.reachable() && bulkhead == null
-        ? reachableWater(person, mouth, rotation, this.offset)
-        : null;
-    MineFluidPolicy.Action action = MineFluidPolicy.next(
-        breach != null, breach != null && breach.reachable(), bulkhead != null,
-        reachableWater != null, carriesBucket(person));
+    boolean hasBucket = carriesBucket(person);
+    ReachableWater water = reachableWater(person, mouth, rotation, this.offset, hasBucket);
+    MineFluidPolicy.Action action = MineFluidPolicy.next(breach != null, water != null, hasBucket,
+        MineSupportMaterials.held(person.personMainInv) > 0);
     if (action == MineFluidPolicy.Action.SEAL) {
       this.offset = breach.inside();
       this.block = person.level().getBlockState(face(mouth, rotation)).getBlock();
       this.sealCell = breach.boundary();
-      this.sealStand = breach.stand();
-      this.placeSeal = true;
-      return RampScan.WORK;
-    }
-    if (action == MineFluidPolicy.Action.BULKHEAD) {
-      this.offset = bulkhead.inside();
-      this.block = person.level().getBlockState(bulkhead.cell()).getBlock();
-      this.sealCell = bulkhead.cell();
-      this.sealStand = bulkhead.stand();
+      this.sealStand = breach.stand() != null ? breach.stand() : standAnywhere(person, mouth, rotation, breach.inside());
       this.placeSeal = true;
       return RampScan.WORK;
     }
     if (action == MineFluidPolicy.Action.BAIL) {
-      if (reachableWater != null) {
-        this.offset = reachableWater.inside();
-        this.block = person.level().getBlockState(reachableWater.cell()).getBlock();
-      }
+      this.offset = water.inside();
+      this.block = person.level().getBlockState(water.cell()).getBlock();
       this.bailWater = true;
       this.lastFluidDeadEnd = null;
       return RampScan.WORK;
     }
-    logFluidDeadEnd(person, mouth, rotation, breach, bulkhead, reachableWater);
+    if (action == MineFluidPolicy.Action.PLUG) {
+      this.offset = water.inside();
+      this.block = person.level().getBlockState(water.cell()).getBlock();
+      this.sealCell = water.cell();
+      this.sealStand = standAnywhere(person, mouth, rotation, water.inside());
+      this.placeSeal = true;
+      this.lastFluidDeadEnd = null;
+      return RampScan.WORK;
+    }
+    logFluidDeadEnd(person, mouth, rotation, breach, water);
     return RampScan.BLOCKED;
+  }
+
+  /**
+   * Somewhere in the shaft to lay a block from when nothing beside the target
+   * can be stood on: the nearest dry planned cell to it, else to the face, else
+   * the walkway cell just inside the mouth, which every shaft has from its first
+   * day. Lining is placed from here without a reach check.
+   */
+  private BlockPos standAnywhere(RealPerson person, BlockPos mouth, Rotation rotation, BlockPos targetLocal) {
+    BlockPos stand = nearestMineStand(person, mouth, rotation, targetLocal);
+    if (stand == null) {
+      stand = nearestMineStand(person, mouth, rotation, this.offset);
+    }
+    return stand != null ? stand : mouth.offset(new BlockPos(0, -1, MineShaft.ENTRY_COLUMN).rotate(rotation));
   }
 
   /**
@@ -2077,8 +2066,7 @@ public final class MineStep implements BlockWorkStep {
   }
 
   private void logFluidDeadEnd(RealPerson person, BlockPos mouth, Rotation rotation,
-      @Nullable BoundaryBreach breach, @Nullable Bulkhead bulkhead,
-      @Nullable ReachableWater reachableWater) {
+      @Nullable BoundaryBreach breach, @Nullable ReachableWater reachableWater) {
     BlockPos world = face(mouth, rotation);
     String state = "mouth=" + mouth.toShortString()
         + ", face=" + world.toShortString()
@@ -2089,8 +2077,8 @@ public final class MineStep implements BlockWorkStep {
         + ", boundary=" + (breach == null ? "none" : breach.boundary().toShortString())
         + ", breachStand=" + (breach == null || breach.stand() == null
             ? "none" : breach.stand().toShortString())
-        + ", bulkhead=" + (bulkhead == null ? "none" : bulkhead.cell().toShortString())
-        + ", reachableWater=" + (reachableWater == null
+        + ", support=" + MineSupportMaterials.held(person.personMainInv)
+        + ", water=" + (reachableWater == null
             ? "none" : reachableWater.cell().toShortString());
     if (!state.equals(this.lastFluidDeadEnd)) {
       this.lastFluidDeadEnd = state;

--- a/src/test/java/com/quzzar/kithkyn/entities/ai/goals/work/MineFluidPolicyTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ai/goals/work/MineFluidPolicyTest.java
@@ -7,44 +7,28 @@ import org.junit.jupiter.api.Test;
 class MineFluidPolicyTest {
 
   @Test
-  void sealsAnOpenBoundaryBeforeUsingTheBucket() {
-    assertEquals(MineFluidPolicy.Action.SEAL, MineFluidPolicy.next(true, true, true, true, true));
-    assertEquals(MineFluidPolicy.Action.SEAL, MineFluidPolicy.next(true, true, true, true, false));
+  void aLeakIsSealedAsSoonAsThereIsLiningWhateverElseIsAtHand() {
+    assertEquals(MineFluidPolicy.Action.SEAL, MineFluidPolicy.next(true, true, true, true));
+    assertEquals(MineFluidPolicy.Action.SEAL, MineFluidPolicy.next(true, false, false, true));
   }
 
   @Test
-  void anUnreachableBoundaryUsesAReachableBulkhead() {
-    assertEquals(MineFluidPolicy.Action.BULKHEAD,
-        MineFluidPolicy.next(true, false, true, true, true));
-    assertEquals(MineFluidPolicy.Action.BULKHEAD,
-        MineFluidPolicy.next(true, false, true, true, false));
+  void aLeakWithNoLiningIsDrainedWithABucketToExposeTheRest() {
+    assertEquals(MineFluidPolicy.Action.BAIL, MineFluidPolicy.next(true, true, true, false));
+    assertEquals(MineFluidPolicy.Action.BLOCKED, MineFluidPolicy.next(true, true, false, false));
+    assertEquals(MineFluidPolicy.Action.BLOCKED, MineFluidPolicy.next(true, false, true, false));
   }
 
   @Test
-  void anUnreachableBoundaryDrainsReachableWaterToExposeTheRemainingLeak() {
-    assertEquals(MineFluidPolicy.Action.BAIL,
-        MineFluidPolicy.next(true, false, false, true, true));
-    assertEquals(MineFluidPolicy.Action.BLOCKED,
-        MineFluidPolicy.next(true, false, false, true, false));
+  void aClosedPocketDrainsWithABucketAndIsPluggedWithoutOne() {
+    assertEquals(MineFluidPolicy.Action.BAIL, MineFluidPolicy.next(false, true, true, true));
+    assertEquals(MineFluidPolicy.Action.BAIL, MineFluidPolicy.next(false, true, true, false));
+    assertEquals(MineFluidPolicy.Action.PLUG, MineFluidPolicy.next(false, true, false, true));
   }
 
   @Test
-  void anUnreachableBoundaryWithoutAnyReachableSealWorkStillBlocks() {
-    assertEquals(MineFluidPolicy.Action.BLOCKED,
-        MineFluidPolicy.next(true, false, false, false, true));
-    assertEquals(MineFluidPolicy.Action.BLOCKED,
-        MineFluidPolicy.next(true, false, false, false, false));
-  }
-
-  @Test
-  void bailsAClosedFloodWhenTheMinerHasABucket() {
-    assertEquals(MineFluidPolicy.Action.BAIL,
-        MineFluidPolicy.next(false, false, false, false, true));
-  }
-
-  @Test
-  void aClosedFloodStillNeedsABucket() {
-    assertEquals(MineFluidPolicy.Action.BLOCKED,
-        MineFluidPolicy.next(false, false, false, false, false));
+  void aClosedPocketWithNeitherBucketNorLiningStillBlocks() {
+    assertEquals(MineFluidPolicy.Action.BLOCKED, MineFluidPolicy.next(false, true, false, false));
+    assertEquals(MineFluidPolicy.Action.BLOCKED, MineFluidPolicy.next(false, false, false, true));
   }
 }


### PR DESCRIPTION
## Summary
- `MineFluidPolicy` and `MineStep.selectFluidWork`: a leak is sealed as soon as the miner has lining, with or without a cell beside it to stand on (`standAnywhere` falls back to the nearest dry planned cell, then the walkway just inside the mouth). Without a bucket the pocket's water is plugged source by source, nearest the face first, and the plugs are dug back out as ordinary rock; with a bucket the drain path is unchanged.
- The rib doorway bulkhead is removed: with every leak sealed where it is, nothing needed it.
- `bailAct` seals an open edge found on the walk whenever there is lining, not only a reachable one; a drain's exposed source edge is sealed from anywhere too.
- Docs: the worker loops sealing paragraph. Tests: the fluid policy table rewritten.

## Test plan
- [x] `./gradlew test`: 477 tests, 0 failures
- [ ] Excavation walk for `mine_desert_1` and access walk for `mine_jungle_1` on this build (running)
- [ ] Kavotu's flooded shaft on the live server after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)