### PR TITLE
Reclassify SC01.2 as the Swamp castle

### DIFF
--- a/docs/castles.md
+++ b/docs/castles.md
@@ -61,13 +61,18 @@ unreachable shortcut onto target decorations. Native checks passed 92 access rou
 deposits and twelve shared-container deposits across all four rotations. Rendered inspection
 confirmed the two barrels and preserved castle appearance before deployment.
 
-## Floodplain castle
+## Swamp castle
 
-The Floodplain castle is the user-edited SC01.2 Overgrown Stone Fort, derived from the
+The Swamp castle is the user-edited SC01.2 Overgrown Stone Fort, derived from the
 Towns and Towers Jungle Fort and restyled with spruce, dark oak, mossed stone and ordinary
-oak foliage. Its final gallery capture stands at `10107, 230, 1308`; the private source and
-production assets live under `run/floodplain-integration/castle/`, while
-`tools/structure/floodplain-castle-20260911.json` records the public metadata and provenance.
+oak foliage. It belongs to the planned ordinary Swamp village, separate from the playable
+Floodplain village for mangrove biomes. Its final gallery capture stands at `10107, 230, 1308`;
+the private staged assets live under `run/swamp-integration/castle/`, while
+`tools/structure/swamp-castle-20260911.json` records the public metadata and provenance.
+
+This building uses the same castle category, ruler, custody, evidence, housing and guard systems
+as the Desert castle. It is a different physical structure: Desert uses R07.2, while Swamp uses
+SC01.2. The Swamp definition remains staged until the complete Swamp catalog and style token land.
 
 The two residential wings provide nine general single beds with shared personal barrels.
 The upstairs ruler suite has a reserved double bed and its own chest. The castle adds a
@@ -91,6 +96,9 @@ The roof is reached by the central ladder. Native testing of all rotations expos
 general navigation problems and fixed them in the shared runtime: a body on a rung now
 advances by occupying that exact rung rather than by an unstable fractional-height test,
 and personal-container routing avoids stepping over beds when a floor route exists.
+The export removed no authored block positions. It only closed the two halves of one spruce
+door for the template's starting state and wrote explicit air into otherwise empty interior
+cells so terrain cannot fill the rooms.
 All 28 sentry runs reached every assigned waypoint across four rotations. The custody fixture
 also passed melee and arrow arrest, all 41 ordinary inventory slots, evidence overflow,
 five-minute reminders, persistence, escape, damaged-cell release and obstructed-exit fallback.

--- a/docs/floodplain-village.md
+++ b/docs/floodplain-village.md
@@ -13,9 +13,8 @@ NeoForge's conventional tags it builds Floodplain until that exists.
 
 ## Selected buildings
 
-The public selection records are `tools/structure/nilotic-selections-20260910.json` and
-`tools/structure/floodplain-castle-20260911.json`; the catalog record is
-`tools/structure/floodplain-catalog-20260910.json`. The datapack holds twenty-one
+The public selection record is `tools/structure/nilotic-selections-20260910.json`; the catalog
+record is `tools/structure/floodplain-catalog-20260910.json`. The datapack holds twenty
 definitions, all new ids, so the pack needs no filter:
 
 | Id | Source exhibit | Beds | Stations |
@@ -37,9 +36,8 @@ definitions, all new ids, so the pack needs no filter:
 | `couple_cottage_floodplain_1` | Nilotic small house 1 with the couple bed | 2 | none |
 | `market_floodplain_1`, `_2`, `_3` | the Desert market tiers restyled | 0 | one to three merchants |
 | `farm_floodplain_1`, `_2` | the Polynesian small and large farms | 0 | farmer |
-| `castle_floodplain_1` | user-edited, swamp-restyled Towns and Towers Jungle Fort | 11 | ruler, baker, blacksmith, jailer, two sword guards and five crossbow guards |
 
-There is no separate tavern or bakery, though the optional castle supplies a baker station.
+There is no separate tavern, bakery or castle.
 There is only one storehouse level: more storehouses are the answer to storage strain, and
 the adopted allays help there
 ([allay-quartermasters.md](allay-quartermasters.md)). The market tiers and the farms are
@@ -79,12 +77,9 @@ and slabs, mud brick walls as railings, jungle trapdoors, muddy mangrove roots o
 gatehouse uprights and roof rim, brown candle clusters on every standing lamp, and the four
 hanging gate lanterns kept. Wall bills are priced in mud bricks.
 
-The castle is an optional late village building rather than part of founding. Its nine
-general single beds occupy two residential wings; the ruler and spouse share the reserved
-double room. The jail evidence barrels above the cell door are excluded from village storage.
-Two sword-and-shield guards patrol the entrance, two crossbow guards cover the balconies,
-and three crossbow guards cover the roof. The baker and blacksmith use their authored work
-areas. All eight banners receive village heraldry.
+The user-edited SC01.2 castle is reserved for the separate ordinary Swamp village. It was
+briefly exported here as `castle_floodplain_1` due to a catalog ownership error, then removed
+without changing the other twenty Floodplain buildings.
 
 ## Authoring and local installation
 
