### PR TITLE
The dead return: undead villages raise the register of the dead, and a wiped village falls

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,6 +44,14 @@ _Avoid_: Pillager, mob, monster
 What a player carries once their standing with an undead village has fallen far enough: the next living village they stand in is raided by its dead. The ominous bottle is the other omen.
 _Avoid_: Bad Omen, raid trigger
 
+**Register of the dead**:
+The level-wide list of every living villager who died, saved whole with when, where and how it ended, from which an undead village raises its arrivals: its own dead first, then the nearest, then the most recent.
+_Avoid_: Graveyard pool, respawn list, corpse list
+
+**Risen**:
+A person raised from the register of the dead into an undead village: the same person, memories and opinions intact, with the old life (village, job, title, marriage, belongings) left in the grave.
+_Avoid_: Respawned villager, revived, zombie
+
 **Reference family**:
 A coherent collection of gallery structures used as architectural evidence while authoring one village biome. Its source name never becomes a runtime village property.
 _Avoid_: Culture, runtime style axis

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,8 +28,9 @@ in it, and update it in the same change that moves what it describes.
 - [undead.md](undead.md): undead villages. People in every respect but one number, the
   stranger baseline that puts every undead fighter past the grudge line on sight, befriended
   one person at a time; the founding roll, the kind on person and village, the skeleton look
-  in ruined rags, the three replace-or-vanilla switches, and undead raids: the dead of a
-  village you have wronged, or an ominous bottle, following you into the next living village.
+  in ruined rags, the three replace-or-vanilla switches, undead raids (the dead of a village
+  you have wronged, or an ominous bottle, following you into the next living village), the
+  register of the dead an undead village raises its people from, and the village that falls.
 - [companions.md](companions.md): the dog or cat some villagers keep. Who is granted one and
   when, the one-per-species cap bonded to the person not the post, the owner naming it and
   choosing its look, the custom follow goal a mob owner needs, the village-tether when the

--- a/docs/population-and-labor.md
+++ b/docs/population-and-labor.md
@@ -346,7 +346,9 @@ the village edge past the wanderer cap: the whole person is saved into the serve
 Recruitment (**implemented**): a growing village that rolls an arrival fills it in this
 order, and only the last step conjures anyone: a loaded wanderer within the recruit radius
 (they walk in from wherever they are, pack, axe and all), then the person longest on the road beyond the
