### PR TITLE
Let the bedtime chest question take things out as well as keep them

### DIFF
--- a/docs/llm-brain.md
+++ b/docs/llm-brain.md
@@ -105,12 +105,14 @@ whether to grind them (one bone makes three), with the same semantics, and the m
 farm's fertiliser shelf described in [worker-loops.md](worker-loops.md). The third personal
 decision is the bedtime chest question: a villager whose home has a chest of its own is asked,
 once a night, which kinds of what they are carrying to keep, any number or none, rather than
-return it all to the stores (`entities/StashOffer`). It is the first consumer of
+return it all to the stores, and which kinds of what the chest holds to take out and carry
+(`entities/StashOffer`). It is the first consumer of
 `LlmService.choose`, the multi-pick sibling of `decide()`: the same lane, gates and prompt
 shape, answered as `{"reason": "...", "choices": [<option numbers>]}` and validated the same
 way, where an empty list is a real answer and a reply with no list is none. Here silence keeps
-nothing, since the rules' own default is the stow that always happened, and only an explicit
-pick holds something back, which the villager then carries home and puts away by hand.
+nothing and takes nothing, since the rules' own default is the stow that always happened, and
+only an explicit pick holds something back or lifts something out, which the villager then does
+by hand at the chest.
 
 That makes the LLM **strongly wanted, not structurally required**: when it is absent,
 slow, or gives an unusable answer, the rules' own top-scoring option stands in and the

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -102,8 +102,9 @@ sleeps in the corresponding room (`village/PersonalChest`; the rule, and which
 workplaces get one, are in [building-spec.md](building-spec.md)). What goes in is decided at
 bedtime, in character: a villager with a chest of their own is asked once a night which kinds
 of what they are carrying home to keep, any number or none, rather than hand it all back to the
-stores (`entities/StashOffer`, the third personal decision in [llm-brain.md](llm-brain.md), over
-`LlmService.choose`, the multi-pick sibling of `decide()`). The briefing names the pack and what the
+stores, and which kinds of what the chest already holds to take out and carry (`entities/StashOffer`,
+the third personal decision in [llm-brain.md](llm-brain.md), over `LlmService.choose`, the
+multi-pick sibling of `decide()`). The briefing names the pack and what the
 chest already holds, calls the chest a small one for keepsakes and says what a store is for: the
 village lives on what its workers bring in, and anything held back at home is lost to its work, then
 what the village is saving for or building and what it is still short of, in the same words as the
@@ -117,12 +118,18 @@ The job's kit (any tool, and what the restock hands out: torches, the bucket, th
 on the list at all, since the miner once kept theirs and the shaft flooded while the bucket sat
 in a barrel at home. Silence keeps nothing, so a mute model costs the village
 no goods. Kept items stay in the pack, the bedtime stow skips them, and `StashAtHomeGoal` walks
