### PR TITLE
Purge barrier states from structure catalogs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,6 +189,16 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
 
+var auditStructureTemplates = tasks.register("auditStructureTemplates", Exec) {
+    group = "verification"
+    description = "Rejects structure templates containing barrier states or out-of-bounds cells."
+    commandLine "python3", "tools/structure/audit-templates.py", "src/main/resources/data/kithkyn/structure"
+}
+
+tasks.named("check").configure {
+    dependsOn auditStructureTemplates
+}
+
 // This block of code expands all declared replace properties in the specified resource targets.
 // A missing property will result in an error. Properties are expanded using ${} Groovy notation.
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/tools/structure/README.md
+++ b/tools/structure/README.md
@@ -26,7 +26,7 @@ themselves — they only transform files you point them at.
 | `flatten.py` | Map pre-1.13 numeric block ids to modern blockstates |
 | `split_scene.py` | Crop the separate buildings out of one multi-building `.schematic` (flood-fill footprints; rejects trees by composition) |
 | `validate.py` | Flag blocks that would drop on placement — bed and door halves, wall torches, gravity-affected stacks, carpet on nothing |
-| `audit-templates.py` | Reject production templates containing barrier blocks or coordinates outside their declared size |
+| `audit-templates.py` | Reject production templates containing barrier states or coordinates outside their declared size |
 | `navcheck.py` | Score how walkable a finished structure is for a villager |
 | `roof.py` | Fix roof-stair facing |
 | `seating-check.py` | Flag catalog buildings seated one block low: a bottom-half stair in the layer that meets the ground is a doorstep swallowed by the terrain |
@@ -37,9 +37,10 @@ Each script's `__main__` is an example driver; point the glob at your own
 structure directory. Run them from this directory so their imports resolve.
 
 Run `python3 tools/structure/audit-templates.py <data/kithkyn/structure>` over every
-public or private catalog before deployment. Gallery containment barriers and blocks outside
-an explicit crop are review fixtures, never building content. The native exporter enforces the
-same invariants while writing a template.
+public or private catalog before deployment. Gallery containment barriers, including unused
+palette entries, are review fixtures, never building content. Blocks outside an explicit crop
+are invalid for the same reason. The native exporter enforces both invariants while writing a
+template. `./gradlew check` runs the audit over the public catalog automatically.
 
 The Birch export expects the canonical project root, prepared Minecraft runtime dependencies,
 an approved capture directory and a destination asset directory. It never reads a live world.

