### PR TITLE
Branch from the ribs at lava and route off-ramp walkers by ordinary paths

### DIFF
--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -743,10 +743,12 @@ and the shaft navigator sends the miner back up the ramp. A longer rib would str
 deep face once stranded her over the shaft. That the pathfinder hands her back onto the ramp is the
 live-verify item, not a proof.
 
-**Finished root ribs seed one more generation of shafts** (2026-09-05). Reaching a temporary
-water or lava stop does not count as finishing a shaft. Once the original diagonal reaches bedrock
-and every ordinary rib has either been cut or honestly stopped, the miner revisits the root ribs
-from the shallowest down. A dry, fully open, fully supported eight-block rib may become an entrance:
+**Finished root ribs seed one more generation of shafts** (2026-09-05). A water stop does not
+count as finishing a shaft: a bucket or lining clears it later. Bedrock does, and so does lava
+(2026-09-11): nothing bails or plugs lava, and treating it as temporary left Zawiriko's miner idle at
+a six-cell lava pocket with every rib cut and a complete rib waiting. Once the original diagonal is
+finished that way and every ordinary rib has either been cut or honestly stopped, the miner revisits
+the root ribs from the shallowest down. A dry, fully open, fully supported eight-block rib may become an entrance:
 from its far end the miner drives a new five-wide diagonal outward. That child uses the exact same
 loop, including flooring, lining, bailing, lighting, vein detours, and its own eight-block ribs. The
 miner finishes the entire child before considering the next root rib. Child ribs do not seed more
@@ -778,7 +780,11 @@ storehouse, the walk to bed. That corridor definition is bounded vertically to t
 five-block headroom; a person far below it is no longer mistaken for a valid ramp occupant. If a route
 request finds a villager below that planned excavation, they are returned immediately to the village
 center rather than spending multiple nights aiming at an overhead waypoint. The ordinary stranded