@@ -124,9 +119,7 @@ rule, lodge composting, the sunk well and the mine ramp that starts at the pit's
 Ruwaleni was deleted and the site founded again as Mavulena, centre -3984 66 5344, so its mine and any
 well it raises follow the new data.
 
-The September 11 castle pass captured the final user-edited SC01.2 structure at
-`10107, 230, 1308`, removed container contents and closed doors for production, and passed
-the no-barrier audit. Native access verification walks every bed, personal barrel, shared
-store, workstation and roof ladder in all four rotations with an adult two-block collision
-body. Separate native checks cover all seven sentry posts on routes local to their assigned
-entrance, balcony or roof level, plus the five-minute custody cycle.
+The September 11 review confirmed that SC01.2 belongs to Swamp rather than Floodplain. The
+completed structure and its successful access, sentry and custody results are retained under
+`tools/structure/swamp-castle-20260911.json`; it is staged outside this production datapack
+until the Swamp catalog is complete.

--- a/docs/structure-review.md
+++ b/docs/structure-review.md
@@ -1779,9 +1779,9 @@ with the ramp mouth one column in. The Desert mine gained a shared chest at the 
 posts, a fence, a trapdoor and a lantern, exported in its existing frame. Both were captured from a flushed
 snapshot, re-exported, checked and installed in their packs.
 
-### Floodplain castle: September 11
+### Swamp castle: September 11
 
-Aaron selected SC01.2, the Towns and Towers Jungle Fort, as the Floodplain castle. The
+Aaron selected SC01.2, the Towns and Towers Jungle Fort, as the Swamp castle. The
 restyle replaced the dark tropical timber with spruce and dark-oak accents, retained the
 mossed stone silhouette, removed cobwebs and converted eight banners into village identity
 slots. Aaron then rebuilt the interior into two residential wings with nine single beds, a
@@ -1794,7 +1794,7 @@ one-block standing cell. It flood-fills only supported interior tiles, rejects o
 large courtyards, and treats crossing the room boundary as escape.
 
 The final gallery structure at `10107, 230, 1308` was captured from a flushed snapshot and
-exported as `castle_floodplain_1`; empty space above its ground course is explicit so terrain
+staged as `castle_swamp_1`; empty space above its ground course is explicit so terrain
 cannot fill the rooms. Container contents are stripped, doors start closed, and the template
 contains no barrier states. Native access testing uses a two-block adult and covers all beds,
 personal barrels, shared stores, stations, ladders and rotations. It exposed and fixed a
@@ -1802,7 +1802,12 @@ rotation-sensitive ladder transition and a container route that preferred steppi
 bed over clear floor. Guard and custody fixtures exercise the seven sentries and five-minute
 jail flow separately. The five upper sentries use station-specific balcony and roof routes so
 they do not crowd the central ladder. Public provenance and coordinates are recorded in
-`tools/structure/floodplain-castle-20260911.json`.
+`tools/structure/swamp-castle-20260911.json`.
+
+The first integration mistakenly placed this building in the Floodplain catalog. Floodplain is
+the separate mangrove/Nilotic village, so the castle was removed from that datapack and retained
+for the planned ordinary Swamp catalog. A source-to-export audit found zero authored block
+positions removed; the only authored state change closes one two-block spruce door.
 
 ### Jungle catalog verified: September 10
 

--- a/docs/village-biomes.md
+++ b/docs/village-biomes.md
@@ -34,7 +34,7 @@ its production catalog and founding behavior are verified.
 | Taiga | Taiga, Old Growth Pine Taiga, Old Growth Spruce Taiga, and compatible cold forests | Cold forest settlement; its final visual language is deliberately deferred between the ornate Polish family and the grittier T&T Viking family |
 | Tundra | Snowy Plains, Ice Spikes, and compatible exposed frozen lowlands | Compact igloos and snowbound buildings suited to treeless terrain |
 | Alpine | Meadow, Grove, Snowy Slopes, and compatible mountain valleys and peaks | Swiss-inspired mountain settlement with steep roofs and slope-conscious buildings |
