### PR TITLE
Fix cropped Jungle fishery exports

### DIFF
--- a/docs/jungle-village.md
+++ b/docs/jungle-village.md
@@ -21,7 +21,7 @@ catalog and immutable output hashes are recorded in
 | `storehouse_jungle_1` | JA03.1 edited small house | No vacancy; one physical quartermaster worksite and three shared containers |
 | `lumberjack_jungle_1` | JA01.4 animal pen | Lumberjack and one shared chest |
 | `tavern_jungle_1` | JA01.6 butcher | Innkeeper and one shared barrel; no bed |
-| `fishery_jungle_1` | JA01.8 fisher | Fisher, one staff bed and one shared barrel |
+| `fishery_jungle_1` | JA01.8 fisher | Fisher, one staff bed and one shared barrel; seated one block into the wet bank |
 | `hunting_lodge_jungle_1` | JA02.1 fletcher | Hunter and one shared chest |
 | `stoneworks_jungle_1` | JA02.5 mason | Mason and one shared chest |
 | `butchery_jungle_1` | JA02.6 shepherd | Butcher, one staff bed and its personal chest |
@@ -89,6 +89,12 @@ as `kithkyn-jungle` and kept with world backups; the public jar deliberately car
 third-party-derived templates ([structure-sourcing.md](structure-sourcing.md)). A manual sample
 can request `/kithkyn create-village ~ ~ ~ jungle`.
 
+The September 11 fishery repair removed the gallery's two-block water-containment frame from
+the exported cuboid: 108 barrier cells had survived outside the declared 8 by 8 by 13 bounds.
+Its definition now uses `sink: 1`, placing the captured ground course into the riverbank instead
+of raising the whole fishery. The shared template audit rejects barriers and out-of-bounds cells
+in every later public or private catalog export.
+
 ## Verification
 
 Core tests cover biome selection, codec persistence, routed physical worksites, mine ownership,
@@ -108,3 +114,8 @@ codec reloads. After the mine-floor revision, a focused native pass added four r
 runs, eight routed-worksite access routes and eight instant/incremental construction placements
 across all four rotations. The exported template has zero blockstate mismatches against Aaron's
 flushed live capture.
+
+The repaired fishery separately passed eight real placements through both construction paths in
+all four rotations, plus twelve physical routes covering its entrance, fisher station, shared
+barrel and assigned bed. The active private catalogs then passed a 103-template block audit with
+no barriers or out-of-bounds coordinates.

--- a/tools/structure/README.md
+++ b/tools/structure/README.md
@@ -26,6 +26,7 @@ themselves — they only transform files you point them at.
 | `flatten.py` | Map pre-1.13 numeric block ids to modern blockstates |
 | `split_scene.py` | Crop the separate buildings out of one multi-building `.schematic` (flood-fill footprints; rejects trees by composition) |
 | `validate.py` | Flag blocks that would drop on placement — bed and door halves, wall torches, gravity-affected stacks, carpet on nothing |
+| `audit-templates.py` | Reject production templates containing barrier blocks or coordinates outside their declared size |
 | `navcheck.py` | Score how walkable a finished structure is for a villager |
 | `roof.py` | Fix roof-stair facing |
 | `seating-check.py` | Flag catalog buildings seated one block low: a bottom-half stair in the layer that meets the ground is a doorstep swallowed by the terrain |
@@ -34,6 +35,11 @@ themselves — they only transform files you point them at.
 
 Each script's `__main__` is an example driver; point the glob at your own
 structure directory. Run them from this directory so their imports resolve.
+
+Run `python3 tools/structure/audit-templates.py <data/kithkyn/structure>` over every
+public or private catalog before deployment. Gallery containment barriers and blocks outside
+an explicit crop are review fixtures, never building content. The native exporter enforces the
+same invariants while writing a template.
 
 The Birch export expects the canonical project root, prepared Minecraft runtime dependencies,
 an approved capture directory and a destination asset directory. It never reads a live world.

