### PR TITLE
Rest villagers' heads and take their gear off while they sleep

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,7 +79,8 @@ in it, and update it in the same change that moves what it describes.
 - [appearance.md](appearance.md): why villagers use the player model and not the vanilla
   villager model, the wide/slim model split by gender, and the client-side runtime skin
   compositor that bakes a villager's look from inherited skin, hair, and eye structures,
-  continuous pigment genes, and occupation- or life-stage-driven clothing.
+  continuous pigment genes, and occupation- or life-stage-driven clothing, plus the sleeping
+  look: eyes shut, head at rest, gear off.
 - [appearance-wardrobes.md](appearance-wardrobes.md): the occupational clothing catalog,
   current role coverage, implementation gaps, and the separation between inherited appearance
   and replaceable job clothing.

--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -6,8 +6,8 @@ people, and they look like people.
 ## The decision
 
 `PersonModel` extends `PlayerModel<Person>` on a 64x64 player skin sheet, rendered by
-`PersonRenderer` (a `HumanoidMobRenderer`) with the vanilla player inner and outer armor
-layers, at a base scale of `0.9375`.
+`PersonRenderer` (a `MobRenderer` carrying the vanilla humanoid gear layers and the player
+inner and outer armor layers), at a base scale of `0.9375`.
 
 The vanilla villager model was considered and rejected. Three reasons:
 
@@ -169,7 +169,26 @@ face. Two-row eyes close to their lower row; one-row eyes become a line. Hair an
 composite over the closed face exactly as they do over the open one.
 
 The preview `age-lineup-asleep` ([ui-preview.md](ui-preview.md)) photographs the four
-lineup faces shut, for comparison with the waking `age-lineup` shot.
+lineup faces shut and at rest, for comparison with the waking `age-lineup` shot.
+
+## Sleeping pose and gear
+
+The rest of the sleeping look is the renderer's, keyed on the same vanilla sleeping state.
+`PersonModel` rests the head: turned forty degrees toward one shoulder and rolled ten
+degrees with it, instead of holding the entity's look direction, and the hat layer follows.
+Which shoulder is the person's own, the parity of their appearance seed, so a row of
+sleepers is not a row of clones and no head flips between frames.
+
+Nothing worn or held is drawn in bed. `PersonRenderer` wraps every gear layer (the vanilla
+humanoid head-block, elytra and hand layers, and the player armor) in `AwakeOnlyLayer`,
+which skips the layer while the person sleeps, and poses the arms as empty so they lie flat
+rather than holding the shape of a sword that is not drawn. The gear stays on the entity;
+only the drawing stops, and it is back the moment they wake.
+
+`/kkdev appearance sleep <targets>` puts a person standing in a bed to sleep and `wake` gets
+them up, for looking at any of this on demand. The preview `age-lineup-bed`
+([ui-preview.md](ui-preview.md)) photographs the four stages asleep in beds, dressed in gear
+that must not show.
 
 ## Genetics readiness
 

--- a/docs/ui-preview.md
+++ b/docs/ui-preview.md
@@ -22,6 +22,7 @@ Reasoning about a layout is not looking at it. If you are changing anything unde
 ./gradlew runClientJoinLocal -Puipreview=age-lineup
 ./gradlew runClientJoinLocal -Puipreview=age-lineup-asleep
 ./gradlew runClientJoinLocal -Puipreview=age-lineup-world
