### PR TITLE
Keep a mine plug in until nothing wet is left beside it

### DIFF
--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -630,7 +630,13 @@ a leak can be stood on is not modelled, because a leak at the far edge of a lake
 a miner with dirt in hand should simply plug it (Aaron, 2026-09-11). Without a bucket the water
 itself is plugged the same way, source by source, nearest the face first, and the plugs are
 quarried back out as ordinary rock once the pocket is dry, so a bucketless village still tunnels
-through a pond or a lake bed at the cost of its lining. A bucket-holder drains the connected water
+through a pond or a lake bed at the cost of its lining. A plug stays in while anything wet is left
+beside it: a solid ramp or rib cell with water against it is lining, not frontier, so the sweep and
+the frontier recovery work that water first instead of breaking the cell, and the seal-before-break
+pass plugs interior water beside a face the way it seals a leak outside it. Without that rule the
+first plug was met as stone on the very next pick and dug, the pocket refilled it, and Calirra's
+miner laid and dug the same block seven hundred times in an hour (2026-09-11). A bucket-holder
+drains the connected water
 that is reachable from the dry side instead, exposing any farther boundary for the next sealing pass. The bucket
 moves into the off hand before that act, swings from the off hand, remains visible for a short
 beat, and then returns to the pack. It is a reusable tool, never filled or consumed. Bailing
@@ -662,11 +668,12 @@ one quiet pocket update and seals the newly exposed source edge before excavatin
 neighbour updates per removed cell is not equivalent: the source can refill the head of the pocket
 while its tail is still being emptied. Any already-scheduled fluid ticks inside that drained pocket
 are cancelled; sealing its source edge performs the normal neighbour update that resumes the
-surrounding simulation outside the mine. She never fills planned walking cells with a temporary wall:
-that wall eventually separated her from the leak it was meant to approach.
-A flooded rib whose outside edge still cannot be reached is closed at its own doorway, so its water
-does not block another rib or the main ramp. With no bucket, genuinely unreachable water remains an
-obstacle and only that excavation front falls back to its ordinary rib-mining behavior.
+surrounding simulation outside the mine. A plug is the one fill of a planned walking cell, and it is
+temporary by construction, quarried once its pocket is dry; the earlier bulkhead, a wall left
+standing in the ramp, eventually separated her from the leak it was meant to approach and is gone.
+A flooded rib is worked the same way as the ramp: its water is bailed or plugged and its plugs
+quarried once dry. Lava is never plugged or bailed, so a face beside it keeps the old rules and lava
+ends a ramp for good.
 
 Mine supports are a family, not exact cobblestone. Any placeable dirt-family block, natural stone,
 cobbled stone, or sandstone can pay for a floor, wall, ceiling, or vein plug, and the actual block

--- a/src/main/java/com/quzzar/kithkyn/dev/WorkerRecoveryVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/WorkerRecoveryVerification.java
@@ -133,7 +133,9 @@ public final class WorkerRecoveryVerification {
       }
     }
     miner.setItemSlot(EquipmentSlot.MAINHAND, new ItemStack(Items.STONE_PICKAXE));