--- a/tools/structure/VillageTemplateExport.java
+++ b/tools/structure/VillageTemplateExport.java
@@ -32,6 +32,34 @@ public final class VillageTemplateExport {
 
   static int[] vector(JsonElement value) { return new Gson().fromJson(value, int[].class); }
 
+  /** Remove palette states no surviving block uses and remap every state index. */
+  static void compactPalette(ListTag palette, ListTag blocks) {
+    boolean[] used = new boolean[palette.size()];
+    for (Tag value : blocks) {
+      int state = ((CompoundTag)value).getInt("state");
+      if (state < 0 || state >= palette.size()) {
+        throw new IllegalArgumentException("Block refers to missing palette state " + state);
+      }
+      used[state] = true;
+    }
+    int[] remap = new int[palette.size()];
+    ListTag compact = new ListTag();
+    for (int state = 0; state < palette.size(); state++) {
+      if (!used[state]) {
+        remap[state] = -1;
+        continue;
+      }
+      remap[state] = compact.size();
+      compact.add(palette.get(state).copy());
+    }
+    for (Tag value : blocks) {
+      CompoundTag block = (CompoundTag)value;
+      block.putInt("state", remap[block.getInt("state")]);
+    }
+    palette.clear();
+    palette.addAll(compact);
+  }
+
   public static void main(String[] args) throws Exception {
     JsonArray plan = JsonParser.parseString(Files.readString(Path.of(args[0]))).getAsJsonArray();
     for (JsonElement entry : plan) {
@@ -134,6 +162,7 @@ public final class VillageTemplateExport {
               && palette.getCompound(block.getInt("state")).getString("Name").equals("minecraft:air");
         });
       }
+      compactPalette(palette, blocks);
       // A block outside the declared size is never intended: it stretches the building's
       // footprint in the world (a gallery sign captured four cells in front of a mine
       // pushed the whole mine back), so the export fails instead of shipping it.
@@ -149,6 +178,12 @@ public final class VillageTemplateExport {
         if (palette.getCompound(block.getInt("state")).getString("Name").equals("minecraft:barrier")) {
           throw new IllegalArgumentException("Barrier block in production structure at " + position + " in "
               + spec.get("output").getAsString() + ": remove gallery containment before export");
+        }
+      }
+      for (Tag state : palette) {
+        if (((CompoundTag)state).getString("Name").equals("minecraft:barrier")) {
+          throw new IllegalArgumentException("Barrier state in production structure palette in "
+              + spec.get("output").getAsString());
         }
       }
       root.put("size", ints(size));

--- a/tools/structure/audit-templates.py
+++ b/tools/structure/audit-templates.py
@@ -20,7 +20,11 @@ def problems(path):
     root = read(path)
     size = root["size"]
     palette = root["palette"]
-    failures = []
+    failures = [
+        (f"palette[{index}]", state["Name"], "barrier state in production template")
+        for index, state in enumerate(palette)
+        if state["Name"] == "minecraft:barrier"
+    ]
     for block in root["blocks"]:
         position = tuple(block["pos"])
         name = palette[block["state"]]["Name"]
@@ -51,7 +55,7 @@ def main(arguments):
     if failed:
         print(f"{failed} of {len(paths)} templates failed")
         return 1
-    print(f"PASS {len(paths)} templates: no barriers or out-of-bounds blocks")
+    print(f"PASS {len(paths)} templates: no barrier states or out-of-bounds blocks")
     return 0
 
 

--- a/tools/structure/badlands-catalog-20260909.json
+++ b/tools/structure/badlands-catalog-20260909.json
@@ -317,11 +317,11 @@
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "source_mod_structure": "data/ctov/structure/village/mesa_fortified/jobsite/farm.nbt",
       "asset": "run/badlands-integration/datapack/data/kithkyn/structure/farm_badlands_1.nbt",
-      "asset_sha256": "3e2bbf8d6e214a20bf41b744634ecde4052ed172392b346895934253dbc6d39f",
+      "asset_sha256": "6e0b24b26d58df102be47d21f73fa76b896b9e390ba0a5d102c8de407dc36322",
       "definition": "run/badlands-integration/datapack/data/kithkyn/kithkyn/buildings/farm_badlands_1.json",
       "definition_sha256": "2dad3d5bb54699721975ff551a46309135f545e1b3994e3375e89ffcb0cb3c4d",
       "reviewed_neutral": "run/pueblo-showcase/services-approved-20260909-183601/neutral/P09.7.nbt",
-      "reviewed_neutral_sha256": "2734e169ed8d43f6cd49cd7c453908525dab77da1a53d0ef9899fcde5c435b82"
+      "reviewed_neutral_sha256": "530c8b441e5789e9517ff704f855a5e9fd20275f8a6d260e88f06c58f6f1e33b"
     },
     {
       "exhibit": "P10.4",

--- a/tools/structure/floodplain-catalog-20260910.json
+++ b/tools/structure/floodplain-catalog-20260910.json
@@ -266,11 +266,11 @@
       "source_mod": "t_and_t-neoforge-fabric-1.13.9+1.21.1.jar",
       "source_mod_structure": "data/kaisyn/structure/village/sparse_jungle_polynesian/houses/sparse_jungle_small_farm_1.nbt",
       "asset": "run/floodplain-integration/datapack/data/kithkyn/structure/farm_floodplain_1.nbt",
-      "asset_sha256": "03d6613a27484c6d5eb7c14080a653e3038b12b3d078d1b776830ba455cd55b4",
+      "asset_sha256": "2a6656eb98b5affe840d885cd0a0e7b0da585af2e14f0e7b3cc1f1dc2790a361",
       "definition": "run/floodplain-integration/datapack/data/kithkyn/kithkyn/buildings/farm_floodplain_1.json",
       "definition_sha256": "7b7bd052fcf3b3e48090c032111ad5ba874bf966148c7610ebf89c3471223770",
       "reviewed_capture": "run/nilotic-showcase/selection-20260910-floodplain/captures/NG04.2.nbt",
-      "reviewed_capture_sha256": "8cd26ad998ffe6f798e906b2c585493c3e777d43f1b77aaed7024d2b0062e9dd"
+      "reviewed_capture_sha256": "e52a80942a2487375f7f7538accb0c78f10231ae75ea7c171bbc07af7c5698e9"
     },
     {
       "exhibit": "NG04.1",

--- a/tools/structure/jungle-bamboo-adoption-20260910.json
+++ b/tools/structure/jungle-bamboo-adoption-20260910.json
@@ -57,7 +57,7 @@
       "before_capture": "run/jungle-showcase/bamboo-adoption-20260910/before/JA01.8.nbt",
       "before_sha256": "f14016c1b29097456670f4f205aca86ea9e255d786c424049b240950a8347f17",
       "capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA01.8.nbt",
-      "sha256": "75709284e8d942de4916bc601a744ccf358c55f4c39448ad90259454479385a1"
+      "sha256": "fdf9520d05a6576c3b12e2133baef9c5acdbcb2d1a8a74fa8a5a0fec5ab02c41"
     },
     {
       "exhibit": "JA02.1",

--- a/tools/structure/jungle-catalog-20260910.json
+++ b/tools/structure/jungle-catalog-20260910.json
@@ -247,7 +247,7 @@
       "recipe": "fishery_1",
       "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_fisher_1.nbt",
       "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA01.8.nbt",
-      "source_capture_sha256": "75709284e8d942de4916bc601a744ccf358c55f4c39448ad90259454479385a1",
+      "source_capture_sha256": "fdf9520d05a6576c3b12e2133baef9c5acdbcb2d1a8a74fa8a5a0fec5ab02c41",
       "gallery_origin": [
         5026,
         230,
@@ -269,7 +269,7 @@
       ],
       "worksites": [],
       "asset": "run/jungle-integration/datapack/data/kithkyn/structure/fishery_jungle_1.nbt",
-      "asset_sha256": "97940b878ce9dc41eacf1b75597f0b6240de946fe82fa16b76939bfbe108a705",
+      "asset_sha256": "03b2a56a00a6b5b434b612a5b9ad3a77809145f43bdda1f973fff02b9c21b1b6",
       "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/fishery_jungle_1.json",
       "definition_sha256": "b150b434a50c9e0810aa79c78c14a15c756a6af0eb79b4afaa9fec754252c261"
     },

