### PR TITLE
Close villagers' eyes while they sleep

### DIFF
--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -146,12 +146,30 @@ v1 `SkinRecipe` fields:
 | `hairPigment` | two RGB shades | diploid hair-pigment gene |
 | `leftEyePigment`, `rightEyePigment` | two RGB shades each | eye-pigment genes + condition |
 | `headwearOccludesHair` | boolean | selected garment metadata |
+| `eyesClosed` | boolean | the vanilla sleeping state, read on the client at render time |
 
 Derivation is one deterministic function `AppearanceInputs -> SkinRecipe`. It uses stable
 rendezvous hashing rather than list indices, so adding an unrelated asset causes minimal
 recipe churn. It selects a model-compatible skin, then same-profile hair and eye masks that
 do not collide. Clothing is selected separately from current occupation and life stage.
 Determinism makes every client agree without syncing the full recipe.
+
+## Sleeping faces
+
+A villager in bed has their eyes shut. The recipe carries an `eyesClosed` flag that the
+client sets from the entity's vanilla sleeping state, which is already synced to every
+client, so no packet or saved field exists for it. A closed face is its own recipe, baked
+once and cached beside the waking one under the same bounded texture cache.
+
+No part carries closed-eye art. The bake leaves the two eye layers out, so the skin that
+every part sheet already paints beneath the eyes shows as lids, and paints the bottom row of
+each eye mask (`AppearanceAsset.lidTexels`) as a lash line in the skin's own shadow,
+pulled deeper than ordinary shading (`PigmentPalette.eyelid`) so it still reads on a dark
+face. Two-row eyes close to their lower row; one-row eyes become a line. Hair and headwear
+composite over the closed face exactly as they do over the open one.
+
+The preview `age-lineup-asleep` ([ui-preview.md](ui-preview.md)) photographs the four
+lineup faces shut, for comparison with the waking `age-lineup` shot.
 
 ## Genetics readiness
 

--- a/docs/ui-preview.md
+++ b/docs/ui-preview.md
@@ -20,6 +20,7 @@ Reasoning about a layout is not looking at it. If you are changing anything unde
 ./gradlew runClientJoinLocal -Puipreview=trade
 ./gradlew runClientJoinLocal -Puipreview=chat
 ./gradlew runClientJoinLocal -Puipreview=age-lineup