-them home and sets them down in the chest by hand ahead of sleep, so nothing teleports here
-either. The camp circle's chest works the same way for the four who sleep there. A chest that cannot be
-reached, is gone, or is full gives the trip up, and the next stow returns the goods as before.
-The chat briefing tells a villager what their chest holds (when its chunk is in sight) and who
-they share it with, so they can speak to it. Watch for `keeps the ... for their chest at home`
-and `put N ... away in their chest at home` in the log.
+them home and sets them down in the chest by hand ahead of sleep, lifting whatever was chosen to
+take out into the pack at the same visit, so nothing teleports here in either direction. Taking
+out (2026-09-11) is for a keepsake to use or give, or supplies the village has since run short
+of: what comes out rides in the pack and meets the next bedtime like anything else carried,
+returning to the stores then unless it is kept again. The question is asked whenever the pack or
+the chest holds anything; a chest out of sight offers nothing to take out. The camp circle's
+chest works the same way for the four who sleep there. A chest that cannot be reached, is gone,
+or is full gives the trip up: the next stow returns the kept goods as before, and what was to be
+taken out stays in the chest. The chat briefing tells a villager what their chest holds (when its
+chunk is in sight) and who they share it with, so they can speak to it. Watch for `keeps the ...
+for their chest at home`, `put N ... away in their chest at home`, `takes the ... out of their
+chest at home` and `took N ... out of their chest at home` in the log.
 
 The walk home goes to the doorstep first when it starts outside (`LocationManager.getEntrance`,
 the cell outside the lowest door nearest the building's authored front, read from the standing blocks), then to supported

--- a/src/main/java/com/quzzar/kithkyn/dev/ChestTakeOutVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/ChestTakeOutVerification.java
@@ -1,0 +1,187 @@
+package com.quzzar.kithkyn.dev;
+
+import com.quzzar.kithkyn.Kithkyn;
+import com.quzzar.kithkyn.PersonEntityType;
+import com.quzzar.kithkyn.entities.RealPerson;
+import com.quzzar.kithkyn.entities.StashOffer;
+import com.quzzar.kithkyn.entities.ai.goals.StashAtHomeGoal;
+import com.quzzar.kithkyn.village.BedAssignment;
+import com.quzzar.kithkyn.village.JobAssignment;
+import com.quzzar.kithkyn.village.Occupation;
+import com.quzzar.kithkyn.village.PersonalChest;
+import com.quzzar.kithkyn.village.Village;
+import com.quzzar.kithkyn.village.buildings.Building;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Rotation;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+
+/**
+ * Opt-in native routine regression for the two-way bedtime chest visit. Use
+ * -Dkithkyn.chestTakeOut.verify=true only in a disposable world.
+ */
+@EventBusSubscriber(modid = Kithkyn.MODID)
+public final class ChestTakeOutVerification {
+  private static int ticks;
+
+  private ChestTakeOutVerification() { }
+
+  @SubscribeEvent
+  public static void tick(ServerTickEvent.Post event) {
+    if (!Boolean.getBoolean("kithkyn.chestTakeOut.verify") || ++ticks != 40) return;
+    try {
+      verify(event.getServer().overworld());
+      Kithkyn.LOGGER.info("[chest-take-out-verify] RESULT PASS: option list shape, question raised by a stocked chest"
+          + " alone, keep and take out in one visit, take out with nothing carried, a vanished chest closes the visit");
+    } catch (Exception | AssertionError failure) {
+      Kithkyn.LOGGER.error("[chest-take-out-verify] RESULT FAIL", failure);
+    } finally {
+      event.getServer().halt(false);
+    }
+  }
+
+  private static void verify(ServerLevel level) throws ReflectiveOperationException {
+    // The question's options: each non-kit kind carried, then each kind in the chest.
+    Map<Item, Integer> carried = new LinkedHashMap<>();
+    carried.put(Items.OAK_LOG, 3);
+    carried.put(Items.STONE_PICKAXE, 1);
+    Map<Item, Integer> stored = new LinkedHashMap<>();
+    stored.put(Items.APPLE, 6);
+    List<StashOffer.Pick> picks = StashOffer.picks(carried, stored);
+    check(picks.size() == 2 && !picks.get(0).fromChest() && picks.get(0).item() == Items.OAK_LOG
+        && picks.get(1).fromChest() && picks.get(1).item() == Items.APPLE,
+        "options are not carried-then-chest with the kit left out: " + picks);
+    check(picks.get(0).option().equals("Hold back the 3 oak log from the village stores")
+        && picks.get(1).option().equals("Take the 6 apple out of your chest to carry"), "option wording: " + picks);
+
+    FixtureVillage village = new FixtureVillage();
+    FixturePerson sleeper = new FixturePerson(level, village);
+    sleeper.setUUID(UUID.fromString("9a4f1c02-6d3b-4e8a-b57c-2f0e9d1a6c43"));
+    sleeper.setOccupation(Occupation.WANDERER);
+    sleeper.reloadState();
+    BlockPos chestPos = PersonalChest.of(sleeper);
+    check(chestPos != null, "fixture bed resolved no chest of its own");
+    level.setBlock(chestPos, Blocks.CHEST.defaultBlockState(), 3);
+    Container chest = PersonalChest.container(sleeper, chestPos);
+    check(chest != null, "placed chest is not readable at " + chestPos);
+    sleeper.setPos(chestPos.getX() + 0.5D, chestPos.getY(), chestPos.getZ() + 2.5D);
+    clock(level, 18000L);
+
+    // Nothing carried beside an empty chest raises no question; a stocked chest does, with nothing carried.
+    Field offerDay = RealPerson.class.getDeclaredField("stashOfferDay");
+    offerDay.setAccessible(true);
+    sleeper.goToBed(0.5D);
+    check(offerDay.getLong(sleeper) == -1L, "question went out with nothing to keep or take");
+    chest.setItem(0, new ItemStack(Items.APPLE, 6));
+    sleeper.callToBedCoolDown = 0;
+    sleeper.goToBed(0.5D);
+    check(offerDay.getLong(sleeper) == 0L, "a stocked chest raised no question for an empty pack");
+
+    // Keep and take out in one visit: the logs go in, the apples come out.
+    sleeper.personMainInv.setItem(0, new ItemStack(Items.OAK_LOG, 3));
+    settle(sleeper, Set.of(Items.OAK_LOG), Set.of(Items.APPLE));
+    StashAtHomeGoal stash = sleeper.goal(StashAtHomeGoal.class);
+    check(stash.canUse(), "the chest visit did not start");
+    stash.start();
+    stash.tick();
+    check(sleeper.personMainInv.countItem(Items.APPLE) == 6 && sleeper.personMainInv.countItem(Items.OAK_LOG) == 0,
+        "pack after the visit: " + PersonalChest.summarize(sleeper.personMainInv));
+    check(chest.countItem(Items.OAK_LOG) == 3 && chest.countItem(Items.APPLE) == 0,
+        "chest after the visit: " + PersonalChest.summarize(chest));
+    check(sleeper.keepingForHome().isEmpty() && sleeper.takingFromHome().isEmpty() && !stash.canUse(),
+        "the visit did not close out");
+
+    // Taking out with nothing carried still makes the trip.
+    sleeper.personMainInv.clearContent();
+    settle(sleeper, Set.of(), Set.of(Items.OAK_LOG));
+    check(stash.canUse(), "a take-out with an empty pack did not start the visit");
+    stash.start();
+    stash.tick();
+    check(sleeper.personMainInv.countItem(Items.OAK_LOG) == 3 && chest.countItem(Items.OAK_LOG) == 0,
+        "take-out alone moved nothing: pack " + PersonalChest.summarize(sleeper.personMainInv)
+            + ", chest " + PersonalChest.summarize(chest));
+
+    // A chest that is gone closes the visit with nothing moved and nothing pending.
+    chest.setItem(0, new ItemStack(Items.BREAD, 2));
+    settle(sleeper, Set.of(Items.OAK_LOG), Set.of(Items.BREAD));
+    level.setBlock(chestPos, Blocks.AIR.defaultBlockState(), 3);
+    check(stash.canUse(), "the visit to a vanished chest did not start");
+    stash.start();
+    stash.tick();
+    check(sleeper.personMainInv.countItem(Items.OAK_LOG) == 3 && sleeper.personMainInv.countItem(Items.BREAD) == 0
+        && sleeper.keepingForHome().isEmpty() && sleeper.takingFromHome().isEmpty(),
+        "a vanished chest did not close the visit cleanly");
+    sleeper.discard();
+  }
+
+  /** The bedtime answer as settleStash records it, without an LLM in the loop. */
+  private static void settle(RealPerson person, Set<Item> keep, Set<Item> take) throws ReflectiveOperationException {
+    Field keeping = RealPerson.class.getDeclaredField("keepingForHome");
+    keeping.setAccessible(true);
+    keeping.set(person, keep);
+    Field taking = RealPerson.class.getDeclaredField("takingFromHome");
+    taking.setAccessible(true);
+    taking.set(person, take);
+  }
+
+  private static void clock(ServerLevel level, long time) {
+    level.setDayTime(time);
+    level.updateSkyBrightness();
+  }
+
+  private static void check(boolean condition, String reason) {
+    if (!condition) throw new AssertionError(reason);
+  }
+
+  private static final class FixturePerson extends RealPerson {
+    private final FixtureVillage village;
+
+    private FixturePerson(ServerLevel level, FixtureVillage village) {
+      super(PersonEntityType.PERSON.get(), level);
+      this.village = village;
+      setNoAi(true);
+    }
+
+    @Override public Village getVillage() { return village; }
+
+    private <T extends Goal> T goal(Class<T> type) {
+      return goalSelector.getAvailableGoals().stream().map(wrapped -> wrapped.getGoal())
+          .filter(type::isInstance).map(type::cast).findFirst().orElseThrow();
+    }
+  }
+
+  /** The birch camp circle, whose bed 0 owns the camp chest; the stores accept everything. */
+  private static final class FixtureVillage extends Village {
+    private final Building center = new Building(new BlockPos(-7000, 150, -7000),
+        "village_center_birch_forest_1", Rotation.NONE);
+    private final List<ItemStack> stored = new ArrayList<>();
+
+    private FixtureVillage() { super("Chest take-out fixture"); }
+
+    @Override public Building getBuilding(UUID id) { return center; }
+    @Override public Building getTownCenter() { return center; }
+    @Override public Collection<Building> getBuildings() { return List.of(center); }
+    @Override public JobAssignment getJobAssignment(UUID id) { return null; }
+    @Override public BedAssignment getBedAssignment(UUID id) { return new BedAssignment(id, center.getUUID(), 0); }
+    @Override public ItemStack storeAwayFrom(ItemStack stack, Collection<BlockPos> excluding, BlockPos near) {
+      stored.add(stack.copy());
+      return ItemStack.EMPTY;
+    }
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
@@ -352,6 +352,8 @@ public class RealPerson extends Person {
   // skipped by the stow, until StashAtHomeGoal sets it down in their own
   // chest; empty when nothing is being kept.
   private transient Set<Item> keepingForHome = Set.of();
+  // And what the same answer said to take out of the chest and carry.
+  private transient Set<Item> takingFromHome = Set.of();
 
   // Village-directed walk target (arriving at the campfire / leaving the
   // village); driven by Village.tickTravelers, executed by VillageTravelGoal.
@@ -1369,18 +1371,26 @@ public class RealPerson extends Person {
 
   /**
    * Once a night, a villager with a chest of their own is asked what, if
-   * anything, they would rather keep than return to the stores (StashOffer).
+   * anything, they would rather keep than return to the stores, and what, if
+   * anything, they would rather take out of the chest and carry (StashOffer).
    * True when the question went out: the stow then waits for the answer.
    */
   private boolean maybeOfferStash() {
     long day = this.level().getDayTime() / 24000L;
     // Night only: a daytime panic runs goToBed too, and that is no time to be
     // asked what to keep.
-    if (this.stashOfferDay == day || !this.level().isNight() || this.personMainInv.isEmpty()) {
+    if (this.stashOfferDay == day || !this.level().isNight()) {
       return false;
     }
     BlockPos chest = PersonalChest.of(this);
     if (chest == null) {
+      return false;
+    }
+    // Nothing carried and nothing in the chest leaves no question to ask. A
+    // chest out of sight reads as nothing to take out, the same "cannot
+    // recall" the briefing states.
+    Container home = PersonalChest.container(this, chest);
+    if (this.personMainInv.isEmpty() && (home == null || home.isEmpty())) {
       return false;
     }
     this.stashOfferDay = day;
@@ -1390,10 +1400,11 @@ public class RealPerson extends Person {
   }
 
   /**
-   * The bedtime chest question answered, or given up on: note what to keep, if
-   * anything, then the rest of the pack goes to the stores as it always did.
+   * The bedtime chest question answered, or given up on: note what to keep and
+   * what to take out of the chest, if anything, then the rest of the pack goes
+   * to the stores as it always did.
    */
-  void settleStash(Set<Item> keep) {
+  void settleStash(Set<Item> keep, Set<Item> takeOut) {
     this.stashPending = false;
     Set<Item> carried = new LinkedHashSet<>();
     for (Item item : keep) {
@@ -1402,7 +1413,8 @@ public class RealPerson extends Person {
       }
     }
     this.keepingForHome = Collections.unmodifiableSet(carried);
-    if (!this.keepingForHome.isEmpty() && this.isSleeping()) {
+    this.takingFromHome = Collections.unmodifiableSet(new LinkedHashSet<>(takeOut));
+    if ((!this.keepingForHome.isEmpty() || !this.takingFromHome.isEmpty()) && this.isSleeping()) {
       // The answer came after they had lain down. A sleeper at night is
       // immobile (Person.isImmobile) and an immobile entity ticks no goals, so
       // the walk home could only have started at dawn, and did, live: a
@@ -1421,9 +1433,15 @@ public class RealPerson extends Person {
     return this.keepingForHome;
   }
 
-  /** The kept items are put away, or the trip was given up: nothing is held back any more. */
+  /** The kinds of item this villager means to take out of their own chest tonight; empty when none. */
+  public Set<Item> takingFromHome() {
+    return this.takingFromHome;
+  }
+
+  /** The chest visit is over, done or given up: nothing is held back and nothing waits to be taken out. */
   public void doneKeeping() {
     this.keepingForHome = Set.of();
+    this.takingFromHome = Set.of();
   }
 
   /**

--- a/src/main/java/com/quzzar/kithkyn/entities/StashOffer.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/StashOffer.java
@@ -37,12 +37,13 @@ import net.minecraft.world.item.ShearsItem;
 import net.minecraft.world.item.TieredItem;
 
 /**
- * Puts one bedtime question to a villager who has a chest of their own: of
- * what they are carrying home tonight, what would they rather keep than hand
- * back to the village stores? The rules lay out the facts, what is in the
- * pack and what the chest already holds, and one option per kind of item
- * carried; the model keeps any number of them, or none, in character, over
- * the multi-pick sibling of decide() (docs/llm-brain.md).
+ * Puts one bedtime question to a villager who has a chest of their own, in
+ * two halves: of what they are carrying home tonight, what would they rather
+ * keep than hand back to the village stores, and of what the chest already
+ * holds, what would they rather take out and carry? The rules lay out the
+ * facts, what is in the pack and what the chest holds, and one option per
+ * kind of item on either side; the model picks any number of them, or none,
+ * in character, over the multi-pick sibling of decide() (docs/llm-brain.md).
  *
  * <p>The chest is for keepsakes, and the briefing says so: the village runs on
  * what its workers bring in, so the question is what is truly personal, not
@@ -53,55 +54,81 @@ import net.minecraft.world.item.TieredItem;
  * at all, since the miner once kept the bucket and the torches the restock had
  * just handed over, and the shaft flooded while they sat in a barrel at home.
  *
- * <p>Silence keeps nothing. The rules' own choice is what always happened,
- * the whole pack back to the stores, so a mute or absent model costs the
- * village no goods; only an explicit pick holds something back. What is kept
- * stays in the pack for the walk home and is set down in the chest by hand
- * ({@link com.quzzar.kithkyn.entities.ai.goals.StashAtHomeGoal}), so
- * nothing teleports. The answer lands through {@link RealPerson#settleStash},
+ * <p>Taking out (2026-09-11) is the other direction of the same visit: a
+ * keepsake to use or give, or supplies the village has since run short of.
+ * What is taken out rides in the pack and meets the next bedtime like
+ * anything else carried, so it returns to the stores then unless it is kept
+ * again. The chest is read only when its chunk is resident; out of sight it
+ * offers nothing to take out, the same "cannot recall" the briefing states.
+ *
+ * <p>Silence keeps nothing and takes nothing. The rules' own choice is what
+ * always happened, the whole pack back to the stores and the chest left as it
+ * is, so a mute or absent model costs the village no goods; only an explicit
+ * pick holds something back or lifts something out. Both happen by hand at
+ * the chest ({@link com.quzzar.kithkyn.entities.ai.goals.StashAtHomeGoal}),
+ * so nothing teleports. The answer lands through {@link RealPerson#settleStash},
  * which stows the rest of the pack: the pack is held whole while the question
  * is out, or the answer would arrive to empty pockets.
  */
 public final class StashOffer {
+
+  /** One option of the question: a kind of item, held back from the stores or taken out of the chest. */
+  public record Pick(Item item, int count, boolean fromChest) {
+    /** The option as the model reads it, naming the cost of holding back and the act of taking out. */
+    public String option() {
+      return fromChest
+          ? "Take the " + count + " " + plain(item) + " out of your chest to carry"
+          : "Hold back the " + count + " " + plain(item) + " from the village stores";
+    }
+  }
 
   private StashOffer() {
   }
 
   /**
    * Asks, and settles the villager's stash on the main thread when the answer
-   * lands. A villager carrying nothing, or a village with no brain ready, is
-   * settled at once with nothing kept.
+   * lands. A villager with nothing to keep or take out, or a village with no
+   * brain ready, is settled at once with nothing kept and nothing taken.
    */
   public static void offer(RealPerson person, BlockPos chest) {
-    Map<Item, Integer> carried = carried(person);
+    Map<Item, Integer> carried = counts(person.personMainInv);
+    Container container = PersonalChest.container(person, chest);
+    Map<Item, Integer> stored = container == null ? Map.of() : counts(container);
+    List<Pick> picks = picks(carried, stored);
     LlmService llm = LlmService.get();
     MinecraftServer server = person.getServer();
-    if (carried.isEmpty() || !llm.isReady() || server == null) {
-      person.settleStash(Set.of());
+    if (picks.isEmpty() || !llm.isReady() || server == null) {
+      person.settleStash(Set.of(), Set.of());
       return;
     }
-    List<Item> kinds = new ArrayList<>();
     List<String> options = new ArrayList<>();
-    for (Item item : carried.keySet()) {
-      if (!isKit(item)) {
-        kinds.add(item);
-      }
-    }
-    if (kinds.isEmpty()) {
-      person.settleStash(Set.of());
-      return;
-    }
-    for (Item item : kinds) {
-      options.add("Hold back the " + carried.get(item) + " " + plain(item) + " from the village stores");
+    for (Pick pick : picks) {
+      options.add(pick.option());
     }
     String purpose = person.getFullName() + "'s chest at home";
-    llm.choose(purpose, situation(person, chest, carried), options).whenComplete((selection, error) -> {
+    llm.choose(purpose, situation(person, container, carried, stored), options).whenComplete((selection, error) -> {
       if (error != null) {
         Kithkyn.LOGGER.error("'{}' could not weigh what to keep at home", person.getFullName(), error);
       }
       Optional<LlmSelection> settled = selection == null ? Optional.empty() : selection;
-      server.execute(() -> finish(person, kinds, settled));
+      server.execute(() -> finish(person, picks, settled));
     });
+  }
+
+  /**
+   * The question's options in order: each kind carried that is not the job's
+   * kit, then each kind the chest holds. The chest side has no kit filter:
+   * whatever is in there is the villager's own.
+   */
+  public static List<Pick> picks(Map<Item, Integer> carried, Map<Item, Integer> stored) {
+    List<Pick> picks = new ArrayList<>();
+    carried.forEach((item, count) -> {
+      if (!isKit(item)) {
+        picks.add(new Pick(item, count, false));
+      }
+    });
+    stored.forEach((item, count) -> picks.add(new Pick(item, count, true)));
+    return picks;
   }
 
   /**
@@ -116,13 +143,14 @@ public final class StashOffer {
   }
 
   /** The facts the model decides on, kept to a few lines so a small model reads all of them. */
-  private static String situation(RealPerson person, BlockPos chest, Map<Item, Integer> carried) {
+  private static String situation(RealPerson person, @Nullable Container container,
+      Map<Item, Integer> carried, Map<Item, Integer> stored) {
     List<String> pack = new ArrayList<>();
     carried.forEach((item, count) -> pack.add(count + " " + plain(item)));
     StringBuilder situation = new StringBuilder(CraftOffer.identityLead(person))
-        .append("You are turning in for the night carrying ").append(String.join(", ", pack))
+        .append("You are turning in for the night carrying ")
+        .append(pack.isEmpty() ? "nothing" : String.join(", ", pack))
         .append(". Your home has a small chest for keepsakes");
-    Container container = PersonalChest.container(person, chest);
     if (container == null) {
       situation.append("; you cannot recall exactly what is in it. ");
     } else {
@@ -134,8 +162,13 @@ public final class StashOffer {
         .append(" home is lost to the village's work. ").append(villageNeed(person.getVillage()))
         .append(" Most nights a worker keeps nothing. Hold something back only")
         .append(" if it is truly personal, a gift, a memento or a bite of something you fancy, never")
-        .append(" supplies or your day's produce. Give your reason in a few words.");
-    return situation.toString();
+        .append(" supplies or your day's produce.");
+    if (!stored.isEmpty()) {
+      situation.append(" You may also take something out of the chest to carry: it rides in your pack")
+          .append(" from tomorrow and goes to the stores at your next bedtime unless you keep it again,")
+          .append(" so take out only what you mean to use or give, or what the village is short of.");
+    }
+    return situation.append(" Give your reason in a few words.").toString();
   }
 
   /**
@@ -177,34 +210,41 @@ public final class StashOffer {
         + (shortfall.isEmpty() ? " and has everything it needs for it." : " and is still short " + shortfall + ".");
   }
 
-  private static void finish(RealPerson person, List<Item> kinds, Optional<LlmSelection> selection) {
+  private static void finish(RealPerson person, List<Pick> picks, Optional<LlmSelection> selection) {
     if (!person.isAlive()) {
       return;
     }
     Set<Item> keep = new LinkedHashSet<>();
+    Set<Item> takeOut = new LinkedHashSet<>();
     if (selection.isEmpty()) {
-      Kithkyn.LOGGER.debug("'{}' had no answer on what to keep at home, so the pack goes to the stores",
+      Kithkyn.LOGGER.debug("'{}' had no answer on their chest at home, so the pack goes to the stores and the chest stays as it is",
           person.getFullName());
     } else {
       for (int index : selection.get().choiceIndexes()) {
-        keep.add(kinds.get(index));
+        Pick pick = picks.get(index);
+        (pick.fromChest() ? takeOut : keep).add(pick.item());
       }
-      if (keep.isEmpty()) {
-        Kithkyn.LOGGER.info("'{}' keeps nothing back tonight: {}", person.getFullName(),
+      if (keep.isEmpty() && takeOut.isEmpty()) {
+        Kithkyn.LOGGER.info("'{}' keeps nothing back tonight and leaves the chest as it is: {}", person.getFullName(),
             selection.get().reason());
-      } else {
+      }
+      if (!keep.isEmpty()) {
         Kithkyn.LOGGER.info("'{}' keeps the {} for their chest at home: {}", person.getFullName(),
             names(keep), selection.get().reason());
       }
+      if (!takeOut.isEmpty()) {
+        Kithkyn.LOGGER.info("'{}' takes the {} out of their chest at home: {}", person.getFullName(),
+            names(takeOut), selection.get().reason());
+      }
     }
-    person.settleStash(keep);
+    person.settleStash(keep, takeOut);
   }
 
-  /** Each kind of item in the pack with how many, in pack order. */
-  private static Map<Item, Integer> carried(RealPerson person) {
+  /** Each kind of item in a container with how many, in slot order. */
+  public static Map<Item, Integer> counts(Container container) {
     Map<Item, Integer> counts = new LinkedHashMap<>();
-    for (int slot = 0; slot < person.personMainInv.getContainerSize(); slot++) {
-      ItemStack stack = person.personMainInv.getItem(slot);
+    for (int slot = 0; slot < container.getContainerSize(); slot++) {
+      ItemStack stack = container.getItem(slot);
       if (!stack.isEmpty()) {
         counts.merge(stack.getItem(), stack.getCount(), Integer::sum);
       }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/StashAtHomeGoal.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/StashAtHomeGoal.java
@@ -1,6 +1,8 @@
 package com.quzzar.kithkyn.entities.ai.goals;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 import com.quzzar.kithkyn.Kithkyn;
@@ -20,10 +22,12 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.phys.Vec3;
 
 /**
- * The walk that follows a bedtime "keep it": a villager who chose to hold
- * things back from the village stores ({@link StashOffer}) carries them home
- * and sets them down in their own chest by hand. Runs ahead of
- * {@link SleepAtNightGoal}, which takes over the moment the pack is put away.
+ * The walk that follows a bedtime "keep it" or "take it out": a villager who
+ * chose to hold things back from the village stores ({@link StashOffer})
+ * carries them home and sets them down in their own chest by hand, and one
+ * who chose to take things out lifts them from the chest into the pack at the
+ * same visit. Runs ahead of {@link SleepAtNightGoal}, which takes over the
+ * moment the chest is done.
  *
  * <p>Two legs when the walk starts outside: to the doorstep first, then to
  * a standing position with hand access to the chest ({@link LocationManager#getEntrance}). A path aimed straight at a
@@ -38,8 +42,9 @@ import net.minecraft.world.phys.Vec3;
  * a path reaches proved worthless live: a villager who has not come closer
  * to the leg's target for a stretch (stood at the foot of a ladder, or found
  * no way in) gives up, as does one still walking after a few minutes. A chest
- * that is gone or full gives up on arrival. In every case the items stay in
- * the pack and the next bedtime stow returns them to the stores as before.
+ * that is gone or full gives up on arrival. In every case what was to be kept
+ * stays in the pack, where the next bedtime stow returns it to the stores as
+ * before, and what was to be taken out stays in the chest.
  */
 public class StashAtHomeGoal extends Goal {
 
@@ -77,7 +82,8 @@ public class StashAtHomeGoal extends Goal {
   @Override
   public boolean canUse() {
     Set<Item> keeping = person.keepingForHome();
-    if (keeping.isEmpty()) {
+    Set<Item> taking = person.takingFromHome();
+    if (keeping.isEmpty() && taking.isEmpty()) {
       return false;
     }
     if (!person.level().isNight()) {
@@ -86,7 +92,7 @@ public class StashAtHomeGoal extends Goal {
       person.doneKeeping();
       return false;
     }
-    if (keeping.stream().noneMatch(item -> person.personMainInv.countItem(item) > 0)) {
+    if (taking.isEmpty() && keeping.stream().noneMatch(item -> person.personMainInv.countItem(item) > 0)) {
       person.doneKeeping(); // already set down, or stowed by a refire
       return false;
     }
@@ -100,8 +106,8 @@ public class StashAtHomeGoal extends Goal {
 
   @Override
   public boolean canContinueToUse() {
-    return !person.keepingForHome().isEmpty() && this.chest != null && this.ticks < GIVE_UP_TICKS
-        && person.level().isNight();
+    return (!person.keepingForHome().isEmpty() || !person.takingFromHome().isEmpty())
+        && this.chest != null && this.ticks < GIVE_UP_TICKS && person.level().isNight();
   }
 
   @Override
@@ -163,15 +169,15 @@ public class StashAtHomeGoal extends Goal {
       this.stalledTicks++;
     }
     if (this.stalledTicks >= STALL_TICKS) {
-      Kithkyn.LOGGER.info("'{}' made no headway toward their chest at home ({} blocks off, {}); the {} stays in the pack",
+      Kithkyn.LOGGER.info("'{}' made no headway toward their chest at home ({} blocks off, {}); {}",
           person.getFullName(), Math.round(distance), this.indoors ? "indoors" : "on the way to the door",
-          StashOffer.names(person.keepingForHome()));
+          pending());
       person.doneKeeping();
       return;
     }
     if (this.ticks >= GIVE_UP_TICKS) {
-      Kithkyn.LOGGER.info("'{}' could not reach their chest at home tonight; the {} stays in the pack",
-          person.getFullName(), StashOffer.names(person.keepingForHome()));
+      Kithkyn.LOGGER.info("'{}' could not reach their chest at home tonight; {}",
+          person.getFullName(), pending());
       person.doneKeeping();
       return;
     }
@@ -199,25 +205,49 @@ public class StashAtHomeGoal extends Goal {
     }
   }
 
+  /** What an abandoned visit leaves where it is: "the wheat stays in the pack, the apple stays in the chest". */
+  private String pending() {
+    List<String> parts = new ArrayList<>();
+    if (!person.keepingForHome().isEmpty()) {
+      parts.add("the " + StashOffer.names(person.keepingForHome()) + " stays in the pack");
+    }
+    if (!person.takingFromHome().isEmpty()) {
+      parts.add("the " + StashOffer.names(person.takingFromHome()) + " stays in the chest");
+    }
+    return String.join(", ", parts);
+  }
+
+  /** At the chest: set the kept kinds down first, which frees the pack, then lift the taken kinds out. */
   private void putAway() {
     Set<Item> keeping = person.keepingForHome();
+    Set<Item> taking = person.takingFromHome();
     Container container = PersonalChest.container(person, this.chest);
     if (container == null) {
-      Kithkyn.LOGGER.info("'{}' found no chest at home to keep the {} in", person.getFullName(),
-          StashOffer.names(keeping));
+      Kithkyn.LOGGER.info("'{}' found no chest at home; {}", person.getFullName(), pending());
       person.doneKeeping();
       return;
     }
-    int moved = 0;
+    int put = 0;
     for (Item item : keeping) {
-      moved += PackLogistics.depositCarried(person, container, item, "home");
+      put += PackLogistics.depositCarried(person, container, item, "home");
     }
-    if (moved > 0) {
+    if (put > 0) {
       Kithkyn.LOGGER.info("'{}' put {} item(s) of {} away in their chest at home", person.getFullName(),
-          moved, StashOffer.names(keeping));
-    } else {
+          put, StashOffer.names(keeping));
+    } else if (!keeping.isEmpty()) {
       Kithkyn.LOGGER.info("'{}' found no room in their chest at home for the {}", person.getFullName(),
           StashOffer.names(keeping));
+    }
+    int took = 0;
+    for (Item item : taking) {
+      took += PackLogistics.takeStored(person, container, item, "home");
+    }
+    if (took > 0) {
+      Kithkyn.LOGGER.info("'{}' took {} item(s) of {} out of their chest at home", person.getFullName(),
+          took, StashOffer.names(taking));
+    } else if (!taking.isEmpty()) {
+      Kithkyn.LOGGER.info("'{}' found none of the {} left in their chest at home, or no room in the pack for it",
+          person.getFullName(), StashOffer.names(taking));
     }
     person.doneKeeping();
   }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/PackLogistics.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/PackLogistics.java
@@ -184,6 +184,38 @@ public final class PackLogistics {
   }
 
   /**
+   * Lift everything of this item the chest holds into the worker's pack,
+   * dropping nothing: whatever does not fit stays in the chest. The mirror of
+   * depositCarried, for the bedtime "take it out". Returns how many items moved.
+   */
+  public static int takeStored(RealPerson person, Container chest, Item item, String role) {
+    return takeMatching(person, chest, stack -> stack.is(item), role);
+  }
+
+  /** The same lift for whatever passes the test rather than one item. */
+  public static int takeMatching(RealPerson person, Container chest,
+      java.util.function.Predicate<ItemStack> take, String role) {
+    Container pack = person.personMainInv;
+    int moved = 0;
+    for (int slot = 0; slot < chest.getContainerSize(); slot++) {
+      ItemStack stack = chest.getItem(slot);
+      if (stack.isEmpty() || !take.test(stack)) {
+        continue;
+      }
+      int before = stack.getCount();
+      ItemStack leftover = net.minecraft.world.level.block.entity.HopperBlockEntity
+          .addItem(chest, pack, stack, null);
+      chest.setItem(slot, leftover);
+      moved += before - leftover.getCount();
+    }
+    if (moved > 0) {
+      Kithkyn.LOGGER.debug("[resource-flow] {} ({}) lifted {} item(s) out of a chest",
+          person.getName().getString(), role, moved);
+    }
+    return moved;
+  }
+
+  /**
    * Offers every non-kept pack stack to a storage operation and writes the
    * returned remainder back into the same slot. Nothing leaves the pack until
    * the destination accepts it, so a full village cannot turn a failed bedtime


### PR DESCRIPTION
## Summary
- The bedtime chest question (`StashOffer`) now has two halves: the existing "Hold back the N X from the village stores" options for what the pack carries, plus "Take the N Y out of your chest to carry" for each kind the chest holds. The chest side has no kit filter: whatever is in there is the villager's own. The briefing adds one sentence on what taking out means, and the question is now asked whenever the pack or the chest holds anything, not only when the pack does. A chest out of sight offers nothing to take out.
- What is taken out rides in the pack and meets the next bedtime like anything else carried: back to the stores then unless it is kept again. So a keepsake can be used or given, and supplies the village has since run short of come back a day later.
- `StashAtHomeGoal` does both transfers in one visit, kept items set down first so the pack has room, then the taken kinds lifted out (`PackLogistics.takeStored`, the mirror of `depositCarried`). A visit given up leaves the taken kinds in the chest; the give-up and no-chest log lines now say what stays where.
- `RealPerson` keeps a `takingFromHome` set beside `keepingForHome`; `settleStash` takes both; `doneKeeping` clears both.
- `docs/worker-loops.md` and `docs/llm-brain.md` updated in the same change.

## Verification
- `./gradlew test` passes.
- New `ChestTakeOutVerification` (`-Dkithkyn.chestTakeOut.verify=true`, disposable flat world, a real chest block at the birch camp circle's chest position) passes: option list shape with the kit left out, no question for an empty pack beside an empty chest, a question for a stocked chest alone, keep and take out in one visit, take out with nothing carried, and a vanished chest closing the visit with nothing moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
