### PR TITLE
Integrate the Floodplain castle

### DIFF
--- a/docs/castles.md
+++ b/docs/castles.md
@@ -1,6 +1,6 @@
 # Castles
 
-## Building and roles
+## Desert castle
 
 The first castle is the edited R07.2 Desert Fort from Towns and Towers. The editable gallery
 copy stands at `4402, 230, 1208`; `tools/structure/desert-castle-20260910.json` records the
@@ -46,7 +46,7 @@ Five general beds cannot house all seven non-ruler castle workers. A village nee
 two additional general beds elsewhere to fill every castle position. The royal spouse's bed
 remains reserved, and the captain moves from their existing town-center assignment.
 
-## Identity and appearance
+### Identity and appearance
 
 All ten banners receive village heraldry, including original ominous patterns. Every bed
 uses a primary or secondary village color; the royal pair shares a color. The white/light-blue
@@ -60,6 +60,40 @@ the barred rooftop cell. One matching sandstone slab closes a low parapet gap wh
 unreachable shortcut onto target decorations. Native checks passed 92 access routes, 32 assigned-bed sleeps, 28 personal-container
 deposits and twelve shared-container deposits across all four rotations. Rendered inspection
 confirmed the two barrels and preserved castle appearance before deployment.
+
+## Floodplain castle
+
+The Floodplain castle is the user-edited SC01.2 Overgrown Stone Fort, derived from the
+Towns and Towers Jungle Fort and restyled with spruce, dark oak, mossed stone and ordinary
+oak foliage. Its final gallery capture stands at `10107, 230, 1308`; the private source and
+production assets live under `run/floodplain-integration/castle/`, while
+`tools/structure/floodplain-castle-20260911.json` records the public metadata and provenance.
+
+The two residential wings provide nine general single beds with shared personal barrels.
+The upstairs ruler suite has a reserved double bed and its own chest. The castle adds a
+leader, baker, blacksmith and jailer. Two sword-and-shield guards cover the entrance, two
+crossbow guards cover the opposing balconies, and three crossbow guards cover the roof.
+These are ordinary authored jobs and housing assignments, so the wider village still needs
+enough residents to fill them.
+
+Each of the seven sentry stations owns a short patrol route on its assigned level. Entrance
+guards remain at the gate, balcony guards remain on their respective balconies, and roof guards
+cover separate parts of the roof. This prevents the upper guard shifts from crowding the central
+ladder while preserving all seven patrols through every building rotation.
+
+The enclosed, multi-block jail room is on the ground floor. Its two evidence barrels sit above the cell door and
+remain outside both village storage and personal storage. Custody uses the same five-minute
+sentence, item rules, reminders, release behavior and theft exclusions described below.
+The eight authored banner positions receive the village banner; all eleven beds receive the
+primary or secondary village color, with both ruler beds sharing the primary color.
+
+The roof is reached by the central ladder. Native testing of all rotations exposed two
+general navigation problems and fixed them in the shared runtime: a body on a rung now
+advances by occupying that exact rung rather than by an unstable fractional-height test,
+and personal-container routing avoids stepping over beds when a floor route exists.
+All 28 sentry runs reached every assigned waypoint across four rotations. The custody fixture
+also passed melee and arrow arrest, all 41 ordinary inventory slots, evidence overflow,
+five-minute reminders, persistence, escape, damaged-cell release and obstructed-exit fallback.
 
 ## Ruler decisions
 

--- a/docs/floodplain-village.md
+++ b/docs/floodplain-village.md
@@ -13,9 +13,9 @@ NeoForge's conventional tags it builds Floodplain until that exists.
 
 ## Selected buildings
 
-The public selection record is `tools/structure/nilotic-selections-20260910.json` (27
-native captures: 20 buildings, 5 wall sections, 2 unassigned candidates) and the catalog
-record is `tools/structure/floodplain-catalog-20260910.json`. The datapack holds twenty
+The public selection records are `tools/structure/nilotic-selections-20260910.json` and
+`tools/structure/floodplain-castle-20260911.json`; the catalog record is
+`tools/structure/floodplain-catalog-20260910.json`. The datapack holds twenty-one
 definitions, all new ids, so the pack needs no filter:
 
 | Id | Source exhibit | Beds | Stations |
@@ -37,9 +37,11 @@ definitions, all new ids, so the pack needs no filter:
 | `couple_cottage_floodplain_1` | Nilotic small house 1 with the couple bed | 2 | none |
 | `market_floodplain_1`, `_2`, `_3` | the Desert market tiers restyled | 0 | one to three merchants |
 | `farm_floodplain_1`, `_2` | the Polynesian small and large farms | 0 | farmer |
+| `castle_floodplain_1` | user-edited, swamp-restyled Towns and Towers Jungle Fort | 11 | ruler, baker, blacksmith, jailer, two sword guards and five crossbow guards |
 
-There is no tavern and no bakery, and only one storehouse level: more storehouses are the
-answer to storage strain, and the adopted allays help there
+There is no separate tavern or bakery, though the optional castle supplies a baker station.
+There is only one storehouse level: more storehouses are the answer to storage strain, and
+the adopted allays help there
 ([allay-quartermasters.md](allay-quartermasters.md)). The market tiers and the farms are
 the only upgrades.
 
@@ -76,6 +78,13 @@ Walls are not exported. The runtime paints the shared arid wall geometry
 and slabs, mud brick walls as railings, jungle trapdoors, muddy mangrove roots on the
 gatehouse uprights and roof rim, brown candle clusters on every standing lamp, and the four
 hanging gate lanterns kept. Wall bills are priced in mud bricks.
+
+The castle is an optional late village building rather than part of founding. Its nine
+general single beds occupy two residential wings; the ruler and spouse share the reserved
+double room. The jail evidence barrels above the cell door are excluded from village storage.
+Two sword-and-shield guards patrol the entrance, two crossbow guards cover the balconies,
+and three crossbow guards cover the roof. The baker and blacksmith use their authored work
+areas. All eight banners receive village heraldry.
 
 ## Authoring and local installation
 
@@ -114,3 +123,10 @@ A second release the same evening (commit 1291788e79) carried the keeper routing
 rule, lodge composting, the sunk well and the mine ramp that starts at the pit's middle column.
 Ruwaleni was deleted and the site founded again as Mavulena, centre -3984 66 5344, so its mine and any
 well it raises follow the new data.