--- a/tools/structure/VillageTemplateExport.java
+++ b/tools/structure/VillageTemplateExport.java
@@ -42,9 +42,25 @@ public final class VillageTemplateExport {
       CompoundTag root = NbtIo.readCompressed(source, NbtAccounter.unlimitedHeap());
       ListTag palette = root.getList("palette", Tag.TAG_COMPOUND);
       int[] shift = spec.has("crop") ? vector(spec.get("crop")) : new int[]{0, 0, 0};
+      int[] size = vector(spec.get("size"));
+      ListTag blocks = root.getList("blocks", Tag.TAG_COMPOUND);
+      if (spec.has("crop")) {
+        // A crop is an explicit selection, not merely a coordinate translation. Gallery
+        // captures commonly surround a building with labels, fluid-containment barriers,
+        // or a review plinth. Discard every source cell outside the selected cuboid before
+        // rebasing it so those review fixtures can never survive at negative coordinates.
+        blocks.removeIf(tag -> {
+          ListTag position = ((CompoundTag)tag).getList("pos", Tag.TAG_INT);
+          for (int axis = 0; axis < 3; axis++) {
+            int local = position.getInt(axis) - shift[axis];
+            if (local < 0 || local >= size[axis]) return true;
+          }
+          return false;
+        });
+      }
       Set<String> white = new HashSet<>();
       for (JsonElement point : spec.getAsJsonArray("white")) white.add(Arrays.toString(vector(point)));
-      for (Tag value : root.getList("blocks", Tag.TAG_COMPOUND)) {
+      for (Tag value : blocks) {
         CompoundTag block = (CompoundTag)value;
         ListTag pos = block.getList("pos", Tag.TAG_INT);
         int[] local = {pos.getInt(0), pos.getInt(1), pos.getInt(2)};
@@ -70,7 +86,6 @@ public final class VillageTemplateExport {
       }
       CompoundTag air = new CompoundTag(); air.putString("Name", "minecraft:air");
       int airIndex = palette.size(); palette.add(air);
-      ListTag blocks = root.getList("blocks", Tag.TAG_COMPOUND);
       for (JsonElement point : spec.getAsJsonArray("air")) {
         CompoundTag block = new CompoundTag(); block.put("pos", ints(vector(point))); block.putInt("state", airIndex); blocks.add(block);
       }
@@ -119,17 +134,21 @@ public final class VillageTemplateExport {
               && palette.getCompound(block.getInt("state")).getString("Name").equals("minecraft:air");
         });
       }
-      int[] size = vector(spec.get("size"));
       // A block outside the declared size is never intended: it stretches the building's
       // footprint in the world (a gallery sign captured four cells in front of a mine
       // pushed the whole mine back), so the export fails instead of shipping it.
       for (Tag tag : blocks) {
-        ListTag position = ((CompoundTag)tag).getList("pos", Tag.TAG_INT);
+        CompoundTag block = (CompoundTag)tag;
+        ListTag position = block.getList("pos", Tag.TAG_INT);
         for (int axis = 0; axis < 3; axis++) {
           if (position.getInt(axis) < 0 || position.getInt(axis) >= size[axis]) {
             throw new IllegalArgumentException("Block outside the declared size at " + position + " in "
                 + spec.get("output").getAsString() + ": crop it out, override it to air inside horizontal_bounds, or widen size");
           }
+        }
+        if (palette.getCompound(block.getInt("state")).getString("Name").equals("minecraft:barrier")) {
+          throw new IllegalArgumentException("Barrier block in production structure at " + position + " in "
+              + spec.get("output").getAsString() + ": remove gallery containment before export");
         }
       }
       root.put("size", ints(size));

--- a/tools/structure/audit-templates.py
+++ b/tools/structure/audit-templates.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Reject production structure templates containing gallery fixtures or invalid cells."""
+
+from pathlib import Path
+import sys
+
+from nbt import read
+
+
+def templates(arguments):
+    for value in arguments:
+        path = Path(value)
+        if path.is_dir():
+            yield from sorted(path.rglob("*.nbt"))
+        elif path.suffix == ".nbt":
+            yield path
+
+
+def problems(path):
+    root = read(path)
+    size = root["size"]
+    palette = root["palette"]
+    failures = []
+    for block in root["blocks"]:
+        position = tuple(block["pos"])
+        name = palette[block["state"]]["Name"]
+        reasons = []
+        if any(coordinate < 0 or coordinate >= size[axis]
+               for axis, coordinate in enumerate(position)):
+            reasons.append("outside declared size")
+        if name == "minecraft:barrier":
+            reasons.append("gallery barrier in production template")
+        if reasons:
+            failures.append((position, name, "; ".join(reasons)))
+    return failures
+
+
+def main(arguments):
+    paths = list(templates(arguments))
+    if not paths:
+        raise SystemExit("Pass one or more structure .nbt files or directories")
+    failed = 0
+    for path in paths:
+        failures = problems(path)
+        if not failures:
+            continue
+        failed += 1
+        print(f"FAIL {path}")
+        for position, name, reason in failures:
+            print(f"  {position}: {name}: {reason}")
+    if failed:
+        print(f"{failed} of {len(paths)} templates failed")
+        return 1
+    print(f"PASS {len(paths)} templates: no barriers or out-of-bounds blocks")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/structure/jungle-catalog-20260910.json
+++ b/tools/structure/jungle-catalog-20260910.json
@@ -269,9 +269,9 @@
       ],
       "worksites": [],
       "asset": "run/jungle-integration/datapack/data/kithkyn/structure/fishery_jungle_1.nbt",
-      "asset_sha256": "2b63a01dc7dde2c3df5ad7637b72951e00d520bbc623d9b6f7a1ec761434724c",
+      "asset_sha256": "97940b878ce9dc41eacf1b75597f0b6240de946fe82fa16b76939bfbe108a705",
       "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/fishery_jungle_1.json",
-      "definition_sha256": "1537356c0e95ea9718e4f05cbb8c54e6092ca7d18d43f31af5be0b232b3a7208"
+      "definition_sha256": "b150b434a50c9e0810aa79c78c14a15c756a6af0eb79b4afaa9fec754252c261"
     },
     {
       "exhibit": "JA02.1",
@@ -800,6 +800,14 @@
     "release": "20260910-193529-jungle-village",
     "datapack": "run/world/datapacks/kithkyn-jungle",
     "building_definitions_loaded": 126,
-    "world_backup": "before-jungle-village-20260910-193529"
+    "world_backup": "before-jungle-village-20260910-193529",
+    "fishery_repair": {
+      "date": "2026-09-11",
+      "barriers_removed": 108,
+      "sink": 1,
+      "template_audit": "103 active private templates, zero barriers and zero out-of-bounds blocks",
+      "placement": "8 real-template placements passed across both construction paths and four rotations",
+      "access": "12 routes passed across all four rotations"
+    }
   }
 }


### PR DESCRIPTION
The Jungle fishery capture shifted its crop without removing the surrounding gallery frame, so 108 barrier blocks survived outside its declared 8×8×13 footprint and the building sat one block high. This crops source cells before rebasing, rejects barriers and out-of-bounds cells during export, adds a catalog-wide auditor, and records the repaired sink and verification.

Validation:
- `./gradlew test`
- 103 active private templates audited with zero barriers and zero out-of-bounds cells
- 8 native fishery placements passed across instant/incremental construction and all four rotations
- 12 native routes passed for the entrance, worksite, shared barrel, and assigned bed
- repaired private datapack installed on the live server; client reconnected
