### PR TITLE
Record the jungle centre edit

### DIFF
--- a/tools/structure/jungle-selections-20260910.json
+++ b/tools/structure/jungle-selections-20260910.json
@@ -122,7 +122,22 @@
         "Exact accessible work positions have not yet been authored."
       ],
       "previous_source_capture": "run/jungle-showcase/selection-20260910-tribal/captures/JA01.1.nbt",
-      "previous_source_capture_sha256": "a23ee77e0e55604c5e0d00e3e6179079e563ff9d15e25dabf7712f633a877c66"
+      "previous_source_capture_sha256": "a23ee77e0e55604c5e0d00e3e6179079e563ff9d15e25dabf7712f633a877c66",
+      "revisions": [
+        {
+          "date": "2026-09-11",
+          "note": "Aaron re-edited the centre on a production copy in the Nilotic gallery (NA11): the three white banners replaced by one white wall banner at the back, the bell moved onto a stone post with a lantern in its old place, and the north edge of the floor opened to a natural path. The identity banner list follows the new banner; posts, meeting point and campfire are unchanged.",
+          "template_sha256": "e751e1babe9f596301127cdc79eca7281617c90e539c1b67b9acb33eb624bede",
+          "definition_sha256": "174805b389c6b27ceb26f0a197b855b145a4c5860242086f332e5c717fc24df4",
+          "banners": [
+            [
+              5,
+              2,
+              9
+            ]
+          ]
+        }
+      ]
     },
     {
       "exhibit": "JA01.4",


### PR DESCRIPTION
## Summary
- `tools/structure/jungle-selections-20260910.json`: the centre (JA01.1) revision. Aaron's gallery edit: one white wall banner at the back replaces the three white banners, the bell moves onto a stone post with a lantern in its old place, and the north edge of the floor opens onto a natural path. The template is 11 by 4 by 11 now; the identity banner slot follows the new banner; posts, meeting point and campfire are unchanged and verified open.
- Template and definition installed in `run/jungle-integration/datapack` and the world pack with a live reload; the previous pair is backed up under `run/backups`.

## Test plan
- [x] Guarded export: nothing outside the declared size, no gallery furniture
- [x] Live reload: 126 definitions, no rejections
- [ ] Native placement and centre access checks for `village_center_jungle_1` running

🤖 Generated with [Claude Code](https://claude.com/claude-code)