-horizon (restored at the village edge and walking in, stats and memories intact), then a
+horizon (restored at the village edge and walking in, stats and memories intact, and only of
+the village's own kind), then, for an undead village only, someone from the register of the dead
+([undead.md](undead.md)), and last a
 new persona. So the same souls circulate between settlements however far apart they stand,
 and a village that collapses seeds the ones that grow. Two caps bound this: the wanderer
 cap on people walking the loaded world (past it a leaver passes beyond the horizon straight

--- a/docs/undead.md
+++ b/docs/undead.md
@@ -74,7 +74,31 @@ would apply, so no pillager raid can start while the undead stand in for them.
 - The kind lives on the village (in the brain's strategy tag beside the style) and on each
   person (synced, saved as `Kind`). Campfire arrivals take the village's kind, children
   take their parents', a wandering merchant takes its home village's, and a village never
-  recruits a village-less wanderer of the other kind. A village is one kind for its life.
+  recruits a village-less wanderer of the other kind, whether roaming nearby or on the road
+  beyond the horizon. A village is one kind for its life, until it falls (below).
+
+## The dead return
+
+An undead village does not take strangers from nowhere while there are dead to raise. Every
+living villager who dies is written whole into the **register of the dead** (`Graveyard`),
+the way the road keeps a wanderer: their entire record, with when, where and how it ended.
+Raiders are never buried, they were never alive, and the undead dying again are gone for good.
+The register is one list for the whole server, bounded by `Register of the dead cap`.
+
+When an undead village's campfire loop calls for an arrival and nobody of its kind is roaming
+nearby or on the road, it raises someone from the register: **its own dead first, then the
+nearest, then the most recent.** The risen come back at the village's edge and walk in like
+anyone else. Only with the register empty is one of the long dead conjured, the way a living
+village conjures a newcomer, so an undead village founded in a fresh world still fills.
+
+What rises is the same person. `Raising` says exactly what of a record survives: name, gender,
+genes, stats, virtues, personality, age, parents, and every attachment, which is where the
+persona, the personal log, the chat history and the opinions of players live. So the dead
+remember, and a villager who liked you in life likes you still, whatever the undead baseline
+says about strangers. What stays in the grave is the old life, village, job, title, marriage,
+camp, and the pack and clothes they dropped where they fell, and the body's moment, its wounds
+and effects. The risen gain one memory, of how it ended and where they rose, and are undead from
+then on.
 
 ## The look
 
@@ -153,6 +177,12 @@ remembered for it the way a slain creeper is.
 when the raid is beaten, every player who cut one of the dead down; reflection decides what
 that was worth. Deaths among the residents go through the village's books like any other.
 
+**The village can fall.** If every resident dies while the dead are at the gate, the raid ends
+as the village falling: it turns undead, the raiders go back to the dark, and the ordinary
+arrival loop, forced below the population floor, raises its own dead first to fill it again.
+The name, the buildings, the stores and the golems stay. A village that had nobody when the
+dead set out cannot fall; it is only ever lost, not emptied.
+
 `/kkdev raid start [now]`, `stop` and `status` drive one by hand; `preview` is the harness hook.
 
 ## What stays the same, on purpose
@@ -191,6 +221,8 @@ show` prints the kind, and `/kkdev appearance audit` runs the recipe matrix for 
 - `raids/UndeadRaid`, `raids/UndeadRaids`, `raids/UndeadRaidPlan`, `raids/RaidCommands`: the
   raid, its omens, its arithmetic, and the dev commands. `entities/ai/goals/RaidMarchGoal` walks
   a raider in.
+- `village/Graveyard`, `village/Raising`: the register of the dead and what of a record rises.
+  `village/WandererPool` keeps the road's kinds apart.
 - `worldgen/ReplacementPacks`: the two data packs behind the village and pillager switches.
 - `configuration/KithkynConfig`: `UndeadVillages`, `UndeadVillageChance`, `ReplacePillagers`,
   `UndeadStrangerBaseline`, `UndeadRaidStandingBelow`, `UndeadRaidCooldownDays`.

--- a/src/main/java/com/quzzar/kithkyn/configuration/KithkynConfig.java
+++ b/src/main/java/com/quzzar/kithkyn/configuration/KithkynConfig.java
@@ -103,6 +103,7 @@ public class KithkynConfig {
     public static int WandererRecruitRadius;
     public static int WandererCap;
     public static int WandererPoolCap;
+    public static int GraveyardCap;
 
     // --- families (advanced) ---
     public static int FamilyFirstTalkDelayDays;
@@ -188,6 +189,7 @@ public class KithkynConfig {
         WandererRecruitRadius = ADVANCED.WandererRecruitRadius.get();
         WandererCap = ADVANCED.WandererCap.get();
         WandererPoolCap = ADVANCED.WandererPoolCap.get();
+        GraveyardCap = ADVANCED.GraveyardCap.get();
 
         // families
         FamilyFirstTalkDelayDays = ADVANCED.FamilyFirstTalkDelayDays.get();
@@ -315,6 +317,7 @@ public class KithkynConfig {
         public final ModConfigSpec.IntValue WandererRecruitRadius;
         public final ModConfigSpec.IntValue WandererCap;
         public final ModConfigSpec.IntValue WandererPoolCap;
+        public final ModConfigSpec.IntValue GraveyardCap;
 
         // families
         public final ModConfigSpec.IntValue FamilyFirstTalkDelayDays;
@@ -396,6 +399,7 @@ public class KithkynConfig {
             WandererRecruitRadius = builder.comment("How far (blocks) a growing village looks for an existing wanderer to recruit before spawning a new arrival.").translation(Kithkyn.MODID + ".config.WandererRecruitRadius").defineInRange("Wanderer recruit radius", 128, 16, 512);
             WandererCap = builder.comment("Loaded wanderers the world keeps on foot. Past the cap, a leaver reaching the village edge passes beyond the horizon at once instead of walking there.").translation(Kithkyn.MODID + ".config.WandererCap").defineInRange("Wanderer cap", 8, 0, 256);
             WandererPoolCap = builder.comment("Most people the world remembers on the road beyond the horizon. Past it the longest-gone is forgotten; 0 forgets everyone the moment they cross.").translation(Kithkyn.MODID + ".config.WandererPoolCap").defineInRange("Wanderer pool cap", 64, 0, 1024);
+            GraveyardCap = builder.comment("Most of the dead the world remembers whole, so an undead village can raise them (docs/undead.md). Past it the longest-dead is forgotten; 0 buries nobody, and undead villages only ever conjure the long dead.").translation(Kithkyn.MODID + ".config.GraveyardCap").defineInRange("Register of the dead cap", 256, 0, 4096);
 
             builder.pop();
 

--- a/src/main/java/com/quzzar/kithkyn/events/CoreEvents.java
+++ b/src/main/java/com/quzzar/kithkyn/events/CoreEvents.java
@@ -270,6 +270,14 @@ public class CoreEvents {
         return;
       }
 
+      // The living are written into the register of the dead, whole, before
+      // the body drops what it carried; an undead village may raise them
+      // later (docs/undead.md). The undead dying again are gone for good.
+      if (person.level() instanceof ServerLevel grave) {
+        VillageManager.get(grave).getGraveyard().bury(person,
+            event.getSource().getLocalizedDeathMessage(person).getString(), grave.getGameTime());
+      }
+
       if (person.getVillage() != null) {
 
         UUID killerUUID = null;

--- a/src/main/java/com/quzzar/kithkyn/raids/UndeadRaid.java
+++ b/src/main/java/com/quzzar/kithkyn/raids/UndeadRaid.java
@@ -65,13 +65,17 @@ public final class UndeadRaid {
     COMING,
     FIGHTING,
     BEATEN,
-    WITHDRAWN
+    WITHDRAWN,
+    /** Every resident died while the dead were at the gate: the village is theirs now. */
+    FALLEN
   }
 
   private final String sourceName;
   @Nullable
   private final UUID culprit;
   private final int waves;
+  /** How many residents the village had when the dead set out; a village that had none cannot fall. */
+  private final int residentsAtStart;
   private Phase phase;
   private int wave;
   private int waveSize;
@@ -82,11 +86,12 @@ public final class UndeadRaid {
   @Nullable
   private ServerBossEvent bar;
 
-  private UndeadRaid(String sourceName, @Nullable UUID culprit, int waves, Phase phase, int wave, int waveSize,
-      long phaseAt, long firstWaveAt) {
+  private UndeadRaid(String sourceName, @Nullable UUID culprit, int waves, int residentsAtStart, Phase phase,
+      int wave, int waveSize, long phaseAt, long firstWaveAt) {
     this.sourceName = sourceName;
     this.culprit = culprit;
     this.waves = waves;
+    this.residentsAtStart = residentsAtStart;
     this.phase = phase;
     this.wave = wave;
     this.waveSize = waveSize;
@@ -100,8 +105,9 @@ public final class UndeadRaid {
    * is who they followed, if anyone. {@code atOnce} skips the countdown, which
    * only the dev command wants.
    */
-  public static UndeadRaid begin(String sourceName, @Nullable UUID culprit, int waves, long gameTime, boolean atOnce) {
-    return new UndeadRaid(sourceName, culprit, waves, Phase.COMING, 0, 0,
+  public static UndeadRaid begin(String sourceName, @Nullable UUID culprit, int waves, int residentsAtStart,
+      long gameTime, boolean atOnce) {
+    return new UndeadRaid(sourceName, culprit, waves, residentsAtStart, Phase.COMING, 0, 0,
         atOnce ? gameTime - COUNTDOWN_TICKS : gameTime, 0L);
   }
 
@@ -110,6 +116,7 @@ public final class UndeadRaid {
         tag.getString("source"),
         tag.hasUUID("culprit") ? tag.getUUID("culprit") : null,
         tag.getInt("waves"),
+        tag.getInt("residents_at_start"),
         Phase.valueOf(tag.getString("phase")),
         tag.getInt("wave"),
         tag.getInt("wave_size"),
@@ -132,6 +139,7 @@ public final class UndeadRaid {
       tag.putUUID("culprit", culprit);
     }
     tag.putInt("waves", waves);
+    tag.putInt("residents_at_start", residentsAtStart);
     tag.putString("phase", phase.name());
     tag.putInt("wave", wave);
     tag.putInt("wave_size", waveSize);
@@ -167,6 +175,10 @@ public final class UndeadRaid {
 
   public int waves() {
     return waves;
+  }
+
+  public int residentsAtStart() {
+    return residentsAtStart;
   }
 
   public Set<UUID> raiders() {
@@ -209,7 +221,9 @@ public final class UndeadRaid {
       }
       case FIGHTING -> {
         prune(level);
-        if (raiders.isEmpty()) {
+        if (residentsAtStart > 0 && village.getPopulation().isEmpty()) {
+          fall(village, level);
+        } else if (raiders.isEmpty()) {
           if (wave >= waves) {
             end(village, level, Phase.BEATEN);
           } else {
@@ -222,7 +236,7 @@ public final class UndeadRaid {
           end(village, level, Phase.WITHDRAWN);
         }
       }
-      case BEATEN, WITHDRAWN -> {
+      case BEATEN, WITHDRAWN, FALLEN -> {
         if (now - phaseAt >= AFTERMATH_TICKS) {
           bar().removeAllPlayers();
           return true;
@@ -319,6 +333,20 @@ public final class UndeadRaid {
     }
   }
 
+  /**
+   * The village is the dead's now: everyone who lived here died at the gate.
+   * It turns undead, the raiders go back to the dark, and the ordinary
+   * arrival loop raises its own dead first to fill it again (docs/undead.md).
+   */
+  private void fall(Village village, ServerLevel level) {
+    withdraw(level);
+    village.setKind(Kind.UNDEAD);
+    phase = Phase.FALLEN;
+    phaseAt = level.getGameTime();
+    Kithkyn.LOGGER.info("[raid] '{}' has fallen to {}", village.getName(), sourceName);
+    tell(village, level, village.getName() + " has fallen to the dead.");
+  }
+
   /** Every player who cut one of the dead down is remembered for it by every resident. */
   private void rememberDefenders(Village village, ServerLevel level) {
     for (Map.Entry<UUID, Integer> entry : kills.entrySet()) {
@@ -377,6 +405,11 @@ public final class UndeadRaid {
         event.setName(Component.literal("The dead withdrew"));
         event.setColor(BossEvent.BossBarColor.YELLOW);
         event.setProgress(0.0F);
+      }
+      case FALLEN -> {
+        event.setName(Component.literal(village.getName() + " has fallen to the dead"));
+        event.setColor(BossEvent.BossBarColor.PURPLE);
+        event.setProgress(1.0F);
       }
     }
     Set<ServerPlayer> near = Set.copyOf(playersNear(village, level));

--- a/src/main/java/com/quzzar/kithkyn/raids/UndeadRaids.java
+++ b/src/main/java/com/quzzar/kithkyn/raids/UndeadRaids.java
@@ -96,7 +96,7 @@ public final class UndeadRaids {
     }
     String sourceName = source == null ? NAMELESS_DEAD : "the dead of " + source.getName();
     UndeadRaid raid = UndeadRaid.begin(sourceName, culprit == null ? null : culprit.getUUID(), waves,
-        level.getGameTime(), atOnce);
+        target.getPopulation().size(), level.getGameTime(), atOnce);
     if (!target.beginRaid(raid)) {
       return false;
     }

--- a/src/main/java/com/quzzar/kithkyn/savedata/VillageManagerSaveData.java
+++ b/src/main/java/com/quzzar/kithkyn/savedata/VillageManagerSaveData.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import com.mojang.serialization.Codec;
 import com.quzzar.kithkyn.Kithkyn;
 import com.quzzar.kithkyn.village.Village;
+import com.quzzar.kithkyn.village.Graveyard;
 import com.quzzar.kithkyn.village.WandererPool;
 
 import net.minecraft.core.BlockPos;
@@ -39,6 +40,7 @@ public class VillageManagerSaveData extends SavedData {
 
     /** Everyone on the road beyond the horizon: one list for the whole server (docs/population-and-labor.md). */
     private final WandererPool wanderers = new WandererPool(this::setDirty);
+    private final Graveyard graveyard = new Graveyard(this::setDirty);
 
     // Runtime-only: the level this registry belongs to, re-attached on access.
     private ServerLevel level;
@@ -131,6 +133,11 @@ public class VillageManagerSaveData extends SavedData {
                     .resultOrPartial(error -> Kithkyn.LOGGER.error("Failed to load the wanderers beyond the horizon: {}", error))
                     .ifPresent(data.wanderers::load);
         }
+        if (tag.contains("TheDead")) {
+            Graveyard.CODEC.parse(NbtOps.INSTANCE, tag.get("TheDead"))
+                    .resultOrPartial(error -> Kithkyn.LOGGER.error("Failed to load the register of the dead: {}", error))
+                    .ifPresent(data.graveyard::load);
+        }
         return data;
     }
 
@@ -148,6 +155,12 @@ public class VillageManagerSaveData extends SavedData {
                 .orElse(null);
         if (road != null) {
             tag.put("Wanderers", road);
+        }
+        Tag dead = Graveyard.CODEC.encodeStart(NbtOps.INSTANCE, List.copyOf(graveyard.entries()))
+                .resultOrPartial(error -> Kithkyn.LOGGER.error("Failed to save the register of the dead: {}", error))
+                .orElse(null);
+        if (dead != null) {
+            tag.put("TheDead", dead);
         }
         return tag;
     }
@@ -261,6 +274,10 @@ public class VillageManagerSaveData extends SavedData {
 
     public WandererPool getWanderers() {
         return wanderers;
+    }
+
+    public Graveyard getGraveyard() {
+        return graveyard;
     }
 
 }

--- a/src/main/java/com/quzzar/kithkyn/village/Graveyard.java
+++ b/src/main/java/com/quzzar/kithkyn/village/Graveyard.java
@@ -1,0 +1,152 @@
+package com.quzzar.kithkyn.village;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.quzzar.kithkyn.Kithkyn;
+import com.quzzar.kithkyn.configuration.KithkynConfig;
+import com.quzzar.kithkyn.entities.Kind;
+import com.quzzar.kithkyn.entities.RealPerson;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+
+/**
+ * The register of the dead (docs/undead.md): every living villager who died,
+ * saved whole the way the road saves a wanderer, with when, where and how it
+ * ended. An undead village growing with nobody of its kind to recruit raises
+ * someone from here before it conjures anyone: its own dead first, then the
+ * nearest, then the most recent. The risen keep who they were and what they
+ * remember; {@link Raising} says what of the old life stays in the grave.
+ *
+ * <p>Raiders are never buried, they were never alive, and the undead dying
+ * again are gone for good. Lives in the village registry's save data, so it
+ * is one register for the whole server, bounded by config.
+ */
+public final class Graveyard {
+
+  /** One of the dead: who, when (game time), where, whose village, how, and everything they were. */
+  public record Entry(String name, long diedAt, long where, String village, String cause, CompoundTag person) {
+    public static final Codec<Entry> CODEC = RecordCodecBuilder.create(inst -> inst.group(
+        Codec.STRING.fieldOf("name").forGetter(Entry::name),
+        Codec.LONG.fieldOf("died_at").forGetter(Entry::diedAt),
+        Codec.LONG.fieldOf("where").forGetter(Entry::where),
+        Codec.STRING.fieldOf("village").forGetter(Entry::village),
+        Codec.STRING.fieldOf("cause").forGetter(Entry::cause),
+        CompoundTag.CODEC.fieldOf("person").forGetter(Entry::person)
+    ).apply(inst, Entry::new));
+  }
+
+  public static final Codec<List<Entry>> CODEC = Entry.CODEC.listOf();
+
+  private final ArrayList<Entry> entries = new ArrayList<>();
+
+  /** Marks the owning save data dirty; every change to the list runs it. */
+  private final Runnable onChange;
+
+  public Graveyard(Runnable onChange) {
+    this.onChange = onChange;
+  }
+
+  /** Replaces the list with what was saved. Load only. */
+  public void load(List<Entry> saved) {
+    entries.clear();
+    entries.addAll(saved);
+  }
+
+  /**
+   * Writes a dying person into the register. Only the living are buried: a
+   * raider was never alive, and the undead dying again are simply gone. What
+   * they carried is left where they fell, not kept. Returns false when the
+   * register keeps nobody (a cap of zero) or the person would not serialize.
+   */
+  public boolean bury(RealPerson person, String cause, long now) {
+    int cap = KithkynConfig.GraveyardCap;
+    if (cap <= 0 || person.getKind() != Kind.LIVING || person.isRaider()) {
+      return false;
+    }
+    CompoundTag tag = new CompoundTag();
+    if (!person.save(tag)) {
+      Kithkyn.LOGGER.warn("'{}' could not be written into the register of the dead", person.getFullName());
+      return false;
+    }
+    Village village = person.getVillage();
+    entries.add(new Entry(person.getFullName(), now, person.blockPosition().asLong(),
+        village == null ? "" : village.getName(), cause, Raising.withoutBelongings(tag)));
+    while (entries.size() > cap) {
+      Entry forgotten = entries.remove(0);
+      Kithkyn.LOGGER.info("'{}' will not rise: the register of the dead remembers only so many", forgotten.name());
+    }
+    onChange.run();
+    return true;
+  }
+
+  /**
+   * Raises the dead best suited to the village, standing at {@code pos} but not
+   * yet added to the level, or null when nobody can rise. One whose id is
+   * still walking the world is left in the register; an entry that no longer
+   * restores is dropped rather than tried again forever, like the road's.
+   */
+  @Nullable
+  public RealPerson raise(ServerLevel level, BlockPos pos, Village village) {
+    BlockPos center = village.centerPosition();
+    for (Entry entry : ranked(entries, village.getName(), center == null ? pos : center)) {
+      if (entry.person().hasUUID("UUID") && level.getEntity(entry.person().getUUID("UUID")) != null) {
+        continue;
+      }
+      entries.remove(entry);
+      onChange.run();
+      RealPerson risen = restore(level, pos, entry);
+      if (risen != null) {
+        risen.logMemory("I remember how it ended: " + entry.cause() + ". I rose again at " + village.getName() + ".",
+            Optional.empty());
+        return risen;
+      }
+    }
+    return null;
+  }
+
+  /** Whose turn it is to rise: the village's own dead, then the nearest, then the most recent. */
+  static List<Entry> ranked(List<Entry> entries, String villageName, BlockPos center) {
+    return entries.stream()
+        .sorted(Comparator.<Entry, Boolean>comparing(entry -> !entry.village().equals(villageName))
+            .thenComparingDouble(entry -> BlockPos.of(entry.where()).distSqr(center))
+            .thenComparing(Comparator.comparingLong(Entry::diedAt).reversed()))
+        .toList();
+  }
+
+  @Nullable
+  private static RealPerson restore(ServerLevel level, BlockPos pos, Entry entry) {
+    try {
+      Entity entity = EntityType.create(Raising.prepare(entry.person()), level).orElse(null);
+      if (entity instanceof RealPerson person) {
+        person.moveTo(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5, level.random.nextFloat() * 360F, 0F);
+        person.setHealth(person.getMaxHealth());
+        return person;
+      }
+      Kithkyn.LOGGER.error("'{}' could not be raised from the register of the dead and is lost", entry.name());
+    } catch (RuntimeException error) {
+      Kithkyn.LOGGER.error("'{}' could not be raised from the register of the dead and is lost", entry.name(), error);
+    }
+    return null;
+  }
+
+  /** Everyone in the register, oldest death first. */
+  public List<Entry> entries() {
+    return Collections.unmodifiableList(entries);
+  }
+
+  public int size() {
+    return entries.size();
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/village/Raising.java
+++ b/src/main/java/com/quzzar/kithkyn/village/Raising.java
@@ -1,0 +1,68 @@
+package com.quzzar.kithkyn.village;
+
+import java.util.List;
+
+import com.quzzar.kithkyn.entities.Kind;
+import com.quzzar.kithkyn.entities.MarriageStatus;
+
+import net.minecraft.nbt.CompoundTag;
+
+/**
+ * What of a dead person's record comes back when they rise, and what stays in
+ * the grave (docs/undead.md). Pure: a saved entity tag in, the tag of the
+ * risen out, so a test can pin down exactly which parts of a life survive.
+ *
+ * Everything that was the person survives: name, gender, genes, stats,
+ * virtues, personality, age, parents, and every attachment, which is where the
+ * persona, the personal log, the chat history and the opinions of players
+ * live. What was the old life is dropped: the village, the job, the title,
+ * the marriage, the camp, the pack and what they wore. What was the body's
+ * moment is dropped too: position, health, wounds, effects, anger. The kind
+ * becomes undead. The id is kept, because it is the same person.
+ */
+public final class Raising {
+
+  /** The old life: village, work, standing in it, and what it was carrying. */
+  static final List<String> OLD_LIFE = List.of(
+      "VillageUUID", "VillageName", "Occupation", "Title", "Camp", "SpouseUUID", "AwaitingAdultHome",
+      "Raider", "RaidTarget", "RaidSource", "WanderingMerchant", "SourceVillageUUID", "WanderingStock",
+      "MerchantDespawnCountdown", "RoamHeading", "RoamDay", "RoamOrigin",
+      "GuiOpen", "Immobile", "Eating", "RunningToEat", "Interrupted", "CallToBedCooldown",
+      "CampfireRecoveryAvailableAt", "DaysSinceSleep", "ShieldCooldown",
+      "Inventory", "MainInventory", "ArmorItems", "HandItems", "ArmorDropChances", "HandDropChances",
+      "body_armor_item", "body_armor_drop_chance", "DeathLootTable", "DeathLootTableSeed");
+
+  /** The body's moment: where it stood and how it was, at the end. */
+  static final List<String> BODY = List.of(
+      "Pos", "Motion", "Rotation", "FallDistance", "Fire", "Air", "OnGround", "PortalCooldown", "Passengers",
+      "Tags", "TicksFrozen", "Health", "HurtTime", "HurtByTimestamp", "DeathTime", "AbsorptionAmount",
+      "active_effects", "ActiveEffects", "FallFlying", "SleepingX", "SleepingY", "SleepingZ", "Brain",
+      "Leash", "leash", "NoAI", "AngerTime", "AngryAt");
+
+  private Raising() {
+  }
+
+  /** The tag a person rises from: their record with the old life and the body's moment stripped out. */
+  public static CompoundTag prepare(CompoundTag dead) {
+    CompoundTag risen = dead.copy();
+    for (String key : OLD_LIFE) {
+      risen.remove(key);
+    }
+    for (String key : BODY) {
+      risen.remove(key);
+    }
+    risen.putString("Kind", Kind.UNDEAD.name());
+    risen.putString("MarriageStatus", MarriageStatus.SINGLE.name());
+    risen.putString("Occupation", Occupation.WANDERER.name());
+    return risen;
+  }
+
+  /** The pack and what they wore, dropped where they fell and so not kept in the grave. */
+  public static CompoundTag withoutBelongings(CompoundTag dead) {
+    CompoundTag kept = dead.copy();
+    for (String key : List.of("Inventory", "MainInventory", "ArmorItems", "HandItems", "body_armor_item")) {
+      kept.remove(key);
+    }
+    return kept;
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/village/Village.java
+++ b/src/main/java/com/quzzar/kithkyn/village/Village.java
@@ -2067,7 +2067,7 @@ public class Village {
     BlockPos edge = edgeSpawnPos();
     BlockPos road = edge != null ? edge : fire;
     var wanderers = VillageManager.get(level).getWanderers();
-    RealPerson returning = wanderers.draw(level, road);
+    RealPerson returning = wanderers.draw(level, road, getKind());
     if (returning != null) {
       List<RealPerson> family = new ArrayList<>();
       family.add(returning);
@@ -2086,6 +2086,19 @@ public class Village {
       Kithkyn.LOGGER.info("the household [{}] came in off the road to village '{}' together",
           family.stream().map(RealPerson::getFullName).toList(), name);
       return;
+    }
+
+    // The undead do not take strangers from nowhere while there are dead to
+    // raise: the register of the dead comes before conjuring, its own dead
+    // first (docs/undead.md). Only with the register empty is one of the
+    // long dead conjured, the way a living village conjures a newcomer.
+    if (getKind() == com.quzzar.kithkyn.entities.Kind.UNDEAD) {
+      RealPerson risen = VillageManager.get(level).getGraveyard().raise(level, road, this);
+      if (risen != null) {
+        admitReturning(risen, fire, deadline);
+        Kithkyn.LOGGER.info("'{}' rose from the dead and is arriving at village '{}'", risen.getFullName(), name);
+        return;
+      }
     }
 
     PersonaSpawner.trySpawn(level, spawnPos, person -> {

--- a/src/main/java/com/quzzar/kithkyn/village/WandererPool.java
+++ b/src/main/java/com/quzzar/kithkyn/village/WandererPool.java
@@ -12,6 +12,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.quzzar.kithkyn.Kithkyn;
 import com.quzzar.kithkyn.configuration.KithkynConfig;
 import com.quzzar.kithkyn.entities.AgeStage;
+import com.quzzar.kithkyn.entities.Kind;
 import com.quzzar.kithkyn.entities.RealPerson;
 
 import net.minecraft.core.BlockPos;
@@ -90,16 +91,22 @@ public final class WandererPool {
   }
 
   /**
-   * Brings the person longest on the road back into the world, standing at
-   * {@code pos} but not yet added to the level, or null when nobody is on the
-   * road. An entry that no longer restores (a build change since it was saved)
-   * is dropped with an error rather than tried again forever: saves under old
-   * names do not load, by decision, and the pool is no exception.
+   * Brings the person of the given kind longest on the road back into the
+   * world, standing at {@code pos} but not yet added to the level, or null
+   * when nobody of that kind is on the road: the living do not settle among
+   * the undead, nor the reverse (docs/undead.md). An entry that no longer
+   * restores (a build change since it was saved) is dropped with an error
+   * rather than tried again forever: saves under old names do not load, by
+   * decision, and the pool is no exception.
    */
   @Nullable
-  public RealPerson draw(ServerLevel level, BlockPos pos) {
-    while (!entries.isEmpty()) {
-      Entry entry = entries.remove(0);
+  public RealPerson draw(ServerLevel level, BlockPos pos, Kind kind) {
+    for (int index = 0; index < entries.size(); index++) {
+      Entry entry = entries.get(index);
+      if (kindOf(entry.person()) != kind) {
+        continue;
+      }
+      entries.remove(index--);
       onChange.run();
       RealPerson restored = restore(level, pos, entry);
       if (restored != null) {
@@ -107,6 +114,11 @@ public final class WandererPool {
       }
     }
     return null;
+  }
+
+  /** The kind a saved person is; living for anyone saved before kinds existed. */
+  static Kind kindOf(CompoundTag person) {
+    return Kind.fromId(person.getString("Kind"));
   }
 
   /** Draws every banked spouse, parent, dependent child, and dependent sibling of an anchor. */

--- a/src/test/java/com/quzzar/kithkyn/raids/UndeadRaidTest.java
+++ b/src/test/java/com/quzzar/kithkyn/raids/UndeadRaidTest.java
@@ -15,10 +15,10 @@ class UndeadRaidTest {
 
   @Test
   void theCountdownIsHalfAMinuteUnlessSkipped() {
-    UndeadRaid raid = UndeadRaid.begin("the dead of Barrowdown", null, 3, 1000L, false);
+    UndeadRaid raid = UndeadRaid.begin("the dead of Barrowdown", null, 3, 5, 1000L, false);
     assertFalse(raid.countdownOver(1000L + UndeadRaid.COUNTDOWN_TICKS - 1));
     assertTrue(raid.countdownOver(1000L + UndeadRaid.COUNTDOWN_TICKS));
-    assertTrue(UndeadRaid.begin("the restless dead", null, 3, 1000L, true).countdownOver(1000L));
+    assertTrue(UndeadRaid.begin("the restless dead", null, 3, 5, 1000L, true).countdownOver(1000L));
   }
 
   @Test
@@ -26,7 +26,7 @@ class UndeadRaidTest {
     UUID culprit = UUID.randomUUID();
     UUID defender = UUID.randomUUID();
     UUID raider = UUID.randomUUID();
-    UndeadRaid raid = UndeadRaid.begin("the dead of Barrowdown", culprit, 4, 500L, false);
+    UndeadRaid raid = UndeadRaid.begin("the dead of Barrowdown", culprit, 4, 7, 500L, false);
     raid.raiderDied(raider, defender);
     raid.raiderDied(UUID.randomUUID(), defender);
     raid.raiderDied(UUID.randomUUID(), null);
@@ -37,6 +37,7 @@ class UndeadRaidTest {
     assertEquals("the dead of Barrowdown", loaded.sourceName());
     assertEquals(culprit, loaded.culprit());
     assertEquals(4, loaded.waves());
+    assertEquals(7, loaded.residentsAtStart());
     assertEquals(UndeadRaid.Phase.COMING, loaded.phase());
     assertEquals(0, loaded.wave());
     assertEquals(500L, loaded.phaseAt());
@@ -47,7 +48,7 @@ class UndeadRaidTest {
 
   @Test
   void theNamelessDeadHaveNoCulprit() {
-    UndeadRaid loaded = UndeadRaid.load(UndeadRaid.begin(UndeadRaids.NAMELESS_DEAD, null, 2, 0L, true).save());
+    UndeadRaid loaded = UndeadRaid.load(UndeadRaid.begin(UndeadRaids.NAMELESS_DEAD, null, 2, 0, 0L, true).save());
     assertNull(loaded.culprit());
     assertEquals("The restless dead", UndeadRaid.capitalize(loaded.sourceName()));
   }

--- a/src/test/java/com/quzzar/kithkyn/village/GraveyardTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/GraveyardTest.java
@@ -1,0 +1,52 @@
+package com.quzzar.kithkyn.village;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.quzzar.kithkyn.entities.Kind;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+
+class GraveyardTest {
+
+  private static Graveyard.Entry entry(String name, long diedAt, BlockPos where, String village) {
+    CompoundTag person = new CompoundTag();
+    person.putUUID("UUID", UUID.randomUUID());
+    person.putString("FirstName", name);
+    return new Graveyard.Entry(name, diedAt, where.asLong(), village, name + " was slain", person);
+  }
+
+  @Test
+  void theVillagesOwnDeadRiseFirstThenTheNearestThenTheMostRecent() {
+    BlockPos center = new BlockPos(0, 64, 0);
+    Graveyard.Entry farRecent = entry("far recent", 900L, new BlockPos(400, 64, 0), "Elsewhere");
+    Graveyard.Entry nearOld = entry("near old", 100L, new BlockPos(40, 64, 0), "Elsewhere");
+    Graveyard.Entry nearRecent = entry("near recent", 800L, new BlockPos(40, 64, 0), "Elsewhere");
+    Graveyard.Entry ownOld = entry("own old", 50L, new BlockPos(600, 64, 0), "Tallowford");
+    List<Graveyard.Entry> ranked = Graveyard.ranked(List.of(farRecent, nearOld, nearRecent, ownOld), "Tallowford", center);
+    assertEquals(List.of(ownOld, nearRecent, nearOld, farRecent), ranked);
+  }
+
+  @Test
+  void anEntrySurvivesTheSave() {
+    Graveyard.Entry entry = entry("Fern Hammond", 1234L, new BlockPos(3, 64, 40), "Tallowford");
+    var encoded = Graveyard.Entry.CODEC.encodeStart(NbtOps.INSTANCE, entry).getOrThrow();
+    Graveyard.Entry decoded = Graveyard.Entry.CODEC.parse(NbtOps.INSTANCE, encoded).getOrThrow();
+    assertEquals(entry, decoded);
+  }
+
+  @Test
+  void theRoadTellsKindsApart() {
+    CompoundTag living = new CompoundTag();
+    CompoundTag undead = new CompoundTag();
+    undead.putString("Kind", "UNDEAD");
+    assertEquals(Kind.LIVING, WandererPool.kindOf(living));
+    assertEquals(Kind.UNDEAD, WandererPool.kindOf(undead));
+  }
+}

--- a/src/test/java/com/quzzar/kithkyn/village/RaisingTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/RaisingTest.java
@@ -1,0 +1,90 @@
+package com.quzzar.kithkyn.village;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+
+class RaisingTest {
+
+  private static CompoundTag dead() {
+    CompoundTag tag = new CompoundTag();
+    tag.putString("id", "kithkyn:person");
+    tag.putUUID("UUID", UUID.fromString("7f1d5a4e-2b3c-4d5e-8f90-123456789abc"));
+    tag.putString("FirstName", "Fern");
+    tag.putString("LastName", "Hammond");
+    tag.putString("Gender", "FEMALE");
+    tag.putString("Personality", "CHEERFUL");
+    tag.putString("AgeStage", "ADULT");
+    tag.putString("Kind", "LIVING");
+    tag.putString("FirstParentUUID", UUID.randomUUID().toString());
+    tag.putString("VillageUUID", "village-1");
+    tag.putString("VillageName", "Tallowford");
+    tag.putString("Occupation", "FARMER");
+    tag.putString("Title", "Elder");
+    tag.putString("MarriageStatus", "MARRIED");
+    tag.putString("SpouseUUID", UUID.randomUUID().toString());
+    tag.putBoolean("Raider", true);
+    tag.putFloat("Health", 0.0F);
+    tag.putShort("DeathTime", (short) 19);
+    tag.put("Pos", new ListTag());
+    tag.put("MainInventory", new ListTag());
+    tag.put("ArmorItems", new ListTag());
+    CompoundTag attachments = new CompoundTag();
+    attachments.putString("kithkyn:persona", "a persona");
+    tag.put("neoforge:attachments", attachments);
+    CompoundTag stats = new CompoundTag();
+    stats.putInt("Strength", 12);
+    tag.put("StatBlock", stats);
+    return tag;
+  }
+
+  @Test
+  void whoTheyWereSurvives() {
+    CompoundTag risen = Raising.prepare(dead());
+    assertEquals("kithkyn:person", risen.getString("id"));
+    assertEquals(UUID.fromString("7f1d5a4e-2b3c-4d5e-8f90-123456789abc"), risen.getUUID("UUID"));
+    assertEquals("Fern", risen.getString("FirstName"));
+    assertEquals("Hammond", risen.getString("LastName"));
+    assertEquals("FEMALE", risen.getString("Gender"));
+    assertEquals("CHEERFUL", risen.getString("Personality"));
+    assertEquals("ADULT", risen.getString("AgeStage"));
+    assertTrue(risen.contains("FirstParentUUID"));
+    assertEquals(12, risen.getCompound("StatBlock").getInt("Strength"));
+    assertEquals("a persona", risen.getCompound("neoforge:attachments").getString("kithkyn:persona"));
+  }
+
+  @Test
+  void theOldLifeAndTheBodyStayInTheGrave() {
+    CompoundTag risen = Raising.prepare(dead());
+    for (String gone : new String[] {"VillageUUID", "VillageName", "Title", "SpouseUUID", "Raider",
+        "Health", "DeathTime", "Pos", "MainInventory", "ArmorItems"}) {
+      assertFalse(risen.contains(gone), gone + " should stay in the grave");
+    }
+    assertEquals("UNDEAD", risen.getString("Kind"));
+    assertEquals("SINGLE", risen.getString("MarriageStatus"));
+    assertEquals("WANDERER", risen.getString("Occupation"));
+  }
+
+  @Test
+  void preparingLeavesTheRecordItself() {
+    CompoundTag record = dead();
+    CompoundTag before = record.copy();
+    Raising.prepare(record);
+    assertEquals(before, record);
+  }
+
+  @Test
+  void belongingsAreLeftWhereTheyFell() {
+    CompoundTag kept = Raising.withoutBelongings(dead());
+    assertFalse(kept.contains("MainInventory"));
+    assertFalse(kept.contains("ArmorItems"));
+    assertEquals("Tallowford", kept.getString("VillageName"), "everything else waits for the raising");
+  }
+}


### PR DESCRIPTION
Closes #124. Follows #121.

## What

- **A register of the dead.** Every living villager who dies is written whole into `Graveyard`, the way the road keeps a wanderer: the entire entity record plus when, where and how it ended. Raiders are never buried, they were never alive, and the undead dying again are gone for good. One list for the server, bounded by a new advanced config cap (256).
- **Undead arrivals are raised from it.** When an undead village's campfire loop calls for an arrival and nobody of its kind is roaming nearby or on the road, it raises someone: its own dead first, then the nearest, then the most recent. The risen come back at the edge and walk in like anyone else. With the register empty it falls back to conjuring one of the long dead, so early undead villages still fill.
- **The same person rises.** `Raising` is a pure strip pass over the saved tag and says exactly what survives: name, gender, genes, stats, virtues, personality, age, parents, and every attachment (persona, personal log, chat history, opinions of players). The old life stays in the grave: village, job, title, marriage, camp, belongings; so does the body's moment: position, health, wounds, effects, anger. The risen gain one memory of how it ended and where they rose.
- **The road keeps kinds apart.** The wanderer pool's draw now takes a kind, so a living returnee never settles among the undead and the reverse.
- **The village can fall.** If every resident dies while the dead are at the gate, the raid ends with the village undead, the raiders withdraw, and the forced refill below the population floor raises its own dead first. A village that had nobody when the dead set out cannot fall.

## Docs

`docs/undead.md` gains "The dead return" and the fall; the population doc's recruitment order, the README index and the glossary follow.

## Verified

- `./gradlew test` green, with new tests for the strip pass (what survives, what stays, the record is untouched), the register's ranking and codec, the road's kind reading, and the raid's saved resident count.
- On a private flat server: an undead village was founded, a summoned living person killed, and four seconds later she rose at the village's edge and walked in as its first resident with name, gender and full health, marked undead, single and idle, carrying "I remember how it ended: Fern Hammond was killed. I rose again at Duncrest." Killed again as undead, she stayed dead and the village went back to conjuring.
- The fall itself was not exercised: without the LLM the test server cannot seat residents for a raid to wipe. The condition is one line (residents at the start, none now) beside the existing wave logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)