+
+The September 11 castle pass captured the final user-edited SC01.2 structure at
+`10107, 230, 1308`, removed container contents and closed doors for production, and passed
+the no-barrier audit. Native access verification walks every bed, personal barrel, shared
+store, workstation and roof ladder in all four rotations with an adult two-block collision
+body. Separate native checks cover all seven sentry posts on routes local to their assigned
+entrance, balcony or roof level, plus the five-minute custody cycle.

--- a/docs/structure-review.md
+++ b/docs/structure-review.md
@@ -1778,6 +1778,32 @@ the building, its door went, and a step leads down into the pit; the miner stand
 with the ramp mouth one column in. The Desert mine gained a shared chest at the pit floor plus two wall
 posts, a fence, a trapdoor and a lantern, exported in its existing frame. Both were captured from a flushed
 snapshot, re-exported, checked and installed in their packs.
+
+### Floodplain castle: September 11
+
+Aaron selected SC01.2, the Towns and Towers Jungle Fort, as the Floodplain castle. The
+restyle replaced the dark tropical timber with spruce and dark-oak accents, retained the
+mossed stone silhouette, removed cobwebs and converted eight banners into village identity
+slots. Aaron then rebuilt the interior into two residential wings with nine single beds, a
+reserved ruler suite with two beds, a baker, a rooftop blacksmith, a ground-floor jail and
+seven guard posts. The two barrels above the jail door are custody evidence and are excluded
+from every village and personal storage list.
+
+Custody now recognizes the authored jail as one enclosed, flat room rather than requiring a
+one-block standing cell. It flood-fills only supported interior tiles, rejects open rooms and
+large courtyards, and treats crossing the room boundary as escape.
+
+The final gallery structure at `10107, 230, 1308` was captured from a flushed snapshot and
+exported as `castle_floodplain_1`; empty space above its ground course is explicit so terrain
+cannot fill the rooms. Container contents are stripped, doors start closed, and the template
+contains no barrier states. Native access testing uses a two-block adult and covers all beds,
+personal barrels, shared stores, stations, ladders and rotations. It exposed and fixed a
+rotation-sensitive ladder transition and a container route that preferred stepping across a
+bed over clear floor. Guard and custody fixtures exercise the seven sentries and five-minute
+jail flow separately. The five upper sentries use station-specific balcony and roof routes so
+they do not crowd the central ladder. Public provenance and coordinates are recorded in
+`tools/structure/floodplain-castle-20260911.json`.
+
 ### Jungle catalog verified: September 10
 
 The approved Jungle selection is now a playable private catalog with 22 definitions: nineteen