-teleport remains the broader last resort for a cave or obstruction the ramp does not reach.
+teleport remains the broader last resort for a cave or obstruction the ramp does not reach. A
+waypoint that lands in undug rock means the walker is not on the ramp at all but in a cave or pocket
+the planned volume overlaps, which is where a guard who fell in beside Zawiriko's shaft was held for
+five minutes with no path at all (2026-09-11); the ordinary pathfinder takes over there. A request
+made mid-step, between two blocks, is answered with nothing and logged as nothing, as vanilla does.
 
 Approaching a root mine's surface work-station anchor from outside uses ordinary ground navigation.
 That anchor is also excavation headroom, but it must not force a newcomer into the first underground

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
@@ -143,6 +143,9 @@ public final class PersonPathNavigation extends GroundPathNavigation {
    * walk starts or ends down one of the village's mine shafts. The goal keeps
    * asking for its real target, and each answer is the next hop from wherever
    * the walker has got to, so the shaft is descended and climbed by the ramp.
+   * A hop that lands in undug rock means the walker is not on the ramp at all
+   * but in a cave or pocket the planned volume overlaps, and the ordinary path
+   * is the only thing that can take them anywhere.
    */
   @Override
   @Nullable
@@ -155,7 +158,19 @@ public final class PersonPathNavigation extends GroundPathNavigation {
         person.tpToHome();
         return null;
       }
+      if (!canUpdatePath()) {
+        // Mid-air between two steps: vanilla answers nothing too, and a shaft hop
+        // asked for now only logged a failure that was not one.
+        return null;
+      }
       BlockPos hop = MineShaft.waypoint(person.getVillage(), this.mob.blockPosition(), pos);
+      if (hop != null && !openFooting(hop)) {
+        // The plan says shaft, the world says rock. A guard who fell into a cave
+        // pocket beside Zawiriko's ramp was held here for minutes (2026-09-11):
+        // the hop through stone could never be reached, so every request got no
+        // path at all. Off the ramp, the ordinary pathfinder decides.
+        hop = null;
+      }
       if (hop != null) {
         Path path = super.createPath(hop, MINE_WAYPOINT_ACCURACY);
         if (path == null || !path.canReach()) {
@@ -194,6 +209,13 @@ public final class PersonPathNavigation extends GroundPathNavigation {
       return super.createPath(Set.of(pos), accuracy);
     }
     return super.createPath(pos, accuracy);
+  }
+
+  /** Whether feet and head at {@code cell} are clear: a dug shaft cell rather than planned rock. */
+  private boolean openFooting(BlockPos cell) {
+    BlockPos head = cell.above();
+    return this.level.getBlockState(cell).getCollisionShape(this.level, cell).isEmpty()
+        && this.level.getBlockState(head).getCollisionShape(this.level, head).isEmpty();
   }
 
   /**

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineStep.java
@@ -104,7 +104,9 @@ import net.neoforged.neoforge.common.Tags;
  * rib cell as dug space, and a cut rib is lit with a torch; a rib that meets liquid
  * or a cave simply stops there.
  *
- * <p>Bedrock plus a finished set of root ribs opens a bounded second pass. The
+ * <p>Bedrock or lava, plus a finished set of root ribs, opens a bounded second
+ * pass. Lava finishes a root because nothing bails or plugs it; water is the
+ * temporary stop that a bucket or lining clears later. The
  * miner revisits complete eight-block root ribs from the top down and, where a
  * five-wide corridor will not overlap an existing child, drives a new diagonal
  * shaft outward from the rib end. A child runs this exact same excavation loop,
@@ -290,7 +292,7 @@ public final class MineStep implements BlockWorkStep {
     DRY_HOLE,
   }
 
-  /** A shaft either offered work, must wait, or has reached bedrock and finished every rib. */
+  /** A shaft either offered work, must wait, or is driven as deep as it ever will be with every rib finished. */
   private record ShaftPick(@Nullable BlockPos stand, boolean exhausted) {
   }
 
@@ -486,7 +488,11 @@ public final class MineStep implements BlockWorkStep {
       if (fanStand != null) {
         return new ShaftPick(fanStand, false);
       }
-      boolean exhausted = this.block == Blocks.BEDROCK;
+      // Bedrock ends a ramp for good, and so does lava: nothing bails or plugs it,
+      // so waiting on it parked Zawiriko's miner idle with every rib cut and a
+      // complete rib ready to seed a child (Aaron, 2026-09-11). Water is the
+      // temporary stop a bucket or lining clears later, so it finishes nothing.
+      boolean exhausted = this.block == Blocks.BEDROCK || this.block == Blocks.LAVA;
       logIdleState(person, exhausted ? NoWork.EXHAUSTED : NoWork.BLOCKED,
           "blocked shaft has no rib work: mouth=" + mouth.toShortString()
           + ", block=" + this.block.getName().getString()
@@ -2080,8 +2086,16 @@ public final class MineStep implements BlockWorkStep {
         + ", support=" + MineSupportMaterials.held(person.personMainInv)
         + ", water=" + (reachableWater == null
             ? "none" : reachableWater.cell().toShortString());
-    if (!state.equals(this.lastFluidDeadEnd)) {
-      this.lastFluidDeadEnd = state;
+    // Dedupe on the reason, not the cell: the sweep alternates between the faces
+    // of one pocket, so a per-cell key wrote a line on every pick for as long as
+    // the stop held (hundreds an hour at Zawiriko's lava, 2026-09-11).
+    String reason = mouth.toShortString() + " " + this.block.getName().getString()
+        + (carriesBucket(person) ? " bucket" : " no-bucket")
+        + (breach == null ? " closed" : " open")
+        + (MineSupportMaterials.held(person.personMainInv) > 0 ? " support" : " no-support")
+        + (reachableWater == null ? " no-water" : " water");
+    if (!reason.equals(this.lastFluidDeadEnd)) {
+      this.lastFluidDeadEnd = reason;
       Kithkyn.LOGGER.info("[mine-state] {} cannot advance flooded shaft: {}",
           person.getName().getString(), state);
     }


### PR DESCRIPTION
## Summary
- **Lava finishes a root shaft.** Child shafts were seeded only at bedrock, so a lava stop parked the miner idle after the ribs (Zawiriko: six enclosed lava cells, every rib cut, the column-4 rib complete and eligible). Lava now counts like bedrock; water stays a temporary stop.
- **Shaft routing hands off when the plan hop is rock.** A walker inside the planned mine volume whose next hop is undug stone is not on the ramp (a guard fell into a cave pocket beside the shaft and was held with no path for five minutes). The ordinary pathfinder takes over there. Mid-air requests return nothing instead of logging a failure.
- **Flooded-shaft log dedupes per reason**, not per face cell: the sweep alternated between two faces of one pocket and wrote a line every pick.
- `docs/worker-loops.md` updated for both rules.

## Verification
- `./gradlew build` (compile and unit tests) passes. Both rules depend on live world state, so the check is the live server after release: the miner should log `opened a child shaft from root rib 4 side ...` and start digging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