-    miner.personMainInv.setItem(0, new ItemStack(Items.DIRT, 64));
+    // Twenty dirt against thirty leaks and seventy-five wet cells: without a bucket
+    // the support runs out mid-pocket, so the ribs must be cut for stone on the way.
+    miner.personMainInv.setItem(0, new ItemStack(Items.DIRT, bucket ? 64 : 20));
     if (bucket) {
       for (int slot = 1; slot < miner.personMainInv.getContainerSize(); slot++) {
         miner.personMainInv.setItem(slot, new ItemStack(Items.APPLE, 64));
@@ -146,15 +148,25 @@ public final class WorkerRecoveryVerification {
     BlockPos leftRib = world(shaft, new BlockPos(-3, -18, 16));
     BlockPos rightRib = world(shaft, new BlockPos(3, -18, 16));
     BlockPos flooded = world(shaft, new BlockPos(0, -19, 17));
-    for (int pick = 0; pick < 50 && !level.getBlockState(leftRib).isAir()
-        && !level.getBlockState(rightRib).isAir(); pick++) {
-      BlockPos stand = mine.select(miner);
-      check(stand != null, "flooded ramp selected no work: " + rotation);
-      standAt(miner, stand);
-      mine.acquired(miner, stand);
-      for (int act = 0; act < 2000 && mine.act(miner, stand); act++) { }
-      mine.released(miner, stand);
-      if (bucket && level.getFluidState(flooded).isEmpty()) break;
+    if (bucket) {
+      for (int pick = 0; pick < 50 && !level.getFluidState(flooded).isEmpty(); pick++) {
+        pick(level, mine, miner, "flooded ramp selected no work: " + rotation);
+      }
+    } else {
+      // Without a bucket the pocket is plugged source by source, never quarried while
+      // wet, and the plugs come out as ordinary rock once it is dry, back into the
+      // pack. The loop that laid and dug the same plug 700 times in an hour at
+      // Calirra (2026-09-11) reached neither milestone, and never ran short.
+      int picks = 0;
+      while (picks < 600 && (wetPocket(level, shaft) || !level.getBlockState(flooded).isAir())) {
+        pick(level, mine, miner, "plugging pocket selected no work: " + rotation + " at pick " + picks);
+        picks++;
+      }
+      check(!wetPocket(level, shaft), "flooded frontier never dried without a bucket: " + rotation);
+      check(level.getBlockState(flooded).isAir(), "dry plugs were not quarried back out: " + rotation);
+      BlockPos lining = world(shaft, new BlockPos(3, -19, 17));
+      check(!level.getBlockState(lining).isAir() && level.getFluidState(lining).isEmpty(),
+          "a sealed leak outside the corridor was quarried with the plugs: " + rotation);
     }
     if (bucket) {
       check(level.getFluidState(flooded).isEmpty(), "food in the offhand prevented bailing");
@@ -172,7 +184,7 @@ public final class WorkerRecoveryVerification {
     }
     check(level.getBlockState(leftRib).isAir() || level.getBlockState(rightRib).isAir(),
         "miner never resumed dry side cuts: " + rotation);
-    check(miner.personMainInv.countItem(Items.DIRT) < 64, "miner skipped reachable lining: " + rotation);
+    check(miner.personMainInv.countItem(Items.DIRT) < 20, "miner skipped reachable lining: " + rotation);
     check(miner.personMainInv.countItem(Items.BUCKET) == 0, "fixture unexpectedly supplied a bucket");
     miner.discard();
   }
@@ -200,6 +212,28 @@ public final class WorkerRecoveryVerification {
         "arrival after reload retained an old access complaint");
     restored.discard();
     approach.arrived();
+  }
+
+  /** One pick of the mine loop, stood where it asked, acted through and released. */
+  private static void pick(ServerLevel level, MineStep mine, RealPerson miner, String failure) {
+    BlockPos stand = mine.select(miner);
+    check(stand != null, failure);
+    standAt(miner, stand);
+    mine.acquired(miner, stand);
+    for (int act = 0; act < 2000 && mine.act(miner, stand); act++) { }
+    mine.released(miner, stand);
+  }
+
+  /** Whether any interior cell of the fixture's flooded frontier rows still holds fluid. */
+  private static boolean wetPocket(ServerLevel level, MineShaft shaft) {
+    for (int z = 17; z <= 21; z++) {
+      for (BlockPos local : BlockPos.betweenClosed(-2, -z - 2, z, 2, -19, z)) {
+        if (!level.getFluidState(world(shaft, local)).isEmpty()) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private static java.util.List<String> blockers(RealPerson person) {

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineStep.java
@@ -743,6 +743,9 @@ public final class MineStep implements BlockWorkStep {
           || here == Blocks.BEDROCK || isLight(level, world)) {
         continue;
       }
+      if (wetInteriorNeighbour(level, mouth, rotation, local) != null) {
+        continue; // a plug, or the wall of a wet pocket: that water is the fluid pass's work, not dry frontier
+      }
       BlockPos frontierStand = standToMine(person, mouth, rotation, world);
       if (frontierStand == null) {
         continue;
@@ -1204,6 +1207,8 @@ public final class MineStep implements BlockWorkStep {
     if (!needsSeal(level, cell)) {
       return; // sealed in the meantime
     }
+    boolean plug = this.activeMouth != null && isLiquid(level, cell)
+        && isDugSpace(cell.subtract(this.activeMouth).rotate(inverse(this.activeRotation)));
     if (!placeSupport(person, cell, "I ran out of dirt or stone to wall off the cave in my mine")) {
       resetShaft();
       return;
@@ -1212,7 +1217,8 @@ public final class MineStep implements BlockWorkStep {
       this.pendingFloodBoundary = null;
       this.pendingFloodInside = null;
     }
-    Kithkyn.LOGGER.info("[mine] {} sealed the shaft lining at {}",
+    Kithkyn.LOGGER.info(plug ? "[mine] {} plugged the water in the shaft at {}"
+        : "[mine] {} sealed the shaft lining at {}",
         person.getName().getString(), cell.toShortString());
   }
 
@@ -1793,7 +1799,11 @@ public final class MineStep implements BlockWorkStep {
     return true; // hold this target while the off-hand bucket remains visible
   }
 
-  /** Close an air or fluid boundary beside the next block before breaking it. */
+  /**
+   * Close an air or fluid boundary beside the next block before breaking it, and
+   * plug any interior water against it: whatever path chose this block (the sweep,
+   * the frontier recovery, a vein, a rib), nothing is broken into a wet pocket.
+   */
   private boolean sealAround(RealPerson person, BlockPos mouth, Rotation rotation, BlockPos world) {
     Level level = person.level();
     BlockPos local = world.subtract(mouth).rotate(inverse(rotation));
@@ -1812,7 +1822,35 @@ public final class MineStep implements BlockWorkStep {
         return false;
       }
     }
+    for (Direction direction : Direction.values()) {
+      BlockPos next = local.relative(direction);
+      BlockPos beside = mouth.offset(next.rotate(rotation));
+      if (isDugSpace(next) && level.getBlockState(beside).is(Blocks.WATER)
+          && !placeSupport(person, beside,
+              "I ran out of dirt or stone to plug the water beside the face")) {
+        resetShaft();
+        return false;
+      }
+    }
     return true;
+  }
+
+  /**
+   * The interior cell beside {@code local} that holds water, if any. A solid ramp
+   * or rib cell with water against it is a plug the fluid pass laid, or the last
+   * wall of a wet pocket, and breaking it only floods the cell it opens: it is
+   * lining until nothing wet is left beside it. Water only: lava is never plugged
+   * or bailed, so a face beside lava keeps the rules it always had.
+   */
+  @Nullable
+  private BlockPos wetInteriorNeighbour(Level level, BlockPos mouth, Rotation rotation, BlockPos local) {
+    for (Direction direction : Direction.values()) {
+      BlockPos next = local.relative(direction);
+      if (isDugSpace(next) && level.getBlockState(mouth.offset(next.rotate(rotation))).is(Blocks.WATER)) {
+        return next;
+      }
+    }
+    return null;
   }
 
   /** Any fluid occupying the cell, flowing or still. */
@@ -1988,6 +2026,20 @@ public final class MineStep implements BlockWorkStep {
       // exactly what left a hole under every torch.
     } while (this.block == Blocks.AIR
         || isLight(person.level(), facePos));
+
+    // A solid cell with interior water against it is not frontier rock: it is a
+    // plug the fluid pass laid, or the last wall of a wet pocket, and breaking it
+    // only floods the cell it opens. Work the pocket from that water first; the
+    // plugs come out as ordinary rock once nothing wet is left beside them. Without
+    // this the sweep met the first plug as stone on the very next pick, dug it, the
+    // pocket refilled it, and Calirra's miner laid and dug the same block seven
+    // hundred times in an hour (2026-09-11).
+    BlockPos wet = wetInteriorNeighbour(person.level(), mouth, rotation, this.offset);
+    if (wet != null) {
+      this.offset = wet;
+      this.block = person.level().getBlockState(face(mouth, rotation)).getBlock();
+      return selectFluidWork(person, mouth, rotation);
+    }
 
     if (impassable(person)) {
       return RampScan.BLOCKED; // the fan-out takes over; the obstacle is logged once, on the way in


### PR DESCRIPTION
## Summary
- The no-bucket plug rule from 2026-09-11 lays a support block into a flooded ramp cell and means to quarry the plugs out once the pocket is dry, but the excavation sweep had no notion of "once dry": it met the first plug as ordinary stone in a ramp cell on the next pick, dug it, the pocket refilled it, and the fluid pass plugged it again. Calirra's miner laid and dug the same block 706 times in an hour (log: `sealed the shaft lining at 7201, 54, 2850`, one to five seconds apart, 14:53 to 15:59) and the shaft went nowhere.
- A solid ramp or rib cell with interior water against it is now lining, not frontier. `locateNext` routes such a cell to the fluid work from that water instead of digging it; `carveFrontier` skips it; and `sealAround` plugs interior water beside any face before it is broken, so the sweep, the frontier recovery, a vein and a rib all obey the same rule. Water only: lava keeps the rules it had. The log line distinguishes `plugged the water in the shaft at` from a lining seal.
- `docs/worker-loops.md` describes the rule and drops the stale bulkhead sentences the plug policy replaced.

## Verification
- `WorkerRecoveryVerification` (`-Dkithkyn.workers.verify=true`) already failed on main before this change with `miner never resumed dry side cuts: NONE`, because the thrash handed the dirt back to the pack and support never ran out. It now gives the bucketless miner twenty dirt against thirty leaks and eighty-one wet cells and asserts, in all four rotations: the pocket dries, the plug at the flooded cell is quarried back out, the ribs get cut for stone on the way, the sealed leaks outside the corridor stay standing, and dirt was spent. It passes; the run's log shows every plug and every lining seal landing on a distinct cell (324 plugs on 324 cells, 120 seals on 120 cells across the five runs).
- `./gradlew test` passes.
- The live server still runs the build from before this change; the loop at Calirra continues until the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