--- a/src/main/java/com/quzzar/kithkyn/dev/ApprovedHouseVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/ApprovedHouseVerification.java
@@ -312,7 +312,13 @@ public final class ApprovedHouseVerification {
       else beginWalk(level);
     } else {
       boolean temporary = residents.isEmpty();
-      walker = temporary ? new ApprovedStructureAccess.Person(level, village) : residents.getFirst();
+      walker = temporary ? new ApprovedStructureAccess.Person(level, village) : residents.stream()
+          .filter(person -> village.getJobAssignment(person.getUUID()) == null)
+          .findFirst().orElse(residents.getFirst());
+      if (!temporary && residents.getFirst() != walker) {
+        residents.remove(walker);
+        residents.addFirst(walker);
+      }
       walker.setLifeStage(AgeStage.ADULT);
       setProbeBody(walker);
       ApprovedStructureAccess.moveTo(walker, entrance);
@@ -332,7 +338,9 @@ public final class ApprovedHouseVerification {
       var spouses = marriedResidents(level);
       check(village.getBedAssignment(spouses.getFirst().getUUID()) == null
           && village.getBedAssignment(spouses.get(1).getUUID()) == null, "Worker couple was pre-housed");
-      claimWorkplace(spouses.getFirst());
+      BuildingInfo.RoomReservation room = info.getRoomReservation(
+          info.getBedLocations().indexOf(pair.first().asLong()));
+      claimWorkplace(spouses.getFirst(), room == null ? null : room.occupation().orElse(null));
       checkCouple(spouses.getFirst(), spouses.get(1), pair);
     }
     for (int single = 0; single < info.getWorkerSingleBedCount(); single++) {
@@ -371,10 +379,16 @@ public final class ApprovedHouseVerification {
   }
 
   private static void claimWorkplace(ApprovedStructureAccess.Person worker) {
+    claimWorkplace(worker, null);
+  }
+
+  private static void claimWorkplace(ApprovedStructureAccess.Person worker, Occupation requiredOccupation) {
     JobAssignment job = village.getUnassignedJobs().stream()
-        .filter(open -> open.getBuildingUUID().equals(building.getUUID())).findFirst()
+        .filter(open -> open.getBuildingUUID().equals(building.getUUID()))
+        .filter(open -> requiredOccupation == null || open.getOccupation() == requiredOccupation)
+        .findFirst()
         .orElseThrow(() -> new AssertionError("More worker rooms than stations in " + label()));
-    check(village.canHouseForJob(worker.getUUID(), building.getUUID()), "Unhoused worker cannot claim the authored room");
+    check(village.canHouseForJob(worker.getUUID(), job), "Unhoused worker cannot claim the authored room");
     village.assignJob(worker.getUUID(), job);
     worker.setOccupation(job.getOccupation());
     check(village.getJobAssignment(worker.getUUID()) != null, "Worker claim did not book its station");
@@ -496,14 +510,18 @@ public final class ApprovedHouseVerification {
       // while the same body is still checking later stations. Founding proves
       // real job and routed-worksite behavior; fixed crossbow posts still need
       // their actual equipment and duty here.
-      if (existing != null) {
-        walker.setOccupation(existing.getOccupation());
-        walker.issueStartingKit();
-      } else if (physicalCategory == null && visit.occupation() == Occupation.GUARD
+      if (physicalCategory == null && visit.occupation() == Occupation.GUARD
           && guardRole == GuardRole.CROSSBOW_POST) {
-        village.assignJob(walker.getUUID(), new JobAssignment(walker.getUUID(), visit.occupation(),
-            building.getUUID(), visit.stationIndex()));
+        if (existing == null || !existing.getBuildingUUID().equals(building.getUUID())
+            || existing.getStationIndex() != visit.stationIndex()) {
+          village.releaseJob(walker.getUUID());
+          village.assignJob(walker.getUUID(), new JobAssignment(walker.getUUID(), visit.occupation(),
+              building.getUUID(), visit.stationIndex()));
+        }
         walker.setOccupation(visit.occupation());
+        walker.issueStartingKit();
+      } else if (existing != null) {
+        walker.setOccupation(existing.getOccupation());
         walker.issueStartingKit();
       } else {
         village.releaseJob(walker.getUUID());
@@ -736,7 +754,11 @@ public final class ApprovedHouseVerification {
     var doors = walker.goalSelector.getAvailableGoals().stream()
         .filter(goal -> goal.getGoal() instanceof OpenDoorGoal)
         .map(goal -> "running=" + goal.isRunning() + ",canUse=" + goal.getGoal().canUse()).toList();
-    return "collision=" + walker.horizontalCollision + ",canOpenDoors="
+    BlockPos feet = walker.blockPosition();
+    return "collision=" + walker.horizontalCollision + ",onClimbable=" + walker.onClimbable()
+        + ",feet=" + feet.subtract(ORIGIN) + ",feetState=" + walker.level().getBlockState(feet)
+        + ",belowState=" + walker.level().getBlockState(feet.below()) + ",motion=" + walker.getDeltaMovement()
+        + ",canOpenDoors="
         + ((GroundPathNavigation) walker.getNavigation()).canOpenDoors() + ",doorGoals=" + doors
         + ",pathDone=" + walker.getNavigation().isDone() + ",nextNode="
         + (path == null ? "none" : path.getNextNodeIndex()) + ",nearbyNodes=" + nodes;

--- a/src/main/java/com/quzzar/kithkyn/dev/CastleOperationsVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/CastleOperationsVerification.java
@@ -31,6 +31,7 @@ public final class CastleOperationsVerification {
   private static int ticks;
   private static int started;
   private static int rotation;
+  private static int completedSentries;
   private static boolean finished;
 
   private CastleOperationsVerification() { }
@@ -51,18 +52,25 @@ public final class CastleOperationsVerification {
             patrol.visited.add(point);
           }
         }
-        check(Math.abs(patrol.person.getY() - patrol.route.getFirst().getY()) < 1.5,
-            "Sentry left assigned floor: " + patrol.person.position());
+        int lowest = patrol.route.stream().mapToInt(BlockPos::getY).min().orElseThrow();
+        int highest = patrol.route.stream().mapToInt(BlockPos::getY).max().orElseThrow();
+        if (highest - lowest <= 1) {
+          check(patrol.person.getY() >= lowest - 1.5D && patrol.person.getY() <= highest + 1.5D,
+              "Sentry left authored patrol floor: " + patrol.person.position());
+        }
       }
       if (ticks - started > 3200) throw new AssertionError("Patrol stalled " + patrols.stream().map(p ->
           p.person.position() + " visited=" + p.visited + " expected=" + p.route).toList());
       if (patrols.stream().allMatch(p -> p.visited.size() == p.route.size())) {
-        Kithkyn.LOGGER.info("{} ROTATION PASS {}: all four actual guard goals visited every assigned floor waypoint", PREFIX, Rotation.values()[rotation]);
+        completedSentries += patrols.size();
+        Kithkyn.LOGGER.info("{} ROTATION PASS {}: all {} actual guard goals visited every authored waypoint",
+            PREFIX, Rotation.values()[rotation], patrols.size());
         patrols.forEach(p -> p.person.discard());
         patrols.clear();
         if (++rotation == 4) {
           finished = true;
-          Kithkyn.LOGGER.info("{} RESULT PASS: sixteen real sentries, all assigned upper/lower waypoints in four rotations, retained floor and loadouts", PREFIX);
+          Kithkyn.LOGGER.info("{} RESULT PASS: {} real sentries visited all authored patrol levels in four rotations and retained loadouts",
+              PREFIX, completedSentries);
           event.getServer().halt(false);
         }
       }
@@ -76,7 +84,10 @@ public final class CastleOperationsVerification {
   private static void setup(ServerLevel level) throws ReflectiveOperationException {
     BlockPos origin = new BlockPos(2400, 159, 2400);
     for (int x = 147; x <= 153; x++) for (int z = 147; z <= 153; z++) level.setChunkForced(x, z, true);
-    Building castle = ApprovedStructureAccess.place(level, origin, Buildings.getByName("castle_desert_1"), Rotation.values()[rotation]);
+    String castleId = System.getProperty("kithkyn.castleOperations.id", "castle_desert_1");
+    var castleInfo = Buildings.getByName(castleId);
+    check(castleInfo != null, "Missing castle definition " + castleId);
+    Building castle = ApprovedStructureAccess.place(level, origin, castleInfo, Rotation.values()[rotation]);
     Village village = new ApprovedStructureAccess.VillageFixture(level, castle, true);
     for (var job : List.copyOf(village.getUnassignedJobs())) {
       if (job.getOccupation() != Occupation.GUARD) continue;
@@ -106,7 +117,15 @@ public final class CastleOperationsVerification {
       check(level.addFreshEntity(person), "Could not spawn sentry");
       patrols.add(new Patrol(person, route, new HashSet<>()));
     }
-    check(patrols.size() == 4, "Expected four sentries");
+    int station = 0;
+    long expected = 0;
+    for (Occupation occupation : castleInfo.getWorkLocations().values()) {
+      if (occupation == Occupation.GUARD && castleInfo.getGuardRole(station) != GuardRole.JAILER) {
+        expected++;
+      }
+      station++;
+    }
+    check(patrols.size() == expected, "Expected " + expected + " patrolling sentries, found " + patrols.size());
     started = ticks;
   }
 

--- a/src/main/java/com/quzzar/kithkyn/dev/CustodyVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/CustodyVerification.java
@@ -78,7 +78,10 @@ public final class CustodyVerification {
     level.getGameRules().getRule(GameRules.RULE_KEEPINVENTORY).set(false, level.getServer());
     BlockPos origin = new BlockPos(2400, 159, 2400);
     for (int x = 147; x <= 153; x++) for (int z = 147; z <= 153; z++) level.setChunkForced(x, z, true);
-    Building castle = ApprovedStructureAccess.place(level, origin, Buildings.getByName("castle_desert_1"), Rotation.NONE);
+    String castleId = System.getProperty("kithkyn.custody.id", "castle_desert_1");
+    var castleInfo = Buildings.getByName(castleId);
+    check(castleInfo != null, "Missing castle definition " + castleId);
+    Building castle = ApprovedStructureAccess.place(level, origin, castleInfo, Rotation.NONE);
     var village = new TestVillage(level, castle);
     VillageManager.get(level).getVillages().put(village.getID(), village);
     var guard = new ApprovedStructureAccess.Person(level, village);

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
@@ -275,7 +275,11 @@ public final class PersonPathNavigation extends GroundPathNavigation {
           this.level.getBlockState(this.path.getNextNodePos()));
       if (Math.abs(this.mob.getX() - next.x) < 0.45D
           && Math.abs(this.mob.getZ() - next.z) < 0.45D
-          && Math.abs(this.mob.getY() - next.y) < 0.35D) this.path.advance();
+          // A climbing body's feet can oscillate anywhere inside the rung's
+          // block. Occupying that exact rung is sufficient to advance toward
+          // the next one; comparing its fractional height advances too early
+          // near the top and can drop the body before it reaches the landing.
+          && this.mob.blockPosition().equals(this.path.getNextNodePos())) this.path.advance();
       this.doStuckDetection(this.getTempMobPos());
       return;
     }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/ContainerAccess.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/ContainerAccess.java
@@ -16,8 +16,10 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.ai.navigation.GroundPathNavigation;
 import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
+import net.minecraft.world.level.pathfinder.Path;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
@@ -56,15 +58,38 @@ public final class ContainerAccess {
         candidates.add(new Approach(pos.immutable(), feet));
       }
     }
-    candidates.sort(Comparator.<Approach>comparingDouble(candidate ->
-        candidate.feet().add(0.0D, eyeHeight, 0.0D).distanceToSqr(Vec3.atCenterOf(target)))
+    candidates.sort(Comparator.<Approach>comparingInt(candidate ->
+        Math.abs(candidate.feet().y - candidate.node().getY()) < 0.01D ? 0 : 1)
+        .thenComparingDouble(candidate ->
+            candidate.feet().add(0.0D, eyeHeight, 0.0D).distanceToSqr(Vec3.atCenterOf(target)))
         .thenComparingDouble(candidate -> candidate.feet().distanceToSqr(person.position())));
+    Approach best = null;
+    int fewestBedSteps = Integer.MAX_VALUE;
     for (Approach candidate : candidates.stream().limit(PATHS_PER_SCAN).toList()) {
-      var path = person.getNavigation().createPath(candidate.node(), 0);
+      Path path = person.getNavigation().createPath(candidate.node(), 0);
       if (path != null && path.canReach() && path.getEndNode() != null
-          && path.getEndNode().asBlockPos().equals(candidate.node())) return candidate.node();
+          && path.getEndNode().asBlockPos().equals(candidate.node())) {
+        int bedSteps = bedSteps(person, path);
+        if (bedSteps < fewestBedSteps) {
+          best = candidate;
+          fewestBedSteps = bedSteps;
+        }
+        if (bedSteps == 0) return candidate.node();
+      }
     }
+    if (best != null) return best.node();
     return closedClosetDoor(person, target, reachSqr, allowedStanding);
+  }
+
+  /** Beds are valid low surfaces, but mobs can catch on their edge while trying to cross them diagonally. */
+  private static int bedSteps(RealPerson person, Path path) {
+    int count = 0;
+    for (int index = 0; index < path.getNodeCount(); index++) {
+      if (person.level().getBlockState(path.getNode(index).asBlockPos().below()).getBlock() instanceof BedBlock) {
+        count++;
+      }
+    }
+    return count;
   }
 
   /** A one-cell closet has no inside stance until the ordinary door goal opens its wooden door. */

--- a/src/main/java/com/quzzar/kithkyn/village/GuardDuty.java
+++ b/src/main/java/com/quzzar/kithkyn/village/GuardDuty.java
@@ -76,20 +76,32 @@ public record GuardDuty(BlockPos position, BlockPos lookAt, boolean ranged, bool
 
   /** The presence of a route changes the awake shift without changing the guard's weapon duty. */
   public static boolean hasCastlePatrol(RealPerson person) {
-    Building castle = assignedCastle(person);
-    return castle != null && !castle.getInfo().getCastleLayout().patrolRoute(authoredRole(person)).isEmpty();
+    return !patrolRoute(person).isEmpty();
   }
 
   /** Authored castle points transformed through the same origin and rotation as the post. */
   public static List<BlockPos> patrolRoute(RealPerson person) {
     Building castle = assignedCastle(person);
-    return castle == null ? List.of() : patrolRoute(castle.getInfo(), authoredRole(person),
+    if (castle == null) return List.of();
+    JobAssignment job = person.getVillage().getJobAssignment(person.getUUID());
+    return job == null ? List.of() : patrolRoute(castle.getInfo(), job.getStationIndex(), authoredRole(person),
         BlockPos.of(castle.getOriginLocation()), castle.getRotation());
   }
 
+  static List<BlockPos> patrolRoute(BuildingInfo info, int stationIndex, @Nullable GuardRole role,
+      BlockPos origin, Rotation rotation) {
+    List<BlockPos> stationRoute = info.getGuardPatrolRoute(stationIndex);
+    return transformRoute(stationRoute.isEmpty() && info.getCastleLayout() != null
+        ? info.getCastleLayout().patrolRoute(role) : stationRoute, origin, rotation);
+  }
+
   static List<BlockPos> patrolRoute(BuildingInfo info, @Nullable GuardRole role, BlockPos origin, Rotation rotation) {
-    return info.getCastleLayout() == null ? List.of() : info.getCastleLayout().patrolRoute(role).stream()
-        .map(point -> origin.offset(point.rotate(rotation))).toList();
+    return info.getCastleLayout() == null ? List.of()
+        : transformRoute(info.getCastleLayout().patrolRoute(role), origin, rotation);
+  }
+
+  private static List<BlockPos> transformRoute(List<BlockPos> route, BlockPos origin, Rotation rotation) {
+    return route.stream().map(point -> origin.offset(point.rotate(rotation))).toList();
   }
 
   /** Castle sword sentries receive their shield as part of their initial defensive kit. */

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/BuildingInfo.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/BuildingInfo.java
@@ -68,12 +68,17 @@ public class BuildingInfo {
    * placed physical worksite while the vacancy remains part of the civic building.
    */
   public record WorkStation(BlockPos pos, Occupation occupation, java.util.Optional<GuardRole> guardDuty,
-      java.util.Optional<String> worksiteCategory) {
+      java.util.Optional<String> worksiteCategory, java.util.Optional<List<BlockPos>> patrolRoute) {
+    public WorkStation {
+      patrolRoute = patrolRoute.map(List::copyOf);
+    }
+
     public static final Codec<WorkStation> CODEC = RecordCodecBuilder.create(inst -> inst.group(
         BlockPos.CODEC.fieldOf("pos").forGetter(WorkStation::pos),
         KithkynCodecs.forEnum(Occupation.class).fieldOf("occupation").forGetter(WorkStation::occupation),
         KithkynCodecs.forEnum(GuardRole.class).optionalFieldOf("guard_duty").forGetter(WorkStation::guardDuty),
-        Codec.STRING.optionalFieldOf("worksite_category").forGetter(WorkStation::worksiteCategory)
+        Codec.STRING.optionalFieldOf("worksite_category").forGetter(WorkStation::worksiteCategory),
+        BlockPos.CODEC.listOf().optionalFieldOf("patrol_route").forGetter(WorkStation::patrolRoute)
     ).apply(inst, WorkStation::new));
   }
 
@@ -166,6 +171,7 @@ public class BuildingInfo {
       info.addWorkLocation(station.pos().getX(), station.pos().getY(), station.pos().getZ(), station.occupation());
       station.guardDuty().ifPresent(duty -> info.guardRoles.put(station.pos().asLong(), duty));
       station.worksiteCategory().ifPresent(worksite -> info.worksiteCategories.put(station.pos().asLong(), worksite));
+      station.patrolRoute().ifPresent(route -> info.guardPatrolRoutes.put(station.pos().asLong(), route));
     });
     containers.forEach(pos -> info.addContainerLocation(pos.getX(), pos.getY(), pos.getZ()));
     personalContainers.forEach(pos -> info.addPersonalContainerLocation(pos.getX(), pos.getY(), pos.getZ()));
@@ -187,6 +193,7 @@ public class BuildingInfo {
   // Insertion-ordered: JobAssignment station indexes rely on a stable iteration order.
   private LinkedHashMap<Long, Occupation> workLocs;
   private final Map<Long, GuardRole> guardRoles = new LinkedHashMap<>();
+  private final Map<Long, List<BlockPos>> guardPatrolRoutes = new LinkedHashMap<>();
   private final Map<Long, String> worksiteCategories = new LinkedHashMap<>();
   private final LinkedHashMap<Long, Occupation> worksiteLocs = new LinkedHashMap<>();
   @javax.annotation.Nullable
@@ -426,6 +433,19 @@ public class BuildingInfo {
     for (var entry : guardRoles.entrySet()) {
       if (workLocs.get(entry.getKey()) != Occupation.GUARD) return "guard_duty requires a GUARD station";
     }
+    for (var entry : guardPatrolRoutes.entrySet()) {
+      if (workLocs.get(entry.getKey()) != Occupation.GUARD) {
+        return "patrol_route requires a GUARD station";
+      }
+      GuardRole role = guardRoles.get(entry.getKey());
+      if (role != GuardRole.CROSSBOW_POST && role != GuardRole.SWORD_POST) {
+        return "patrol_route requires a CROSSBOW_POST or SWORD_POST guard_duty";
+      }
+      if (castleLayout == null) return "patrol_route requires castle amenities";
+      if (entry.getValue().size() < 2 || new java.util.HashSet<>(entry.getValue()).size() < 2) {
+        return "patrol_route requires at least two distinct waypoints";
+      }
+    }
     if (worksiteCategories.values().stream().anyMatch(String::isBlank)) {
       return "worksite_category cannot be blank";
     }
@@ -591,6 +611,13 @@ public class BuildingInfo {
     return guardRoles.get(position);
   }
 
+  /** A sentry's own floor route; absent metadata falls back to the castle role route. */
+  public List<BlockPos> getGuardPatrolRoute(int stationIndex) {
+    if (stationIndex < 0 || stationIndex >= workLocs.size()) return List.of();
+    Long position = new ArrayList<>(workLocs.keySet()).get(stationIndex);
+    return guardPatrolRoutes.getOrDefault(position, List.of());
+  }
+
   public ArrayList<Long> getBedLocations() {
     return bedLocs;
   }
@@ -695,7 +722,8 @@ public class BuildingInfo {
     return workLocs.entrySet().stream()
         .map(entry -> new WorkStation(BlockPos.of(entry.getKey()), entry.getValue(),
             java.util.Optional.ofNullable(guardRoles.get(entry.getKey())),
-            java.util.Optional.ofNullable(worksiteCategories.get(entry.getKey())))).toList();
+            java.util.Optional.ofNullable(worksiteCategories.get(entry.getKey())),
+            java.util.Optional.ofNullable(guardPatrolRoutes.get(entry.getKey())))).toList();
   }
 
   private List<Worksite> worksites() {

--- a/src/main/java/com/quzzar/kithkyn/wrongdoing/VillageCustody.java
+++ b/src/main/java/com/quzzar/kithkyn/wrongdoing/VillageCustody.java
@@ -8,9 +8,12 @@ import com.quzzar.kithkyn.village.VillageGolems;
 import com.quzzar.kithkyn.village.VillageManager;
 import com.quzzar.kithkyn.village.buildings.Building;
 import com.quzzar.kithkyn.village.buildings.WorkerFooting;
+import java.util.ArrayDeque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import net.minecraft.core.BlockPos;
@@ -31,8 +34,11 @@ import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.animal.AbstractGolem;
+import net.minecraft.world.level.block.DoorBlock;
+import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.saveddata.SavedData;
 import net.minecraft.world.level.block.entity.BarrelBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.phys.Vec3;
 
@@ -160,7 +166,7 @@ public final class VillageCustody extends SavedData {
       ledger.release(player, sentence, custodyLevel, true, "Your sentence is complete. You have thirty seconds to leave peacefully.");
       return;
     }
-    if (custodyLevel != player.serverLevel() || escaped(player.position(), sentence.cell())) {
+    if (custodyLevel != player.serverLevel()) {
       ledger.release(player, sentence, custodyLevel, false, "You escaped custody. You have thirty seconds before the village guards pursue you again.");
       return;
     }
@@ -171,6 +177,10 @@ public final class VillageCustody extends SavedData {
         .findFirst().orElse(null);
     if (castle == null || village.isBeingRebuilt(castle.getUUID()) || !validCell(player.serverLevel(), sentence.cell())) {
       ledger.release(player, sentence, custodyLevel, true, "The cell is no longer usable. You have been released with thirty seconds to leave.");
+      return;
+    }
+    if (escaped(player.serverLevel(), player.position(), sentence.cell())) {
+      ledger.release(player, sentence, custodyLevel, false, "You escaped custody. You have thirty seconds before the village guards pursue you again.");
       return;
     }
     applyFatigue(player, sentence, now);
@@ -189,6 +199,13 @@ public final class VillageCustody extends SavedData {
         || position.y < cell.getY() - 0.5D || position.y > cell.getY() + 2.0D;
   }
 
+  /** An enclosed room may contain several standing tiles; crossing its physical boundary is escape. */
+  static boolean escaped(ServerLevel level, Vec3 position, BlockPos cell) {
+    if (position.y < cell.getY() - 0.5D || position.y > cell.getY() + 2.0D) return true;
+    BlockPos occupied = BlockPos.containing(position.x, cell.getY(), position.z);
+    return !cellInterior(level, cell).contains(occupied);
+  }
+
   /** Death from another source ends custody rather than sending a respawned player back into prison. */
   public static void died(ServerPlayer player) {
     VillageCustody ledger = get(player.serverLevel());
@@ -199,15 +216,47 @@ public final class VillageCustody extends SavedData {
     }
   }
 
-  /** A missing wall, unsupported floor, flooded cell or blocked body prevents an arrest. */
+  /** A missing wall, unsupported floor, flooded room or blocked body prevents an arrest. */
   public static boolean validCell(ServerLevel level, BlockPos cell) {
-    if (!level.hasChunkAt(cell) || !WorkerFooting.canStand(level, cell)) return false;
-    for (Direction side : Direction.Plane.HORIZONTAL) {
-      BlockPos wall = cell.relative(side);
-      if (level.getBlockState(wall).getCollisionShape(level, wall).isEmpty()
-          && level.getBlockState(wall.above()).getCollisionShape(level, wall.above()).isEmpty()) return false;
+    return !cellInterior(level, cell).isEmpty();
+  }
+
+  /** Flood-fills one flat jail room, bounded to keep an open castle or courtyard from becoming a cell. */
+  private static Set<BlockPos> cellInterior(ServerLevel level, BlockPos cell) {
+    if (!level.hasChunkAt(cell) || !WorkerFooting.canStand(level, cell)) return Set.of();
+    Set<BlockPos> interior = new HashSet<>();
+    ArrayDeque<BlockPos> open = new ArrayDeque<>();
+    interior.add(cell.immutable());
+    open.add(cell.immutable());
+    while (!open.isEmpty()) {
+      BlockPos current = open.removeFirst();
+      for (Direction side : Direction.Plane.HORIZONTAL) {
+        BlockPos neighbor = current.relative(side);
+        if (!level.hasChunkAt(neighbor)) return Set.of();
+        if (blocksCellBoundary(level, neighbor)) continue;
+        if (WorkerFooting.canStand(level, neighbor)) {
+          if (interior.add(neighbor.immutable())) {
+            if (interior.size() > 64) return Set.of();
+            open.addLast(neighbor.immutable());
+          }
+          continue;
+        }
+        return Set.of();
+      }
     }
-    return true;
+    return Set.copyOf(interior);
+  }
+
+  private static boolean blocksCellBoundary(ServerLevel level, BlockPos position) {
+    for (BlockPos part : List.of(position, position.above())) {
+      BlockState state = level.getBlockState(part);
+      if ((state.getBlock() instanceof DoorBlock && state.getValue(DoorBlock.OPEN))
+          || (state.getBlock() instanceof FenceGateBlock && state.getValue(FenceGateBlock.OPEN))) {
+        continue;
+      }
+      if (!state.getCollisionShape(level, part).isEmpty()) return true;
+    }
+    return false;
   }
 
   private void release(ServerPlayer player, Sentence sentence, @Nullable ServerLevel level, boolean relocate, String message) {
@@ -282,8 +331,11 @@ public final class VillageCustody extends SavedData {
 
   @Nullable
   private static BlockPos safeReleasePoint(ServerLevel level, BlockPos cell, BlockPos requested) {
+    Set<BlockPos> interior = cellInterior(level, cell);
     for (BlockPos candidate : BlockPos.withinManhattan(requested, 6, 4, 6)) {
-      if ((Math.abs(candidate.getX() - cell.getX()) > 1 || Math.abs(candidate.getZ() - cell.getZ()) > 1)
+      boolean outsideCell = interior.isEmpty() || interior.stream().allMatch(tile ->
+          Math.abs(candidate.getX() - tile.getX()) > 1 || Math.abs(candidate.getZ() - tile.getZ()) > 1);
+      if (outsideCell
           && level.hasChunkAt(candidate) && WorkerFooting.canStand(level, candidate)) return candidate.immutable();
     }
     return null;

--- a/src/test/java/com/quzzar/kithkyn/village/GuardDutyTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/GuardDutyTest.java
@@ -43,6 +43,52 @@ class GuardDutyTest {
   }
 
   @Test
+  void aCastleSentryUsesItsOwnFloorRouteBeforeTheRoleFallback() {
+    BuildingInfo info = BuildingInfo.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+        {"structure":"castle_floodplain_1","category":"castle","work_stations":[
+          {"pos":[4,1,4],"occupation":"BAKER"},
+          {"pos":[5,2,5],"occupation":"GUARD","guard_duty":"SWORD_POST",
+            "patrol_route":[[5,2,5],[8,2,5]]},
+          {"pos":[5,10,5],"occupation":"GUARD","guard_duty":"CROSSBOW_POST",
+            "patrol_route":[[5,10,5],[5,10,8]]}],
+          "castle":{"custody_cell":[6,2,8],"release_point":[6,2,11],
+            "evidence_containers":[[7,5,9],[8,5,9]],
+            "patrol_routes":{"SWORD_POST":[[1,1,1],[2,1,1]],
+              "CROSSBOW_POST":[[1,10,1],[2,10,1]]}}}
+        """)).getOrThrow();
+    BlockPos origin = new BlockPos(100, 70, -80);
+    for (Rotation rotation : Rotation.values()) {
+      assertEquals(java.util.List.of(origin.offset(new BlockPos(5,2,5).rotate(rotation)),
+          origin.offset(new BlockPos(8,2,5).rotate(rotation))),
+          GuardDuty.patrolRoute(info, 1, GuardRole.SWORD_POST, origin, rotation));
+      assertEquals(java.util.List.of(origin.offset(new BlockPos(5,10,5).rotate(rotation)),
+          origin.offset(new BlockPos(5,10,8).rotate(rotation))),
+          GuardDuty.patrolRoute(info, 2, GuardRole.CROSSBOW_POST, origin, rotation));
+    }
+    BuildingInfo restored = BuildingInfo.CODEC.parse(JsonOps.INSTANCE,
+        BuildingInfo.CODEC.encodeStart(JsonOps.INSTANCE, info).getOrThrow()).getOrThrow();
+    assertEquals(java.util.List.of(new BlockPos(5,2,5), new BlockPos(8,2,5)),
+        restored.getGuardPatrolRoute(1));
+    assertNull(restored.validate());
+  }
+
+  @Test
+  void stationPatrolRoutesRequireAPostAndTwoDistinctWaypoints() {
+    BuildingInfo ordinaryGuard = castleWithStation("""
+        {"pos":[5,2,5],"occupation":"GUARD","guard_duty":"JAILER",
+          "patrol_route":[[5,2,5],[8,2,5]]}
+        """);
+    assertEquals("patrol_route requires a CROSSBOW_POST or SWORD_POST guard_duty",
+        ordinaryGuard.validate());
+
+    BuildingInfo onePoint = castleWithStation("""
+        {"pos":[5,2,5],"occupation":"GUARD","guard_duty":"SWORD_POST",
+          "patrol_route":[[5,2,5],[5,2,5]]}
+        """);
+    assertEquals("patrol_route requires at least two distinct waypoints", onePoint.validate());
+  }
+
+  @Test
   void jailerKeepsAFixedSwordPostInsteadOfBecomingACrossbowSentry() {
     BuildingInfo info = BuildingInfo.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
         {"structure":"castle_desert_1","work_stations":[
@@ -180,5 +226,13 @@ class GuardDutyTest {
           "grants": %s
         }
         """.formatted(ranged ? "[\"RANGED_GUARD_POSTS\"]" : "[\"PROTECTION\"]"))).getOrThrow();
+  }
+
+  private static BuildingInfo castleWithStation(String station) {
+    return BuildingInfo.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString("""
+        {"structure":"castle_floodplain_1","category":"castle","work_stations":[%s],
+          "castle":{"custody_cell":[6,2,8],"release_point":[6,2,11],
+            "evidence_containers":[[7,5,9],[8,5,9]]}}
+        """.formatted(station))).getOrThrow();
   }
 }

--- a/tools/structure/floodplain-castle-20260911.json
+++ b/tools/structure/floodplain-castle-20260911.json
@@ -1,0 +1,98 @@
+{
+  "exhibit": "SC01.2",
+  "label": "Floodplain Castle",
+  "gallery_origin": [10107, 230, 1308],
+  "capture_size": [31, 27, 31],
+  "source_exhibit": "JH01.4",
+  "source_mod": "t_and_t-neoforge-fabric-1.13.9+1.21.1.jar",
+  "source_mod_structure": "data/kaisyn/structure/outpost/forts/jungle/base_plate.nbt",
+  "source_mod_sha256": "fbac5e09371f93ff7be44b193be4436c585081ed6fc5a569ac6e62571cece708",
+  "source_capture": "run/floodplain-integration/castle/source-capture.nbt",
+  "source_capture_sha256": "72e2ac81744a032e029267255cc2da8879e4674f8cc038516e4053e753760f6a",
+  "status": "verified",
+  "capacity": {
+    "beds": 11,
+    "general_single_beds": 9,
+    "royal_couple_beds": 2
+  },
+  "rooms": [
+    {
+      "id": "royal_suite",
+      "beds": [[19, 10, 20], [20, 10, 20]],
+      "reservation": "LEADER and spouse",
+      "personal_containers": [[21, 11, 16]]
+    },
+    {
+      "id": "east_ground_rooms",
+      "beds": [[23, 2, 13], [25, 2, 13]],
+      "personal_containers": [[26, 2, 13]]
+    },
+    {
+      "id": "west_ground_rooms",
+      "beds": [[5, 2, 17], [7, 2, 17]],
+      "personal_containers": [[4, 2, 17]]
+    },
+    {
+      "id": "west_upper_rooms",
+      "beds": [[7, 6, 13], [7, 6, 15]],
+      "personal_containers": [[7, 6, 17]]
+    },
+    {
+      "id": "east_upper_rooms",
+      "beds": [[23, 6, 13], [23, 6, 15], [23, 6, 17]],
+      "personal_containers": [[26, 6, 17]]
+    }
+  ],
+  "work_areas": [
+    {"role": "leader", "pos": [19, 10, 17]},
+    {"role": "baker", "pos": [10, 10, 19]},
+    {"role": "blacksmith", "pos": [21, 18, 11]},
+    {"role": "jailer", "pos": [14, 2, 10]}
+  ],
+  "guard_posts": {
+    "entrance_sword_and_shield": [[14, 1, 26], [16, 1, 26]],
+    "balcony_crossbow_and_sword": [[15, 10, 5], [15, 10, 25]],
+    "roof_crossbow_and_sword": [[9, 18, 9], [15, 18, 22], [21, 18, 9]]
+  },
+  "patrol_routes": [
+    {"post": [14, 1, 26], "waypoints": [[14, 1, 26], [14, 2, 23]]},
+    {"post": [16, 1, 26], "waypoints": [[16, 1, 26], [16, 2, 23]]},
+    {"post": [15, 10, 5], "waypoints": [[15, 10, 5], [13, 10, 4], [17, 10, 4]]},
+    {"post": [15, 10, 25], "waypoints": [[15, 10, 25], [13, 10, 25], [15, 10, 23], [17, 10, 23]]},
+    {"post": [9, 18, 9], "waypoints": [[9, 18, 9], [8, 18, 8], [9, 18, 11], [11, 18, 11]]},
+    {"post": [15, 18, 22], "waypoints": [[15, 18, 22], [13, 18, 22], [13, 18, 19], [17, 18, 19], [17, 18, 22]]},
+    {"post": [21, 18, 9], "waypoints": [[21, 18, 9], [19, 18, 8], [19, 18, 11], [22, 18, 11]]}
+  ],
+  "jail": {
+    "cell": [16, 2, 8],
+    "release_point": [16, 2, 11],
+    "evidence_containers": [[16, 5, 9], [17, 5, 9]],
+    "sentence_seconds": 300,
+    "evidence_is_village_storage": false
+  },
+  "village_identity": {
+    "banner_slots": 8,
+    "bed_policy": "Single beds alternate primary and secondary; the royal pair shares the primary color."
+  },
+  "shared_containers": [[10, 3, 20], [21, 19, 18]],
+  "excluded_decorative_containers": [
+    {"pos": [9, 10, 17], "reason": "The cake blocks a reliable hand approach to the baker counter."},
+    {"pos": [10, 14, 20], "reason": "Decorative and outside the resident route."}
+  ],
+  "production": {
+    "definition": "run/floodplain-integration/datapack/data/kithkyn/kithkyn/buildings/castle_floodplain_1.json",
+    "template": "run/floodplain-integration/datapack/data/kithkyn/structure/castle_floodplain_1.nbt",
+    "template_sha256": "5e1c3ebe75c056d5f72e0465aad11432502732dc235033b588f42b50958ccc88",
+    "definition_sha256": "78fd107447545b8db7e6b14955576b53b6a38a5bdbf61f19725f7ec61675a399"
+  },
+  "verification": {
+    "barrier_audit": "passed",
+    "static_pack": "run/floodplain-integration/check.py: 21 definitions and templates",
+    "physical_access": "run/swamp-castle-study-20260911/user-final-verification/access/verification.json",
+    "guard_patrols": "run/swamp-castle-study-20260911/user-final-verification/patrol/verification.json: 28 sentry runs across four rotations",
+    "custody": "run/swamp-castle-study-20260911/user-final-verification/custody/verification.json: all custody, evidence, timer, escape and safe-release checks passed",
+    "visual_review": "run/swamp-castle-study-20260911/sc01-2-restyle/render/client/screenshots/"
+  },
+  "source_policy": "Towns and Towers source and derived NBT remain private under run/.",
+  "design_document": "docs/castles.md"
+}

--- a/tools/structure/floodplain-catalog-20260910.json
+++ b/tools/structure/floodplain-catalog-20260910.json
@@ -3,7 +3,8 @@
   "status": "verified_and_locally_deployed",
   "source_policy": "Locally approved playable datapack, excluded from public distribution. Source provenance is retained; written redistribution permission is not asserted.",
   "manifests": [
-    "tools/structure/nilotic-selections-20260910.json"
+    "tools/structure/nilotic-selections-20260910.json",
+    "tools/structure/floodplain-castle-20260911.json"
   ],
   "selected": [
     {
@@ -285,6 +286,20 @@
       "definition_sha256": "e14c5fc8f76598f8cb743864e94c4e91a21114b196e3232d0210e5b7f7dd6755",
       "reviewed_capture": "run/nilotic-showcase/selection-20260910-floodplain/captures/NG04.1.nbt",
       "reviewed_capture_sha256": "9bf52e9a72cb1b3e75c194d6d6d19b4431b7d82d43b72defcb203caeedc00e74"
+    },
+    {
+      "exhibit": "SC01.2",
+      "structure": "castle_floodplain_1",
+      "manifest": "tools/structure/floodplain-castle-20260911.json",
+      "recipe": "castle_1",
+      "source_mod": "t_and_t-neoforge-fabric-1.13.9+1.21.1.jar",
+      "source_mod_structure": "data/kaisyn/structure/outpost/forts/jungle/base_plate.nbt",
+      "asset": "run/floodplain-integration/datapack/data/kithkyn/structure/castle_floodplain_1.nbt",
+      "asset_sha256": "5e1c3ebe75c056d5f72e0465aad11432502732dc235033b588f42b50958ccc88",
+      "definition": "run/floodplain-integration/datapack/data/kithkyn/kithkyn/buildings/castle_floodplain_1.json",
+      "definition_sha256": "78fd107447545b8db7e6b14955576b53b6a38a5bdbf61f19725f7ec61675a399",
+      "reviewed_capture": "run/floodplain-integration/castle/source-capture.nbt",
+      "reviewed_capture_sha256": "72e2ac81744a032e029267255cc2da8879e4674f8cc038516e4053e753760f6a"
     }
   ],
   "excluded": [
@@ -320,13 +335,19 @@
   "exporter": "run/floodplain-integration/prepare.py",
   "native_writer": "tools/structure/VillageTemplateExport.java (with the entities plan key)",
   "verification": {
-    "static": "run/floodplain-integration/check.py: 20 definitions and templates",
-    "unit_tests": "470 tests, 0 failures",
+    "static": "run/floodplain-integration/check.py: 21 definitions and templates",
+    "unit_tests": "482 tests, 0 failures, 8 skipped",
     "allay_run": "run/allay-verification/run.py RESULT PASS",
     "placement_and_restart": "run/floodplain-integration/placement/verification.json",
     "center": "run/floodplain-integration/center/verification.json",
     "access": "run/floodplain-integration/access/verification.json",
-    "founding": "run/floodplain-integration/founding/verification.json"
+    "founding": "run/floodplain-integration/founding/verification.json",
+    "castle": {
+      "access": "run/swamp-castle-study-20260911/user-final-verification/access/verification.json",
+      "patrol": "run/swamp-castle-study-20260911/user-final-verification/patrol/verification.json",
+      "custody": "run/swamp-castle-study-20260911/user-final-verification/custody/verification.json",
+      "barrier_audit": "passed"
+    }
   },
   "datapack": "run/floodplain-integration/datapack",
   "recipe_catalog": "src/main/resources/data/kithkyn/kithkyn/construction_recipes",
@@ -399,6 +420,13 @@
         "mine_floodplain_1"
       ],
       "note": "Aaron re-edited the mine on a production copy in the gallery (NA08.1): the pit is four columns long, the door is gone and a step leads down into the pit. The miner stands at the pit's west column and the ramp mouth is one column in, so three columns of descent stay inside the pit."
+    },
+    {
+      "date": "2026-09-11",
+      "structures": [
+        "castle_floodplain_1"
+      ],
+      "note": "Captured Aaron's final SC01.2 castle edit with eleven beds, a ruler suite, baker, blacksmith, jailer, two entrance guards, two balcony guards, three roof guards and two non-village evidence barrels. Each sentry has a route local to its assigned floor and post."
     }
   ]
 }


### PR DESCRIPTION
The Floodplain castle now uses Aaron's final SC01.2 capture as an optional regional castle with eleven beds, village banners, ruler/baker/blacksmith/jailer roles, two evidence barrels, and seven guards. Each sentry owns a local entrance, balcony, or roof route, so upper guards no longer crowd the central ladder; custody also supports this castle's enclosed multi-block jail room while preserving escape and safe-release behavior.

This also fixes two navigation problems exposed by the castle: rotated ladder climbs now advance by occupied rung, and container approaches prefer clear floor over crossing beds.

Validation:
- `./gradlew check` — 482 tests passed, 8 skipped; 33 tracked templates passed the barrier/bounds audit
- Floodplain static check — 21 definitions/templates passed
- Floodplain barrier audit — all 21 templates passed
- Native access — 4 rotations, 116 routes, 44 room walks/sleeps, 44 personal deposits, 44 station walks, 8 shared deposits
- Native patrol — 28 sentry runs across 4 rotations, all waypoints and loadouts passed
- Native custody — melee/arrow arrest, 41 inventory slots, evidence capacity, five-minute reminders, persistence, escape, damaged-cell release, and blocked-exit fallback passed
