### PR TITLE
Preserve terrain around Jungle fishery

### DIFF
--- a/docs/jungle-village.md
+++ b/docs/jungle-village.md
@@ -92,8 +92,10 @@ can request `/kithkyn create-village ~ ~ ~ jungle`.
 The September 11 fishery repair removed the gallery's two-block water-containment frame from
 the exported cuboid: 108 barrier cells had survived outside the declared 8 by 8 by 13 bounds.
 Its definition now uses `sink: 1`, placing the captured ground course into the riverbank instead
-of raising the whole fishery. The shared template audit rejects barriers and out-of-bounds cells
-in every later public or private catalog export.
+of raising the whole fishery. Because that sink also places local layer 1 at terrain height, the
+export now treats layers 0 and 1 as ground: 37 empty cells around the pond are omitted instead of
+encoded as air, so construction preserves the surrounding bank. The shared template audit rejects
+barriers and out-of-bounds cells in every later public or private catalog export.
 
 ## Verification
 
@@ -117,5 +119,6 @@ flushed live capture.
 
 The repaired fishery separately passed eight real placements through both construction paths in
 all four rotations, plus twelve physical routes covering its entrance, fisher station, shared
-barrel and assigned bed. The active private catalogs then passed a 103-template block audit with
-no barriers or out-of-bounds coordinates.
+barrel and assigned bed. After correcting its ground contract, the same focused placement and
+access checks passed again. Its two terrain-seated layers contain no explicit air, and all 22
+Jungle templates pass the block audit with no barriers or out-of-bounds coordinates.

--- a/docs/structure-review.md
+++ b/docs/structure-review.md
@@ -1836,3 +1836,11 @@ loops opened the intended first descending step without crossing either authored
 eight routed-worksite walks covered both barrels plus mine descent and return; and eight instant or
 incremental construction placements retained the revised template. The production NBT has zero
 blockstate differences from the flushed gallery capture.
+
+The Jungle fishery's first repair removed its gallery barrier frame and lowered it into the wet
+bank, but its export still encoded 37 empty cells at local layer 1 as air. With `sink: 1`, that is
+the visible terrain layer, so new construction could erase the bank around the pond. The fishery
+now protects both local layers 0 and 1: those cells are omitted and leave existing terrain in place,
+while the pond water and authored foundation remain unchanged. Eight real placements and twelve
+navigation routes passed again across all four rotations, and the 22-template Jungle catalog has
+no barriers or out-of-bounds blocks.

--- a/tools/structure/README.md
+++ b/tools/structure/README.md
@@ -98,7 +98,9 @@ second bakery bed and update identity slots. `birch-tavern-20260909.json` refere
 immutable approved capture, source hash and explicit amenity metadata. The same native
 writer preserves the edited grass and lighting, empties storage, and neutralizes only the
 keeper's assigned bed. Dense captures can declare `ground_layer` so exterior ground-level
-air does not excavate the supporting terrain. The source captures are never rewritten.
+air does not excavate the supporting terrain. `ground_layer` is the highest local template layer
+whose empty cells must preserve existing terrain; account for `sink` when choosing it. A sink-one
+pond building, for example, protects local layers 0 and 1. The source captures are never rewritten.
 
 ## Pueblo center review
 

--- a/tools/structure/jungle-catalog-20260910.json
+++ b/tools/structure/jungle-catalog-20260910.json
@@ -263,13 +263,14 @@
         8,
         13
       ],
+      "ground_layer": 1,
       "beds": 1,
       "stations": [
         "FISHER"
       ],
       "worksites": [],
       "asset": "run/jungle-integration/datapack/data/kithkyn/structure/fishery_jungle_1.nbt",
-      "asset_sha256": "03b2a56a00a6b5b434b612a5b9ad3a77809145f43bdda1f973fff02b9c21b1b6",
+      "asset_sha256": "4df5059390a048c9f5d7162d50668ed452ceb02415bba10f94a35747e2d17be2",
       "definition": "run/jungle-integration/datapack/data/kithkyn/kithkyn/buildings/fishery_jungle_1.json",
       "definition_sha256": "b150b434a50c9e0810aa79c78c14a15c756a6af0eb79b4afaa9fec754252c261"
     },
@@ -804,8 +805,9 @@
     "fishery_repair": {
       "date": "2026-09-11",
       "barriers_removed": 108,
+      "ground_air_removed": 37,
       "sink": 1,
-      "template_audit": "103 active private templates, zero barriers and zero out-of-bounds blocks",
+      "template_audit": "Jungle catalog: 22 templates, zero barriers and zero out-of-bounds blocks; fishery layers 0-1 contain no explicit air",
       "placement": "8 real-template placements passed across both construction paths and four rotations",
       "access": "12 routes passed across all four rotations"
     }


### PR DESCRIPTION
The Jungle fishery sinks one block into terrain, but its private export only treated local layer 0 as ground. That left 37 explicit air cells on local layer 1, so a newly built fishery could erase the bank around its pond.

The private template now treats layers 0 and 1 as terrain-preserving ground. Pond water, foundation blocks, amenities, and the existing `sink: 1` placement stay unchanged.

Validation:
- eight real placements through instant and incremental construction across all four rotations
- twelve navigation routes covering the entrance, fisher station, shared barrel, and assigned bed
- all 22 Jungle templates contain no barriers or out-of-bounds blocks
- the fishery contains no explicit air at or below local layer 1