--- a/tools/structure/jungle-selections-20260910.json
+++ b/tools/structure/jungle-selections-20260910.json
@@ -584,7 +584,7 @@
       "source_mod_structure": "data/kaisyn/structure/village/jungle_tribal/houses/jungle_fisher_1.nbt",
       "source_mod_structure_sha256": "a9e36ffa090731fa7bb0bd4dd9f1d2c4ba98ded917ad23562598cd337827ea1a",
       "source_capture": "run/jungle-showcase/bamboo-adoption-20260910/after-placement/captures/JA01.8.nbt",
-      "source_capture_sha256": "75709284e8d942de4916bc601a744ccf358c55f4c39448ad90259454479385a1",
+      "source_capture_sha256": "fdf9520d05a6576c3b12e2133baef9c5acdbcb2d1a8a74fa8a5a0fec5ab02c41",
       "gallery_origin": [
         5026,
         230,

--- a/tools/structure/nilotic-selections-20260910.json
+++ b/tools/structure/nilotic-selections-20260910.json
@@ -3070,7 +3070,7 @@
       "source_mod_structure": "data/kaisyn/structure/village/sparse_jungle_polynesian/houses/sparse_jungle_small_farm_1.nbt",
       "source_mod_structure_sha256": "084e1024b62cb2bf96f5283e96c5b271919b5fd4bcd141e371661aa7d1dc1337",
       "source_capture": "run/nilotic-showcase/selection-20260910-floodplain/captures/NG04.2.nbt",
-      "source_capture_sha256": "8cd26ad998ffe6f798e906b2c585493c3e777d43f1b77aaed7024d2b0062e9dd",
+      "source_capture_sha256": "e52a80942a2487375f7f7538accb0c78f10231ae75ea7c171bbc07af7c5698e9",
       "gallery_origin": [
         9189,
         230,

--- a/tools/structure/pueblo-services-20260909.json
+++ b/tools/structure/pueblo-services-20260909.json
@@ -552,7 +552,7 @@
           "minecraft:water": 13
         }
       },
-      "neutral_template_sha256": "2734e169ed8d43f6cd49cd7c453908525dab77da1a53d0ef9899fcde5c435b82",
+      "neutral_template_sha256": "530c8b441e5789e9517ff704f855a5e9fd20275f8a6d260e88f06c58f6f1e33b",
       "export_options_file": "run/pueblo-showcase/services-approved-20260909-183601/P09.7-export-options.json",
       "source_mod": "[Neoforge]ctov-3.6.3.jar",
       "production": {


### PR DESCRIPTION
Three production structures retained unused `minecraft:barrier` palette states even after their placed barrier cells were removed. The referenced Jungle and Floodplain captures also still contained gallery containment. This cleanup removes those source/live references, compacts unused states during export, rejects palette-only barriers during audit, and makes the public audit part of `./gradlew check`.

Validation:
- `./gradlew check`
- 339 public, live private, prepared, castle, and referenced source templates audited with zero barrier states and zero out-of-bounds cells
- 144 catalog asset/source hashes matched their files
- Jungle fishery export, structural validation, and navigation checks passed
- Exporter rejected a historical crop containing placed barriers
- Auditor rejected a historical palette-only barrier reference