-| Swamp | Swamp, Orchid Swamp, and compatible ordinary wetlands | Boat-based or overgrown wetland village, distinct from the mud-brick Floodplain catalog |
+| Swamp | Swamp, Orchid Swamp, and compatible ordinary wetlands | Boat-based or overgrown wetland village, distinct from the mud-brick Floodplain catalog; SC01.2 is its configured castle |
 | Polynesian Coast | Sparse Jungle, tropical beaches, warm-ocean islands, and compatible tropical coasts | Open, warm-climate coastal buildings based on the Polynesian reference family |
 | Nautical Coast | Beach, Stony Shore, and compatible temperate or cold coasts | Fishing town, docks, shoreline buildings, and lighthouse landmarks |
 | Savanna Tent | Savanna, Savanna Plateau, Windswept Savanna, and compatible dry grasslands | African-inspired tent and grassland settlement with portable-looking structures and a coherent warm-climate material palette |

--- a/tools/structure/floodplain-catalog-20260910.json
+++ b/tools/structure/floodplain-catalog-20260910.json
@@ -3,8 +3,7 @@
   "status": "verified_and_locally_deployed",
   "source_policy": "Locally approved playable datapack, excluded from public distribution. Source provenance is retained; written redistribution permission is not asserted.",
   "manifests": [
-    "tools/structure/nilotic-selections-20260910.json",
-    "tools/structure/floodplain-castle-20260911.json"
+    "tools/structure/nilotic-selections-20260910.json"
   ],
   "selected": [
     {
@@ -286,20 +285,6 @@
       "definition_sha256": "e14c5fc8f76598f8cb743864e94c4e91a21114b196e3232d0210e5b7f7dd6755",
       "reviewed_capture": "run/nilotic-showcase/selection-20260910-floodplain/captures/NG04.1.nbt",
       "reviewed_capture_sha256": "9bf52e9a72cb1b3e75c194d6d6d19b4431b7d82d43b72defcb203caeedc00e74"
-    },
-    {
-      "exhibit": "SC01.2",
-      "structure": "castle_floodplain_1",
-      "manifest": "tools/structure/floodplain-castle-20260911.json",
-      "recipe": "castle_1",
-      "source_mod": "t_and_t-neoforge-fabric-1.13.9+1.21.1.jar",
-      "source_mod_structure": "data/kaisyn/structure/outpost/forts/jungle/base_plate.nbt",
-      "asset": "run/floodplain-integration/datapack/data/kithkyn/structure/castle_floodplain_1.nbt",
-      "asset_sha256": "5e1c3ebe75c056d5f72e0465aad11432502732dc235033b588f42b50958ccc88",
-      "definition": "run/floodplain-integration/datapack/data/kithkyn/kithkyn/buildings/castle_floodplain_1.json",
-      "definition_sha256": "78fd107447545b8db7e6b14955576b53b6a38a5bdbf61f19725f7ec61675a399",
-      "reviewed_capture": "run/floodplain-integration/castle/source-capture.nbt",
-      "reviewed_capture_sha256": "72e2ac81744a032e029267255cc2da8879e4674f8cc038516e4053e753760f6a"
     }
   ],
   "excluded": [
@@ -335,19 +320,13 @@
   "exporter": "run/floodplain-integration/prepare.py",
   "native_writer": "tools/structure/VillageTemplateExport.java (with the entities plan key)",
   "verification": {
-    "static": "run/floodplain-integration/check.py: 21 definitions and templates",
+    "static": "run/floodplain-integration/check.py: 20 definitions and templates",
     "unit_tests": "482 tests, 0 failures, 8 skipped",
     "allay_run": "run/allay-verification/run.py RESULT PASS",
     "placement_and_restart": "run/floodplain-integration/placement/verification.json",
     "center": "run/floodplain-integration/center/verification.json",
     "access": "run/floodplain-integration/access/verification.json",
-    "founding": "run/floodplain-integration/founding/verification.json",
-    "castle": {
-      "access": "run/swamp-castle-study-20260911/user-final-verification/access/verification.json",
-      "patrol": "run/swamp-castle-study-20260911/user-final-verification/patrol/verification.json",
-      "custody": "run/swamp-castle-study-20260911/user-final-verification/custody/verification.json",
-      "barrier_audit": "passed"
-    }
+    "founding": "run/floodplain-integration/founding/verification.json"
   },
   "datapack": "run/floodplain-integration/datapack",
   "recipe_catalog": "src/main/resources/data/kithkyn/kithkyn/construction_recipes",
@@ -423,10 +402,12 @@
     },
     {
       "date": "2026-09-11",
-      "structures": [
+      "note": "SC01.2 was selected for the separate Swamp village but was initially exported into Floodplain in error. It is now staged as castle_swamp_1 and has been removed from the Floodplain catalog.",
+      "removed_structures": [
         "castle_floodplain_1"
       ],
-      "note": "Captured Aaron's final SC01.2 castle edit with eleven beds, a ruler suite, baker, blacksmith, jailer, two entrance guards, two balcony guards, three roof guards and two non-village evidence barrels. Each sentry has a route local to its assigned floor and post."
+      "moved_to": "tools/structure/swamp-castle-20260911.json",
+      "verification": "Static audit and native founding fixture pass with 20 Floodplain definitions, 2 housing alternatives, 12 upgrade fits and all four founding rotations."
     }
   ]
 }