+./gradlew runClientJoinLocal -Puipreview=age-lineup-bed
 ```
 
 Start the local development server first. The preview client joins it as `Dev`, opens the named
@@ -38,11 +39,18 @@ lets it settle, then calls `Screenshot.grab` and stops the client. Chat and trad
 `PersonChatScreen` payload. `age-lineup` creates four unspawned client-side people with identical
 appearance inputs, changes only their age stage, and renders them through the real entity renderer.
 `age-lineup-asleep` is the same four given a client-side sleeping position, which shuts their eyes
-through the sleeping face bake ([appearance.md](appearance.md)) while the standing pose keeps every
-face upright and comparable with the waking shot.
+through the sleeping face bake and rests their heads to one side through the model
+([appearance.md](appearance.md)), while the standing pose keeps every body upright and comparable
+with the waking shot.
 `age-lineup-world` briefly spawns the same controlled stages in front of the preview player so the
 real entity attachments, name line, role line, camera perspective, and model scale are photographed
 together. The tagged entities are removed immediately after the capture.
+`age-lineup-bed` is the world lineup asleep: four beds side-on to the camera, each stage summoned
+into one wearing a sword, a shield and a full iron set, then put to bed through
+`/kkdev appearance sleep`, so the shot must show bare sleepers with shut eyes and turned heads. The
+client log lists what the server still has on each of them, so a bare body is provably gear the
+renderer left off. Beds and camera stand are removed with the entities. Needs developer commands on,
+which the local development server has.
 
 Two traps are already paid for, and both cost an hour the first time:
 

--- a/src/main/java/com/quzzar/kithkyn/client/gui/AgeLineupScreen.java
+++ b/src/main/java/com/quzzar/kithkyn/client/gui/AgeLineupScreen.java
@@ -27,8 +27,9 @@ import net.minecraft.util.Mth;
  * <p>All four preview people share the same appearance genes and default
  * client-side attributes. Only {@link AgeStage} changes, so a screenshot makes
  * model proportions and relative stage scale directly comparable. The same four
- * can be shown asleep: a client-side sleeping position shuts their eyes without
- * laying them down, which photographs the closed face at every stage.
+ * can be shown asleep: a client-side sleeping position shuts their eyes and rests
+ * their heads without laying them down, which photographs the sleeping face at
+ * every stage. The beds themselves are the world preview's job.
  */
 public final class AgeLineupScreen extends Screen {
 
@@ -57,7 +58,7 @@ public final class AgeLineupScreen extends Screen {
         graphics.drawCenteredString(
                 font,
                 asleep
-                        ? "The waking lineup with every eye shut"
+                        ? "The waking lineup asleep: eyes shut, heads at rest"
                         : "Same appearance and attributes; only age changes",
                 width / 2,
                 27,
@@ -111,7 +112,8 @@ public final class AgeLineupScreen extends Screen {
             person.setLifeStage(stage);
             if (asleep) {
                 // Sleeping is a position, not a pose: the compositor reads it to
-                // shut the eyes, while the standing pose keeps the face upright.
+                // shut the eyes and the model reads it to rest the head, while the
+                // standing pose keeps every body upright and comparable.
                 person.setSleepingPos(BlockPos.ZERO);
             }
             created.add(new StagePreview(stage, person));

--- a/src/main/java/com/quzzar/kithkyn/client/gui/UiPreview.java
+++ b/src/main/java/com/quzzar/kithkyn/client/gui/UiPreview.java
@@ -5,11 +5,14 @@ import java.util.Locale;
 
 import com.quzzar.kithkyn.Kithkyn;
 import com.quzzar.kithkyn.entities.AgeStage;
+import com.quzzar.kithkyn.entities.Person;
 import com.quzzar.kithkyn.networking.MarketOffersPacket;
 
 import net.minecraft.client.CameraType;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Screenshot;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -32,6 +35,7 @@ import net.neoforged.neoforge.client.event.ClientTickEvent;
  * ./gradlew runClientJoinLocal -Puipreview=age-lineup
  * ./gradlew runClientJoinLocal -Puipreview=age-lineup-asleep
  * ./gradlew runClientJoinLocal -Puipreview=age-lineup-world
+ * ./gradlew runClientJoinLocal -Puipreview=age-lineup-bed
  * </pre>
  *
  * The client joins the local development server, opens the named preview over
@@ -57,11 +61,25 @@ public final class UiPreview {
     /** The lineup with every eye shut, photographed through the sleeping face bake. */
     private static final String ASLEEP_LINEUP_MODE = "age-lineup-asleep";
     private static final String WORLD_LINEUP_MODE = "age-lineup-world";
+    /** The world lineup asleep: each stage in its own bed, dressed in gear the bed must not show. */
+    private static final String BED_LINEUP_MODE = "age-lineup-bed";
     private static final String WORLD_LINEUP_TAG = "kithkyn_age_lineup_preview";
     private static final String WORLD_LINEUP_CAMERA_TAG = WORLD_LINEUP_TAG + "_camera";
-    private static final String WORLD_LINEUP_CENTER_TAG = WORLD_LINEUP_TAG + "_center";
     private static final String WORLD_LINEUP_RETURN_TAG = WORLD_LINEUP_TAG + "_return";
     private static final double[] WORLD_LINEUP_OFFSETS = {2.7D, 0.9D, -0.9D, -2.7D};
+    /** The standing lineup's chest height and its distance south of the camera. */
+    private static final double STANDING_LINEUP_TARGET_Y = 199.35D;
+    private static final double STANDING_LINEUP_DISTANCE = 5.5D;
+    /** Foot block x of each side-on bed, the head one block east; together centred on the camera. */
+    private static final int[] BED_LINEUP_FEET = {-5, -2, 1, 4};
+    /** The mattress height and the beds' distance south of the camera stand. */
+    private static final double BED_LINEUP_TARGET_Y = 199.5D;
+    private static final double BED_LINEUP_DISTANCE = 6.0D;
+    /** A sword, a shield and a full iron set: all on the sleeper, none of it to be drawn. */
+    private static final String BED_LINEUP_GEAR = ",HandItems:[{id:\"minecraft:iron_sword\",count:1},"
+            + "{id:\"minecraft:shield\",count:1}],"
+            + "ArmorItems:[{id:\"minecraft:iron_boots\",count:1},{id:\"minecraft:iron_leggings\",count:1},"
+            + "{id:\"minecraft:iron_chestplate\",count:1},{id:\"minecraft:iron_helmet\",count:1}]";
 
     private static int ticks = -1;
     private static boolean shot;
@@ -116,11 +134,19 @@ public final class UiPreview {
             PersonChatScreen.onReply(0, "Aye, and the north road's been thick with bandits "
                     + "since the frost broke, so mind yourself past the old mill.", false);
         }
+        if (isBedLineup()) {
+            aimCamera(client, BED_LINEUP_TARGET_Y, BED_LINEUP_DISTANCE);
+        } else if (isWorldLineup()) {
+            aimCamera(client, STANDING_LINEUP_TARGET_Y, STANDING_LINEUP_DISTANCE);
+        }
         int settleTicks = isWorldLineup() ? WORLD_SETTLE_TICKS : SETTLE_TICKS;
         if (++ticks < settleTicks) {
             return;
         }
         shot = true;
+        if (isBedLineup()) {
+            logBedLineup(client);
+        }
         Screenshot.grab(client.gameDirectory, "ui-" + MODE + ".png",
                 client.getMainRenderTarget(),
                 message -> Kithkyn.LOGGER.info("UI preview saved: {}", message.getString()));
@@ -217,38 +243,102 @@ public final class UiPreview {
                 "execute at @s run summon minecraft:marker ~ ~ ~ {Tags:[\""
                         + WORLD_LINEUP_TAG + "\",\"" + WORLD_LINEUP_RETURN_TAG + "\"]}");
         sendCommand(client, "fill -6 198 -2 6 198 9 minecraft:grass_block");
-        sendCommand(client, "tp @s 0.5 199 0.5 0 0");
         sendCommand(client, "effect give @s minecraft:night_vision 30 0 true");
+        if (isBedLineup()) {
+            summonBedLineup(client);
+        } else {
+            summonStandingLineup(client);
+        }
+        sendCommand(client, "tag @s remove " + WORLD_LINEUP_CAMERA_TAG);
+    }
+
+    /**
+     * Points the first-person camera due south and down at the lineup, every settle
+     * tick, from the eye height the teleport has landed the player at. A server-side
+     * facing teleport used to do this and lost the race once, photographing the sky
+     * above the beds; the client owns its own look direction, so it aims itself.
+     */
+    private static void aimCamera(Minecraft client, double targetY, double distance) {
+        float pitch = (float) Math.toDegrees(Math.atan2(client.player.getEyeY() - targetY, distance));
+        client.player.setYRot(0.0F);
+        client.player.yRotO = 0.0F;
+        client.player.setXRot(pitch);
+        client.player.xRotO = pitch;
+    }
+
+    /** The four stages standing in a row, each turned to face the camera. */
+    private static void summonStandingLineup(Minecraft client) {
+        sendCommand(client, "tp @s 0.5 199 0.5 0 0");
         for (int index = 0; index < AgeStage.values().length; index++) {
             AgeStage stage = AgeStage.values()[index];
             String command = String.format(
                     Locale.ROOT,
                     "execute at @s rotated as @s run summon kithkyn:person ^%.2f ^ ^5.50 %s",
                     WORLD_LINEUP_OFFSETS[index],
-                    worldPersonNbt(stage));
+                    worldPersonNbt(stage, ""));
             sendCommand(client, command);
         }
-        sendCommand(client,
-                "execute at @s rotated as @s run summon minecraft:marker ^ ^0.35 ^5.50 "
-                        + "{Tags:[\"" + WORLD_LINEUP_TAG + "\",\"" + WORLD_LINEUP_CENTER_TAG + "\"]}");
         sendCommand(client,
                 "execute as @e[type=kithkyn:person,tag=" + WORLD_LINEUP_TAG
                         + ",distance=..16] at @s run tp @s ~ ~ ~ facing entity "
                         + "@a[tag=" + WORLD_LINEUP_CAMERA_TAG + ",limit=1] eyes");
-        sendCommand(client,
-                "tp @s ~ ~ ~ facing entity @e[type=minecraft:marker,tag="
-                        + WORLD_LINEUP_CENTER_TAG + ",limit=1,sort=nearest] eyes");
-        sendCommand(client, "tag @s remove " + WORLD_LINEUP_CAMERA_TAG);
     }
 
-    private static String worldPersonNbt(AgeStage stage) {
+    /**
+     * The four stages asleep, each in a bed lying side-on to the camera with its head to
+     * the east, photographed from a two-block stand so the camera looks down onto them.
+     * Every sleeper is summoned armed and armored and then put to bed through the
+     * developer command, so the shot must show bare sleepers with their heads turned;
+     * {@link #logBedLineup} records what the server still has on them, so bare bodies
+     * read as gear the renderer left off and not gear the server took away.
+     */
+    private static void summonBedLineup(Minecraft client) {
+        sendCommand(client, "fill 0 199 0 0 200 0 minecraft:grass_block");
+        sendCommand(client, "tp @s 0.5 201 0.5 0 0");
+        for (int index = 0; index < AgeStage.values().length; index++) {
+            int foot = BED_LINEUP_FEET[index];
+            int head = foot + 1;
+            sendCommand(client, String.format(Locale.ROOT,
+                    "setblock %d 199 6 minecraft:red_bed[facing=east,part=foot]", foot));
+            sendCommand(client, String.format(Locale.ROOT,
+                    "setblock %d 199 6 minecraft:red_bed[facing=east,part=head]", head));
+            sendCommand(client, String.format(Locale.ROOT,
+                    "summon kithkyn:person %.1f 199.6 6.5 %s",
+                    head + 0.5D,
+                    worldPersonNbt(AgeStage.values()[index], BED_LINEUP_GEAR)));
+        }
+        sendCommand(client,
+                "kkdev appearance sleep @e[type=kithkyn:person,tag=" + WORLD_LINEUP_TAG + ",distance=..16]");
+    }
+
+    /**
+     * What the server still has on each sleeper at the moment of the shot. Scoreboard
+     * tags never reach the client, so this reads every person near the preview player,
+     * which in the sky above spawn is the lineup and nobody else.
+     */
+    private static void logBedLineup(Minecraft client) {
+        for (Entity entity : client.level.entitiesForRendering()) {
+            if (entity instanceof Person person && person.distanceToSqr(client.player) < 16.0D * 16.0D) {
+                Kithkyn.LOGGER.info("Bed lineup: {} sleeping={} hands={} {} armor={} {} {} {}",
+                        person.getLifeStage(), person.isSleeping(),
+                        person.getMainHandItem().getItem(), person.getOffhandItem().getItem(),
+                        person.getItemBySlot(EquipmentSlot.HEAD).getItem(),
+                        person.getItemBySlot(EquipmentSlot.CHEST).getItem(),
+                        person.getItemBySlot(EquipmentSlot.LEGS).getItem(),
+                        person.getItemBySlot(EquipmentSlot.FEET).getItem());
+            }
+        }
+    }
+
+    /** A summoned lineup person; {@code gear} is extra NBT, empty or the bed lineup's kit. */
+    private static String worldPersonNbt(AgeStage stage, String gear) {
         return "{Tags:[\"" + WORLD_LINEUP_TAG + "\"],"
                 + "SkinVariant:" + AgeLineupScreen.PREVIEW_SEED + ","
                 + "StatBlock:{Strength:10,Dexterity:10,Constitution:10,Intelligence:10,"
                 + "Wisdom:10,Charisma:10,Size:10,Eyesight:10},"
                 + "AgeStage:\"" + stage.name() + "\",FirstName:\"Avery\",LastName:\"Stone\","
                 + "Title:\"Adult\",Occupation:\"WANDERER\",NoAI:1b,Immobile:1b,"
-                + "Invulnerable:1b,Silent:1b,CustomNameVisible:1b}";
+                + "Invulnerable:1b,Silent:1b,CustomNameVisible:1b" + gear + "}";
     }
 
     private static void cleanWorldLineup(Minecraft client) {
@@ -256,6 +346,10 @@ public final class UiPreview {
                 "tp @s @e[type=minecraft:marker,tag=" + WORLD_LINEUP_RETURN_TAG + ",limit=1]");
         sendCommand(client, "kill @e[tag=" + WORLD_LINEUP_TAG + "]");
         sendCommand(client, "fill -6 198 -2 6 198 9 minecraft:air");
+        if (isBedLineup()) {
+            // The beds and the camera stand.
+            sendCommand(client, "fill -6 199 -2 6 200 9 minecraft:air");
+        }
         sendCommand(client, "effect clear @s minecraft:night_vision");
         sendCommand(client, "tag @s remove " + WORLD_LINEUP_CAMERA_TAG);
     }
@@ -265,7 +359,11 @@ public final class UiPreview {
     }
 
     private static boolean isWorldLineup() {
-        return WORLD_LINEUP_MODE.equalsIgnoreCase(MODE);
+        return WORLD_LINEUP_MODE.equalsIgnoreCase(MODE) || isBedLineup();
+    }
+
+    private static boolean isBedLineup() {
+        return BED_LINEUP_MODE.equalsIgnoreCase(MODE);
     }
 
     private static boolean isLineup() {

--- a/src/main/java/com/quzzar/kithkyn/client/models/PersonModel.java
+++ b/src/main/java/com/quzzar/kithkyn/client/models/PersonModel.java
@@ -14,6 +14,13 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.UseAnim;
 
 public class PersonModel extends PlayerModel<Person> {
+
+    /** How far a sleeper's head turns toward a shoulder: a good way over, well short of full profile. */
+    private static final float RESTING_HEAD_TURN = (float) Math.toRadians(40.0);
+
+    /** The small roll that goes with the turn, so the head lies to that side rather than merely looks. */
+    private static final float RESTING_HEAD_TILT = (float) Math.toRadians(10.0);
+
     public PersonModel(ModelPart part, boolean slim) {
         super(part, slim);
     }
@@ -26,6 +33,10 @@ public class PersonModel extends PlayerModel<Person> {
         // adult proportions at their smaller AgeStage scale.
         this.young = entityIn.getLifeStage().usesYoungModel();
         super.setupAnim(entityIn, limbSwing, limbSwingAmount, ageInTicks, netbipedHeadYaw, bipedHeadPitch);
+        if (entityIn.isSleeping()) {
+            this.restHead(entityIn);
+            return;
+        }
         if (entityIn.getMainArm() == HumanoidArm.RIGHT) {
             this.eatingAnimationRightHand(InteractionHand.MAIN_HAND, entityIn, ageInTicks);
             this.eatingAnimationLeftHand(InteractionHand.OFF_HAND, entityIn, ageInTicks);
@@ -35,6 +46,25 @@ public class PersonModel extends PlayerModel<Person> {
         }
     }
     
+    /**
+     * A sleeper's head lies to one side. The vanilla pose keeps the head on the
+     * entity's look direction, which has nothing to do with rest; this turns the
+     * face a good way toward one shoulder and tips the crown toward that same
+     * shoulder, on top of the shut eyes the sleeping skin bake provides. Which side
+     * is the person's own, fixed by their appearance seed: a row of sleepers is not
+     * a row of clones, and a head never flips between frames. The hat layer follows
+     * the head as always.
+     */
+    private void restHead(Person entity) {
+        float side = entity.getAppearanceSeed() % 2 == 0 ? 1.0F : -1.0F;
+        this.head.xRot = 0.0F;
+        this.head.yRot = side * RESTING_HEAD_TURN;
+        // Model roll runs against yaw in sign: a negative roll leans the crown toward
+        // the shoulder a positive yaw turns the face to (checked in the preview).
+        this.head.zRot = -side * RESTING_HEAD_TILT;
+        this.hat.copyFrom(this.head);
+    }
+
     /** The wide (Steve) body: 4-pixel arms. */
     public static LayerDefinition createMesh() {
         MeshDefinition meshdefinition = PlayerModel.createMesh(CubeDeformation.NONE, false);

--- a/src/main/java/com/quzzar/kithkyn/client/renderer/AwakeOnlyLayer.java
+++ b/src/main/java/com/quzzar/kithkyn/client/renderer/AwakeOnlyLayer.java
@@ -1,0 +1,38 @@
+package com.quzzar.kithkyn.client.renderer;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.RenderLayerParent;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
+import net.minecraft.world.entity.LivingEntity;
+
+/**
+ * A layer of gear that is only worn while awake.
+ *
+ * <p>Everything a person wears or holds is gear: the armor, the item in each hand, the
+ * block or skull on the head, the elytra. A sleeper has none of it on; they went to bed.
+ * The wrapped layer renders exactly as vanilla would while the entity is awake and is
+ * skipped outright while it sleeps, so a bed shows the person and not their kit.
+ */
+public final class AwakeOnlyLayer<T extends LivingEntity, M extends EntityModel<T>> extends RenderLayer<T, M> {
+
+    private final RenderLayer<T, M> gear;
+
+    public AwakeOnlyLayer(RenderLayerParent<T, M> renderer, RenderLayer<T, M> gear) {
+        super(renderer);
+        this.gear = gear;
+    }
+
+    @Override
+    public void render(PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, T entity,
+            float limbSwing, float limbSwingAmount, float partialTick, float ageInTicks, float netHeadYaw,
+            float headPitch) {
+        if (entity.isSleeping()) {
+            return;
+        }
+        this.gear.render(poseStack, bufferSource, packedLight, entity, limbSwing, limbSwingAmount, partialTick,
+                ageInTicks, netHeadYaw, headPitch);
+    }
+}

--- a/src/main/java/com/quzzar/kithkyn/client/renderer/PersonRenderer.java
+++ b/src/main/java/com/quzzar/kithkyn/client/renderer/PersonRenderer.java
@@ -14,8 +14,11 @@ import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.geom.ModelLayers;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
-import net.minecraft.client.renderer.entity.HumanoidMobRenderer;
+import net.minecraft.client.renderer.entity.MobRenderer;
+import net.minecraft.client.renderer.entity.layers.CustomHeadLayer;
+import net.minecraft.client.renderer.entity.layers.ElytraLayer;
 import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.HumanoidArm;
@@ -23,7 +26,7 @@ import net.minecraft.world.item.CrossbowItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.UseAnim;
 
-public class PersonRenderer extends HumanoidMobRenderer<Person, HumanoidModel<Person>> {
+public class PersonRenderer extends MobRenderer<Person, HumanoidModel<Person>> {
 
     /** The two body geometries, chosen from the person's appearance recipe in {@link #render}. */
     private final PersonModel wideModel;
@@ -35,10 +38,16 @@ public class PersonRenderer extends HumanoidMobRenderer<Person, HumanoidModel<Pe
         this.slimModel = new PersonModel(context.bakeLayer(PersonClientEvents.PERSON_SLIM), true);
         this.model = this.wideModel;
 
-        this.addLayer(new HumanoidArmorLayer<>(this,
+        // The gear a HumanoidMobRenderer would add (head block, elytra, hands) plus
+        // the player armor, each worn only while awake: a sleeper renders bare.
+        this.addLayer(new AwakeOnlyLayer<>(this,
+                new CustomHeadLayer<>(this, context.getModelSet(), context.getItemInHandRenderer())));
+        this.addLayer(new AwakeOnlyLayer<>(this, new ElytraLayer<>(this, context.getModelSet())));
+        this.addLayer(new AwakeOnlyLayer<>(this, new ItemInHandLayer<>(this, context.getItemInHandRenderer())));
+        this.addLayer(new AwakeOnlyLayer<>(this, new HumanoidArmorLayer<>(this,
                 new HumanoidModel<>(context.bakeLayer(ModelLayers.PLAYER_INNER_ARMOR)),
                 new HumanoidModel<>(context.bakeLayer(ModelLayers.PLAYER_OUTER_ARMOR)),
-                context.getModelManager()));
+                context.getModelManager())));
     }
 
     @Override
@@ -270,10 +279,15 @@ public class PersonRenderer extends HumanoidMobRenderer<Person, HumanoidModel<Pe
         ItemStack itemstack = entityIn.getMainHandItem();
         ItemStack itemstack1 = entityIn.getOffhandItem();
         guardmodel.setAllVisible(true);
-        HumanoidModel.ArmPose bipedmodel$armpose = this.getArmPose(entityIn, itemstack, itemstack1,
-                InteractionHand.MAIN_HAND);
-        HumanoidModel.ArmPose bipedmodel$armpose1 = this.getArmPose(entityIn, itemstack, itemstack1,
-                InteractionHand.OFF_HAND);
+        // A sleeper's hands are empty on screen, so the arms lie flat rather than
+        // holding the shape of gear that is not drawn.
+        boolean awake = !entityIn.isSleeping();
+        HumanoidModel.ArmPose bipedmodel$armpose = awake
+                ? this.getArmPose(entityIn, itemstack, itemstack1, InteractionHand.MAIN_HAND)
+                : HumanoidModel.ArmPose.EMPTY;
+        HumanoidModel.ArmPose bipedmodel$armpose1 = awake
+                ? this.getArmPose(entityIn, itemstack, itemstack1, InteractionHand.OFF_HAND)
+                : HumanoidModel.ArmPose.EMPTY;
         guardmodel.crouching = entityIn.isCrouching();
         if (entityIn.getMainArm() == HumanoidArm.RIGHT) {
             guardmodel.rightArmPose = bipedmodel$armpose;

--- a/src/main/java/com/quzzar/kithkyn/dev/AppearanceCommands.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/AppearanceCommands.java
@@ -41,10 +41,14 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.block.BedBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BedPart;
 
 /** Live development controls and invariant audits for the layered appearance system. */
 public final class AppearanceCommands {
@@ -146,7 +150,17 @@ public final class AppearanceCommands {
                     .executes(context -> setOccupation(
                         context.getSource(),
                         EntityArgument.getEntity(context, "target"),
-                        StringArgumentType.getString(context, "occupation"))))));
+                        StringArgumentType.getString(context, "occupation"))))))
+        .then(Commands.literal("sleep")
+            .then(Commands.argument("targets", EntityArgument.entities())
+                .executes(context -> sleep(
+                    context.getSource(),
+                    EntityArgument.getEntities(context, "targets")))))
+        .then(Commands.literal("wake")
+            .then(Commands.argument("targets", EntityArgument.entities())
+                .executes(context -> wake(
+                    context.getSource(),
+                    EntityArgument.getEntities(context, "targets")))));
   }
 
   private static int show(CommandSourceStack source, Entity entity) {
@@ -525,6 +539,60 @@ public final class AppearanceCommands {
             + occupation.name().toLowerCase(Locale.ROOT)
             + ". This development override does not update the village's job-assignment ledger."), true);
     return 1;
+  }
+
+  /**
+   * Puts each targeted person to bed where they stand, for looking at the sleeping
+   * render on demand: shut eyes, the head at rest, no gear. The target must be standing
+   * in a bed, either half; a sleep started anywhere else ends on the next tick, when
+   * vanilla finds no bed beneath them. The village's night is not consulted, so a person
+   * with AI gets up as soon as a goal decides they should.
+   */
+  private static int sleep(CommandSourceStack source, Collection<? extends Entity> entities) {
+    int slept = 0;
+    for (Entity entity : entities) {
+      RealPerson person = requirePerson(source, entity);
+      if (person == null) {
+        continue;
+      }
+      BlockPos head = bedHeadUnder(person);
+      if (head == null) {
+        source.sendFailure(Component.literal(person.getFullName() + " is not standing in a bed."));
+        continue;
+      }
+      person.startSleeping(head);
+      slept++;
+    }
+    int count = slept;
+    source.sendSuccess(() -> Component.literal("Put " + count + " to bed."), true);
+    return slept;
+  }
+
+  /** Gets each targeted person up; nothing happens to anyone already awake. */
+  private static int wake(CommandSourceStack source, Collection<? extends Entity> entities) {
+    int woken = 0;
+    for (Entity entity : entities) {
+      RealPerson person = requirePerson(source, entity);
+      if (person != null) {
+        person.stopSleeping();
+        woken++;
+      }
+    }
+    int count = woken;
+    source.sendSuccess(() -> Component.literal("Woke " + count + "."), true);
+    return woken;
+  }
+
+  /** The head half of the bed the person stands in, or null when they stand in no bed. */
+  private static BlockPos bedHeadUnder(RealPerson person) {
+    BlockPos at = person.blockPosition();
+    BlockState state = person.level().getBlockState(at);
+    if (!(state.getBlock() instanceof BedBlock)) {
+      return null;
+    }
+    // A bed's facing runs from its foot to its head, the same step vanilla takes when a
+    // player clicks the foot half.
+    return state.getValue(BedBlock.PART) == BedPart.HEAD ? at : at.relative(state.getValue(BedBlock.FACING));
   }
 
   private static AppearanceInputs inputs(RealPerson person) {


### PR DESCRIPTION
## What

Follows #107 (closed eyes). While a villager sleeps:

- **Head at rest.** Turned 40° toward one shoulder and tipped 10° the same way, replacing the look-direction pose. The side is fixed per person by appearance-seed parity, so sleepers vary and never flip between frames.
- **No gear drawn.** `PersonRenderer` now extends `MobRenderer` and wraps the vanilla head-block, elytra and hand layers plus the player armor in `AwakeOnlyLayer`, which skips them while asleep. Arms pose as empty so they lie flat. Equipment stays on the entity; only the drawing stops.

Everything keys on the vanilla sleeping state already synced to clients, like the closed-eyes bake, so nothing new is saved or sent.

## Tooling

- `/kkdev appearance sleep <targets>` / `wake <targets>`: put a person standing in a bed to sleep, or get them up, for inspecting the sleeping render on demand.
- New preview `age-lineup-bed`: four beds side-on to the camera, each stage summoned with a sword, shield and full iron set and then put to bed. The shot must show bare sleepers; the client log lists what the server still has on each of them.
- The world lineups now aim the camera client-side from known geometry. The server-side `facing` teleport lost the race once and photographed the sky.

## Verification

- `./gradlew build` (compile + unit tests) passes.
- Photographed on a private superflat server built from this branch: `age-lineup-asleep` (heads turned and tipped, eyes shut), `age-lineup-bed` (bare sleepers in beds while the log shows sword/shield/iron set still equipped), and `age-lineup-world` unchanged.

Docs: `docs/appearance.md` (new "Sleeping pose and gear" section), `docs/ui-preview.md`, `docs/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