+./gradlew runClientJoinLocal -Puipreview=age-lineup-asleep
 ./gradlew runClientJoinLocal -Puipreview=age-lineup-world
 ```
 
@@ -36,6 +37,9 @@ Takes roughly two to four minutes, most of it client startup.
 lets it settle, then calls `Screenshot.grab` and stops the client. Chat and trade use a fixed
 `PersonChatScreen` payload. `age-lineup` creates four unspawned client-side people with identical
 appearance inputs, changes only their age stage, and renders them through the real entity renderer.
+`age-lineup-asleep` is the same four given a client-side sleeping position, which shuts their eyes
+through the sleeping face bake ([appearance.md](appearance.md)) while the standing pose keeps every
+face upright and comparable with the waking shot.
 `age-lineup-world` briefly spawns the same controlled stages in front of the preview player so the
 real entity attachments, name line, role line, camera perspective, and model scale are photographed
 together. The tagged entities are removed immediately after the capture.

--- a/src/main/java/com/quzzar/kithkyn/appearance/AppearanceAsset.java
+++ b/src/main/java/com/quzzar/kithkyn/appearance/AppearanceAsset.java
@@ -49,12 +49,27 @@ public record AppearanceAsset(
   }
 
   public boolean eyeFitsHair(AppearancePart eye, AppearanceAsset hair) {
-    List<Texel> texels = switch (eye) {
+    return eyeTexels(eye).stream()
+        .noneMatch(texel -> hair.frontHairOcclusion.contains(texel.packedIndex()));
+  }
+
+  /**
+   * Where a lowered lid rests: the bottom row of the eye mask. A sleeping face keeps
+   * skin over the rest of the mask and paints only this row as a lash line, so every
+   * authored eye shape closes without a second set of art.
+   */
+  public List<Texel> lidTexels(AppearancePart eye) {
+    List<Texel> texels = eyeTexels(eye);
+    int bottom = texels.stream().mapToInt(Texel::y).max().orElse(-1);
+    return texels.stream().filter(texel -> texel.y() == bottom).toList();
+  }
+
+  private List<Texel> eyeTexels(AppearancePart eye) {
+    return switch (eye) {
       case EYE_LEFT -> leftEyeTexels;
       case EYE_RIGHT -> rightEyeTexels;
       default -> throw new IllegalArgumentException("Not an eye part: " + eye);
     };
-    return texels.stream().noneMatch(texel -> hair.frontHairOcclusion.contains(texel.packedIndex()));
   }
 
   public Set<Integer> pigmentColors(AppearancePart part) {
@@ -70,11 +85,7 @@ public record AppearanceAsset(
    * sources may mix only when this key matches.
    */
   public String eyeGeometryKey(AppearancePart eye) {
-    List<Texel> texels = switch (eye) {
-      case EYE_LEFT -> leftEyeTexels;
-      case EYE_RIGHT -> rightEyeTexels;
-      default -> throw new IllegalArgumentException("Not an eye part: " + eye);
-    };
+    List<Texel> texels = eyeTexels(eye);
     if (texels.isEmpty()) {
       return "";
     }

--- a/src/main/java/com/quzzar/kithkyn/appearance/AppearanceRecipeFactory.java
+++ b/src/main/java/com/quzzar/kithkyn/appearance/AppearanceRecipeFactory.java
@@ -81,7 +81,8 @@ public final class AppearanceRecipeFactory {
         PigmentPalette.hair(inputs.genes().hairPigment()),
         leftEyePigment,
         rightEyePigment,
-        garment.headwearOccludesHair());
+        garment.headwearOccludesHair(),
+        false);
   }
 
   public static Gender expressionFor(AppearanceInputs inputs) {

--- a/src/main/java/com/quzzar/kithkyn/appearance/PigmentPalette.java
+++ b/src/main/java/com/quzzar/kithkyn/appearance/PigmentPalette.java
@@ -24,6 +24,8 @@ public final class PigmentPalette {
   private static final int EYE_DARK_COOL = 0x5A4A3C;
   private static final int EYE_DARK_WARM = 0x70461F;
   private static final int EYE_SHADOW = 0x171A18;
+  /** Deeper than the 0.22 of ordinary skin shading, so the line reads on a dark face too. */
+  private static final float EYELID_SHADE = 0.7F;
 
   private PigmentPalette() {
   }
@@ -41,6 +43,11 @@ public final class PigmentPalette {
   public static PigmentColor eyes(PigmentGene gene) {
     int base = range(gene, EYE_LIGHT_COOL, EYE_LIGHT_WARM, EYE_DARK_COOL, EYE_DARK_WARM);
     return new PigmentColor(base, mix(base, EYE_SHADOW, 0.38F));
+  }
+
+  /** The lash line of a closed eye: the skin tone pulled most of the way into its shadow. */
+  public static int eyelid(PigmentColor skin) {
+    return mix(skin.baseRgb(), SKIN_SHADOW, EYELID_SHADE);
   }
 
   /** Make the rare second iris visibly different when two nearby genes round alike. */

--- a/src/main/java/com/quzzar/kithkyn/appearance/SkinRecipe.java
+++ b/src/main/java/com/quzzar/kithkyn/appearance/SkinRecipe.java
@@ -15,5 +15,19 @@ public record SkinRecipe(
     PigmentColor hairPigment,
     PigmentColor leftEyePigment,
     PigmentColor rightEyePigment,
-    boolean headwearOccludesHair) {
+    boolean headwearOccludesHair,
+    boolean eyesClosed) {
+
+  /**
+   * The same face with its eyes shut: the eye layers give way to a lash line on the
+   * skin while the person sleeps. A distinct recipe, so the sleeping texture is baked
+   * and cached beside the waking one and neither is rebaked on waking or dozing off.
+   */
+  public SkinRecipe withEyesClosed(boolean closed) {
+    if (closed == eyesClosed) {
+      return this;
+    }
+    return new SkinRecipe(model, expression, skin, clothing, leftEye, rightEye, hair,
+        skinPigment, hairPigment, leftEyePigment, rightEyePigment, headwearOccludesHair, closed);
+  }
 }

--- a/src/main/java/com/quzzar/kithkyn/client/appearance/PersonAppearanceTextures.java
+++ b/src/main/java/com/quzzar/kithkyn/client/appearance/PersonAppearanceTextures.java
@@ -19,7 +19,9 @@ import com.quzzar.kithkyn.appearance.AppearanceRecipeFactory;
 import com.quzzar.kithkyn.appearance.BodyModel;
 import com.quzzar.kithkyn.appearance.LifeStage;
 import com.quzzar.kithkyn.appearance.PigmentColor;
+import com.quzzar.kithkyn.appearance.PigmentPalette;
 import com.quzzar.kithkyn.appearance.SkinRecipe;
+import com.quzzar.kithkyn.appearance.Texel;
 import com.quzzar.kithkyn.entities.AgeStage;
 import com.quzzar.kithkyn.entities.Gender;
 import com.quzzar.kithkyn.entities.Person;
@@ -40,6 +42,7 @@ public final class PersonAppearanceTextures implements ResourceManagerReloadList
   public static final PersonAppearanceTextures INSTANCE = new PersonAppearanceTextures();
 
   private static final int TEXTURE_SIZE = 64;
+  private static final int OPAQUE_ALPHA = 0xFF000000;
   private static final int MAXIMUM_CACHED_TEXTURES = 128;
   private static final ResourceLocation CATALOG = ResourceLocation.fromNamespaceAndPath(
       Kithkyn.MODID, "appearance/catalog.json");
@@ -51,9 +54,14 @@ public final class PersonAppearanceTextures implements ResourceManagerReloadList
   private PersonAppearanceTextures() {
   }
 
+  /**
+   * The baked skin for this person as they are right now: their inherited face, with
+   * the eyes shut while they sleep. Vanilla syncs the sleeping state to every client,
+   * so no extra data crosses the wire for it.
+   */
   public ResourceLocation textureFor(Person person) {
     try {
-      SkinRecipe recipe = recipeFor(person);
+      SkinRecipe recipe = recipeFor(person).withEyesClosed(person.isSleeping());
       ResourceLocation cached = textures.get(recipe);
       if (cached != null) {
         return cached;
@@ -126,15 +134,14 @@ public final class PersonAppearanceTextures implements ResourceManagerReloadList
     NativeImage output = new NativeImage(TEXTURE_SIZE, TEXTURE_SIZE, true);
     try (NativeImage skin = loadLayer(resources, skinAsset, AppearancePart.SKIN);
         NativeImage clothing = loadLayer(resources, clothingAsset, AppearancePart.CLOTHING);
-        NativeImage leftEye = loadLayer(resources, leftEyeAsset, AppearancePart.EYE_LEFT);
-        NativeImage rightEye = loadLayer(resources, rightEyeAsset, AppearancePart.EYE_RIGHT);
         NativeImage hair = loadLayer(resources, hairAsset, AppearancePart.HAIR)) {
       copyOpaque(output, skin, skinAsset.pigmentColors(AppearancePart.SKIN), recipe.skinPigment(), null, false);
       copyOpaque(output, clothing, Set.of(), null, null, false);
-      copyOpaque(output, leftEye, leftEyeAsset.pigmentColors(AppearancePart.EYE_LEFT),
-          recipe.leftEyePigment(), null, false);
-      copyOpaque(output, rightEye, rightEyeAsset.pigmentColors(AppearancePart.EYE_RIGHT),
-          recipe.rightEyePigment(), null, false);
+      if (recipe.eyesClosed()) {
+        closeEyes(output, recipe, leftEyeAsset, rightEyeAsset);
+      } else {
+        openEyes(output, resources, recipe, leftEyeAsset, rightEyeAsset);
+      }
       copyOpaque(output, hair, hairAsset.pigmentColors(AppearancePart.HAIR), recipe.hairPigment(),
           clothing, recipe.headwearOccludesHair());
     } catch (IOException | RuntimeException exception) {
@@ -147,6 +154,35 @@ public final class PersonAppearanceTextures implements ResourceManagerReloadList
     ResourceLocation location = dynamicLocation(recipe);
     Minecraft.getInstance().getTextureManager().register(location, texture);
     return location;
+  }
+
+  /** The authored eye masks, each in its inherited iris colour. */
+  private void openEyes(NativeImage output, ResourceManager resources, SkinRecipe recipe,
+      AppearanceAsset leftEyeAsset, AppearanceAsset rightEyeAsset) throws IOException {
+    try (NativeImage leftEye = loadLayer(resources, leftEyeAsset, AppearancePart.EYE_LEFT);
+        NativeImage rightEye = loadLayer(resources, rightEyeAsset, AppearancePart.EYE_RIGHT)) {
+      copyOpaque(output, leftEye, leftEyeAsset.pigmentColors(AppearancePart.EYE_LEFT),
+          recipe.leftEyePigment(), null, false);
+      copyOpaque(output, rightEye, rightEyeAsset.pigmentColors(AppearancePart.EYE_RIGHT),
+          recipe.rightEyePigment(), null, false);
+    }
+  }
+
+  /**
+   * A sleeping face. The eye layers are left out, so the skin already copied beneath
+   * them shows as closed lids, and the bottom row of each mask is painted as a lash
+   * line in the skin's own shadow. No part carries closed-eye art; every authored
+   * shape closes this way.
+   */
+  private static void closeEyes(NativeImage output, SkinRecipe recipe,
+      AppearanceAsset leftEyeAsset, AppearanceAsset rightEyeAsset) {
+    int lash = abgrWithRgb(OPAQUE_ALPHA, PigmentPalette.eyelid(recipe.skinPigment()));
+    for (Texel texel : leftEyeAsset.lidTexels(AppearancePart.EYE_LEFT)) {
+      output.setPixelRGBA(texel.x(), texel.y(), lash);
+    }
+    for (Texel texel : rightEyeAsset.lidTexels(AppearancePart.EYE_RIGHT)) {
+      output.setPixelRGBA(texel.x(), texel.y(), lash);
+    }
   }
 
   private NativeImage loadLayer(ResourceManager resources, AppearanceAsset asset, AppearancePart part)

--- a/src/main/java/com/quzzar/kithkyn/client/gui/AgeLineupScreen.java
+++ b/src/main/java/com/quzzar/kithkyn/client/gui/AgeLineupScreen.java
@@ -14,6 +14,7 @@ import com.quzzar.kithkyn.entities.RealPerson;
 import com.quzzar.kithkyn.entities.genetics.AppearanceGenes;
 
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.core.BlockPos;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -25,7 +26,9 @@ import net.minecraft.util.Mth;
  *
  * <p>All four preview people share the same appearance genes and default
  * client-side attributes. Only {@link AgeStage} changes, so a screenshot makes
- * model proportions and relative stage scale directly comparable.
+ * model proportions and relative stage scale directly comparable. The same four
+ * can be shown asleep: a client-side sleeping position shuts their eyes without
+ * laying them down, which photographs the closed face at every stage.
  */
 public final class AgeLineupScreen extends Screen {
 
@@ -38,10 +41,12 @@ public final class AgeLineupScreen extends Screen {
     private static final int SECONDARY_TEXT = 0xFF9EA5AE;
 
     private final List<StagePreview> previews;
+    private final boolean asleep;
 
-    public AgeLineupScreen(ClientLevel level) {
-        super(Component.literal("Villager age stages"));
-        this.previews = createPreviews(level);
+    public AgeLineupScreen(ClientLevel level, boolean asleep) {
+        super(Component.literal(asleep ? "Villager age stages, asleep" : "Villager age stages"));
+        this.asleep = asleep;
+        this.previews = createPreviews(level, asleep);
     }
 
     @Override
@@ -51,7 +56,9 @@ public final class AgeLineupScreen extends Screen {
         graphics.drawCenteredString(font, title, width / 2, 14, PRIMARY_TEXT);
         graphics.drawCenteredString(
                 font,
-                "Same appearance and attributes; only age changes",
+                asleep
+                        ? "The waking lineup with every eye shut"
+                        : "Same appearance and attributes; only age changes",
                 width / 2,
                 27,
                 SECONDARY_TEXT);
@@ -92,7 +99,7 @@ public final class AgeLineupScreen extends Screen {
         return false;
     }
 
-    private static List<StagePreview> createPreviews(ClientLevel level) {
+    private static List<StagePreview> createPreviews(ClientLevel level, boolean asleep) {
         AppearanceGenes genes = AppearanceGenes.fromLegacySeed(PREVIEW_SEED);
         List<StagePreview> created = new ArrayList<>();
         for (AgeStage stage : AgeStage.values()) {
@@ -102,6 +109,11 @@ public final class AgeLineupScreen extends Screen {
             person.setAppearanceSeed(PREVIEW_SEED);
             person.setAppearanceGenes(genes);
             person.setLifeStage(stage);
+            if (asleep) {
+                // Sleeping is a position, not a pose: the compositor reads it to
+                // shut the eyes, while the standing pose keeps the face upright.
+                person.setSleepingPos(BlockPos.ZERO);
+            }
             created.add(new StagePreview(stage, person));
         }
         return List.copyOf(created);

--- a/src/main/java/com/quzzar/kithkyn/client/gui/UiPreview.java
+++ b/src/main/java/com/quzzar/kithkyn/client/gui/UiPreview.java
@@ -30,6 +30,7 @@ import net.neoforged.neoforge.client.event.ClientTickEvent;
  * <pre>
  * ./gradlew runClientJoinLocal -Puipreview=trade
  * ./gradlew runClientJoinLocal -Puipreview=age-lineup
+ * ./gradlew runClientJoinLocal -Puipreview=age-lineup-asleep
  * ./gradlew runClientJoinLocal -Puipreview=age-lineup-world
  * </pre>
  *
@@ -52,6 +53,9 @@ public final class UiPreview {
     private static final int SETTLE_TICKS = 40;
     /** Extra time for server-spawned people and their composed skins to arrive. */
     private static final int WORLD_SETTLE_TICKS = 80;
+    private static final String LINEUP_MODE = "age-lineup";
+    /** The lineup with every eye shut, photographed through the sleeping face bake. */
+    private static final String ASLEEP_LINEUP_MODE = "age-lineup-asleep";
     private static final String WORLD_LINEUP_MODE = "age-lineup-world";
     private static final String WORLD_LINEUP_TAG = "kithkyn_age_lineup_preview";
     private static final String WORLD_LINEUP_CAMERA_TAG = WORLD_LINEUP_TAG + "_camera";
@@ -131,8 +135,8 @@ public final class UiPreview {
             openWorldLineup(client);
             return;
         }
-        if ("age-lineup".equalsIgnoreCase(MODE)) {
-            client.setScreen(new AgeLineupScreen(client.level));
+        if (isLineup()) {
+            client.setScreen(new AgeLineupScreen(client.level, ASLEEP_LINEUP_MODE.equalsIgnoreCase(MODE)));
             return;
         }
         boolean trade = !"chat".equalsIgnoreCase(MODE) && !"typing".equalsIgnoreCase(MODE)
@@ -195,7 +199,7 @@ public final class UiPreview {
         if (isWorldLineup()) {
             return client.screen == null;
         }
-        if ("age-lineup".equalsIgnoreCase(MODE)) {
+        if (isLineup()) {
             return client.screen instanceof AgeLineupScreen;
         }
         return client.screen instanceof PersonChatScreen;
@@ -262,5 +266,9 @@ public final class UiPreview {
 
     private static boolean isWorldLineup() {
         return WORLD_LINEUP_MODE.equalsIgnoreCase(MODE);
+    }
+
+    private static boolean isLineup() {
+        return LINEUP_MODE.equalsIgnoreCase(MODE) || ASLEEP_LINEUP_MODE.equalsIgnoreCase(MODE);
     }
 }

--- a/src/test/java/com/quzzar/kithkyn/appearance/AppearanceAssetTest.java
+++ b/src/test/java/com/quzzar/kithkyn/appearance/AppearanceAssetTest.java
@@ -1,0 +1,53 @@
+package com.quzzar.kithkyn.appearance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class AppearanceAssetTest {
+
+  private static AppearanceCatalog catalog;
+
+  @BeforeAll
+  static void loadCatalog() throws IOException {
+    try (InputStream stream = Objects.requireNonNull(
+            AppearanceAssetTest.class.getClassLoader().getResourceAsStream("assets/kithkyn/appearance/catalog.json"),
+            "The appearance catalogue is on the test classpath");
+        InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+      catalog = AppearanceCatalog.load(reader);
+    }
+  }
+
+  @Test
+  void everyAuthoredEyeClosesAlongTheBottomRowOfItsOwnMask() {
+    int eyes = 0;
+    for (AppearanceAsset asset : catalog.assets()) {
+      for (AppearancePart eye : List.of(AppearancePart.EYE_LEFT, AppearancePart.EYE_RIGHT)) {
+        if (!asset.has(eye)) {
+          continue;
+        }
+        eyes++;
+        List<Texel> mask = eye == AppearancePart.EYE_LEFT ? asset.leftEyeTexels() : asset.rightEyeTexels();
+        List<Texel> lid = asset.lidTexels(eye);
+        int bottom = mask.stream().mapToInt(Texel::y).max().orElseThrow();
+        assertFalse(lid.isEmpty(), asset.id() + " " + eye + " has no lid row");
+        assertTrue(mask.containsAll(lid), asset.id() + " " + eye + " lid leaves its mask");
+        assertTrue(lid.stream().allMatch(texel -> texel.y() == bottom),
+            asset.id() + " " + eye + " lid is not one bottom row");
+        assertEquals(mask.stream().filter(texel -> texel.y() == bottom).count(), lid.size(),
+            asset.id() + " " + eye + " lid misses part of its bottom row");
+      }
+    }
+    assertTrue(eyes > 0, "The catalogue carries eye parts");
+  }
+}

--- a/src/test/java/com/quzzar/kithkyn/appearance/AppearanceRecipeFactoryTest.java
+++ b/src/test/java/com/quzzar/kithkyn/appearance/AppearanceRecipeFactoryTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -131,7 +132,8 @@ class AppearanceRecipeFactoryTest {
         valid.hairPigment(),
         valid.leftEyePigment(),
         valid.rightEyePigment(),
-        !valid.headwearOccludesHair());
+        !valid.headwearOccludesHair(),
+        valid.eyesClosed());
 
     assertTrue(AppearanceRecipeAudit.validate(catalog, inputs, invalid).stream()
         .anyMatch(failure -> failure.contains("headwear occlusion")));
@@ -213,5 +215,27 @@ class AppearanceRecipeFactoryTest {
     int green = (first >>> 8 & 0xFF) - (second >>> 8 & 0xFF);
     int blue = (first & 0xFF) - (second & 0xFF);
     return Math.sqrt(red * red + green * green + blue * blue);
+  }
+
+  @Test
+  void aSleepingFaceIsTheSameRecipeWithOnlyTheEyesShut() {
+    AppearanceInputs inputs = new AppearanceInputs(
+        11,
+        AppearanceGenes.fromLegacySeed(11),
+        Gender.FEMALE,
+        Occupation.FARMER,
+        LifeStage.ADULT,
+        GeneticCondition.NONE);
+    SkinRecipe awake = AppearanceRecipeFactory.create(catalog, inputs);
+    SkinRecipe asleep = awake.withEyesClosed(true);
+
+    assertFalse(awake.eyesClosed());
+    assertTrue(asleep.eyesClosed());
+    assertNotEquals(awake, asleep);
+    assertEquals(awake, asleep.withEyesClosed(false));
+    assertSame(awake, awake.withEyesClosed(false));
+    assertEquals(awake.leftEye(), asleep.leftEye());
+    assertEquals(awake.skinPigment(), asleep.skinPigment());
+    assertTrue(AppearanceRecipeAudit.validate(catalog, inputs, asleep).isEmpty());
   }
 }

--- a/src/test/java/com/quzzar/kithkyn/appearance/PigmentGeneticsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/appearance/PigmentGeneticsTest.java
@@ -71,4 +71,14 @@ class PigmentGeneticsTest {
     int blue = (first & 0xFF) - (second & 0xFF);
     return Math.sqrt(red * red + green * green + blue * blue);
   }
+
+  @Test
+  void eyelidIsDarkerThanTheSkinShadowOnLightAndDarkFaces() {
+    for (int depth : new int[] {0, 128, 255}) {
+      PigmentColor skin = PigmentPalette.skin(PigmentGene.homozygous(depth, 96));
+      int eyelid = PigmentPalette.eyelid(skin);
+      assertTrue(luminance(eyelid) < luminance(skin.shadowRgb()), "eyelid lighter than shadow at depth " + depth);
+      assertTrue(luminance(skin.shadowRgb()) < luminance(skin.baseRgb()), "shadow lighter than base at depth " + depth);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- A sleeping villager's face is baked with its eyes shut: the eye layers are skipped so the skin beneath shows as lids, and the bottom row of each eye mask (`AppearanceAsset.lidTexels`) is painted as a lash line in the skin's own shadow (`PigmentPalette.eyelid`, deeper than ordinary shading so it reads on dark faces).
- `SkinRecipe` gains `eyesClosed`, set on the client from the vanilla sleeping state that is already synced, so the closed face is its own cached texture and nothing new crosses the wire or the save.
- `age-lineup-asleep` preview mode photographs the four lineup faces shut; docs for appearance and the preview harness updated.

## Verification
- `./gradlew test` passes (new tests: the sleeping variant differs only in the flag and still audits clean; every catalogued eye closes along one bottom row of its own mask; the eyelid tone is darker than the skin shadow on light and dark faces).
- Rendered through the preview harness against the live server: `age-lineup` and `age-lineup-asleep` captured with the same build and compared head by head at 4x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