--- a/tools/structure/swamp-castle-20260911.json
+++ b/tools/structure/swamp-castle-20260911.json
@@ -1,15 +1,26 @@
 {
   "exhibit": "SC01.2",
-  "label": "Floodplain Castle",
+  "label": "Swamp Castle",
   "gallery_origin": [10107, 230, 1308],
   "capture_size": [31, 27, 31],
   "source_exhibit": "JH01.4",
   "source_mod": "t_and_t-neoforge-fabric-1.13.9+1.21.1.jar",
   "source_mod_structure": "data/kaisyn/structure/outpost/forts/jungle/base_plate.nbt",
   "source_mod_sha256": "fbac5e09371f93ff7be44b193be4436c585081ed6fc5a569ac6e62571cece708",
-  "source_capture": "run/floodplain-integration/castle/source-capture.nbt",
+  "source_capture": "run/swamp-integration/castle/source-capture.nbt",
   "source_capture_sha256": "72e2ac81744a032e029267255cc2da8879e4674f8cc038516e4053e753760f6a",
-  "status": "verified",
+  "status": "configured_and_verified_pending_swamp_catalog",
+  "runtime_model": {
+    "shared_with": "castle_desert_1",
+    "new_building_category": false,
+    "structure_relationship": "Same ruler, custody, evidence, housing and guard systems; different authored building and role layout.",
+    "shared_navigation_extensions": [
+      "A climber advances after occupying the next ladder rung.",
+      "Container routes prefer clear floor over crossing a bed.",
+      "Each sentry station may declare its own local patrol route.",
+      "Custody accepts a bounded multi-block room as one cell."
+    ]
+  },
   "capacity": {
     "beds": 11,
     "general_single_beds": 9,
@@ -79,20 +90,22 @@
     {"pos": [9, 10, 17], "reason": "The cake blocks a reliable hand approach to the baker counter."},
     {"pos": [10, 14, 20], "reason": "Decorative and outside the resident route."}
   ],
-  "production": {
-    "definition": "run/floodplain-integration/datapack/data/kithkyn/kithkyn/buildings/castle_floodplain_1.json",
-    "template": "run/floodplain-integration/datapack/data/kithkyn/structure/castle_floodplain_1.nbt",
+  "staged": {
+    "definition": "run/swamp-integration/castle/castle_swamp_1.json",
+    "template": "run/swamp-integration/castle/castle_swamp_1.nbt",
     "template_sha256": "5e1c3ebe75c056d5f72e0465aad11432502732dc235033b588f42b50958ccc88",
-    "definition_sha256": "78fd107447545b8db7e6b14955576b53b6a38a5bdbf61f19725f7ec61675a399"
+    "definition_sha256": "c1bb5047e102a939db6dff891cff4150f38170350753fe9a7a9c5e733c2ae214"
   },
   "verification": {
     "barrier_audit": "passed",
-    "static_pack": "run/floodplain-integration/check.py: 21 definitions and templates",
+    "authored_blocks_removed": 0,
+    "export_state_changes": "The two halves of one authored spruce door start closed; all other authored block states are preserved.",
     "physical_access": "run/swamp-castle-study-20260911/user-final-verification/access/verification.json",
     "guard_patrols": "run/swamp-castle-study-20260911/user-final-verification/patrol/verification.json: 28 sentry runs across four rotations",
     "custody": "run/swamp-castle-study-20260911/user-final-verification/custody/verification.json: all custody, evidence, timer, escape and safe-release checks passed",
     "visual_review": "run/swamp-castle-study-20260911/sc01-2-restyle/render/client/screenshots/"
   },
+  "catalog_status": "Reserved for the separate Swamp catalog; not installed in the playable Floodplain datapack.",
   "source_policy": "Towns and Towers source and derived NBT remain private under run/.",
   "design_document": "docs/castles.md"
 }


### PR DESCRIPTION
SC01.2 was selected as the ordinary Swamp village castle but was mistakenly exported into the separate mangrove/Nilotic Floodplain catalog. This removes it from Floodplain, stages it as `castle_swamp_1`, and corrects the public design and provenance records.

The castle continues to use the existing shared ruler, custody, evidence, housing, and guard systems. Its geometry remains intact: the export removes zero authored block positions, closes one two-block spruce door, and fills otherwise empty interior cells with explicit air.

Validation:
- Floodplain static audit: 20 definitions and templates
- Floodplain native founding: 20 strict templates, 2 housing alternatives, 12 upgrade fits, 4 founding rotations and natural biome selection
- Swamp castle source/export comparison: 0 authored positions removed; only 2 spruce-door block states changed
- staged Swamp template and definition hashes match the public record
