### PR TITLE
Fix Swamp structure seating and mine width

### DIFF
--- a/docs/building-spec.md
+++ b/docs/building-spec.md
@@ -33,8 +33,9 @@ against the enum before it is authored.
 the miner excavates the underground ramp and branches at runtime. `sink` specifies how the
 lowest authored layer seats against the terrain: zero replaces the surface block, while -1
 places that layer above it. `mine_entrance` specifies a cardinal descent direction, a mouth
-offset from each MINER station, and a width of three or five blocks (default five). The
-building's rotation applies to both direction and offset. Width changes the side walls and
+offset from each MINER station, and a width of two, three or five blocks (default five). The
+building's rotation applies to both direction and offset. A two-wide corridor occupies local
+x -1 and 0 so its mouth remains a real walk cell instead of a half-block center. Width changes the side walls and
 branch mouths; it does not change the one-down-per-forward-block slope, headroom, or entrance
 step. Children inherit their root's width. The top entrance remains open rather than being
 lined as though its outdoor air were a cave. Existing shafts retain their saved entrance
@@ -107,7 +108,10 @@ homes and services can form streets and courtyards with natural sprawl. Building
 two-block gaps and inward fronts, with one-block gaps and other rotations when needed.
 They can align with any previously planned building rather than fixed sides of the center.
 
-Each building uses its own local ground elevation and applies its authored sink once.
+Each building uses its own local ground elevation and applies its authored sink once. A template
+with negative `sink` also reads the ground immediately outside its rotated public front. When
+that approach is higher than the footprint's modal plane, the building follows it so an exposed
+doorstep does not sit in a cut trench.
 The same terrain-preparation queues as normal construction clear and fill only its footprint.
 Founding applies this work immediately, without charging the recipe. Ground between buildings
 stays natural. Normal completion hooks register amenities and clear natural overhead vegetation.

--- a/docs/site-selection.md
+++ b/docs/site-selection.md
@@ -71,7 +71,9 @@ cover it.
 Before any candidate is scored, the heights of the whole search square are read once from the
 chunk heightmaps (`MOTION_BLOCKING_NO_LEAVES`, the real ground under a canopy) into a grid,
 so every candidate's flatness is arithmetic: its plane is the height most of its columns
-share, and ground with more than one column in eight past the per-column budget, or averaging
+share. A template raised with negative `sink` lifts that plane to the modal height immediately
+outside its rotated public front when the approach stands higher; this keeps its exposed lowest
+step above the bank on uneven ground. Ground with more than one column in eight past the per-column budget, or averaging
 past the levelling budget across the rest, is refused without a block scan. A few tall columns
 are let through because a tree reads as a tall column and is cleared, not levelled; one outlier
 is always allowed through even on a small footprint. The exact scan also uses that allowance for

--- a/docs/structure-authoring.md
+++ b/docs/structure-authoring.md
@@ -224,6 +224,8 @@ A template's layer 0 replaces the terrain's top block; `sink` buries that many m
 stair swallowed by the ground: a bottom-half stair in the layer that meets the surface. Run
 `tools/structure/seating-check.py <data-root>...` over a pack before activating it; a floor
 layer with such a stair wants `sink: -1`, while a farm's or plaza's edging stairs in a ground
-course are a judgement call. The Badlands storehouse, mine, bakery and tavern, the Desert
+course are a judgement call. Runtime placement also checks the rotated public-front ground for
+negative-sink templates and follows a higher approach rather than cutting a sunken doorway.
+The Badlands storehouse, mine, bakery and tavern, the Desert
 small houses and couple cottage, and the Birch mine and second watchtower were raised this way
 on 2026-09-10; buildings already standing keep their seat.

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineStep.java
@@ -117,8 +117,9 @@ import net.neoforged.neoforge.common.Tags;
  */
 public final class MineStep implements BlockWorkStep {
 
-  /** The corridor's half-width, the one definition of the shaft's shape (MineShaft). */
-  private int radius = MineShaft.RADIUS;
+  /** The corridor's transverse bounds, shared with excavation and navigation. */
+  private int minX = -MineShaft.RADIUS;
+  private int maxX = MineShaft.RADIUS;
   private MineTopology topology = new MineTopology(MineShaft.RADIUS);
 
   /**
@@ -375,7 +376,7 @@ public final class MineStep implements BlockWorkStep {
   private ShaftPick selectShaft(RealPerson person, MineShaft shaft) {
     BlockPos mouth = shaft.mouth();
     Rotation rotation = shaft.rotation();
-    activateShaft(mouth, rotation, shaft.radius());
+    activateShaft(shaft);
     ShaftPick entrance = selectEntranceClearance(person, shaft);
     if (entrance != null) {
       return entrance;
@@ -612,7 +613,7 @@ public final class MineStep implements BlockWorkStep {
     Level level = person.level();
     int floor = ribFloorY(depth);
     for (int step = 1; step <= FAN_LENGTH; step++) {
-      int x = side * (root.radius() + step);
+      int x = root.ribX(side, step);
       for (int dy = 0; dy < FAN_HEIGHT; dy++) {
         BlockPos cell = root.mouth().offset(new BlockPos(x, floor + dy, depth).rotate(root.rotation()));
         BlockState state = level.getBlockState(cell);
@@ -629,12 +630,24 @@ public final class MineStep implements BlockWorkStep {
     return true;
   }
 
-  private void activateShaft(BlockPos mouth, Rotation rotation, int radius) {
-    if (mouth.equals(this.activeMouth) && rotation == this.activeRotation && radius == this.radius) {
+  /** One rib cell counted out from the active corridor's appropriate edge. */
+  private int ribX(int side, int step) {
+    if (side != -1 && side != 1) {
+      throw new IllegalArgumentException("A mine branch side must be -1 or 1");
+    }
+    return side < 0 ? minX - step : maxX + step;
+  }
+
+  private void activateShaft(MineShaft shaft) {
+    BlockPos mouth = shaft.mouth();
+    Rotation rotation = shaft.rotation();
+    if (mouth.equals(this.activeMouth) && rotation == this.activeRotation
+        && shaft.minX() == this.minX && shaft.maxX() == this.maxX) {
       return;
     }
-    this.radius = radius;
-    this.topology = new MineTopology(radius);
+    this.minX = shaft.minX();
+    this.maxX = shaft.maxX();
+    this.topology = new MineTopology(minX, maxX);
     this.activeMouth = mouth;
     this.activeRotation = rotation;
     this.fanning = false;
@@ -833,7 +846,7 @@ public final class MineStep implements BlockWorkStep {
     for (int side = 1; side >= -1; side -= 2) {
       boolean cutting = true;
       for (int step = 1; step <= FAN_LENGTH && cutting; step++) {
-        int x = side * (radius + step);
+        int x = ribX(side, step);
         for (int dy = 0; dy < FAN_HEIGHT; dy++) {
           BlockPos local = new BlockPos(x, floorY + dy, zr);
           BlockPos world = mouth.offset(local.rotate(rotation));
@@ -885,7 +898,7 @@ public final class MineStep implements BlockWorkStep {
    */
   @Nullable
   private BlockPos ribTorch(RealPerson person, BlockPos mouth, Rotation rotation, int zr, int side, int floorY) {
-    BlockPos cell = new BlockPos(side * (radius + 2), floorY + 1, zr);
+    BlockPos cell = new BlockPos(ribX(side, 2), floorY + 1, zr);
     BlockPos world = mouth.offset(cell.rotate(rotation));
     Level level = person.level();
     if (!level.getBlockState(world).isAir()
@@ -1385,8 +1398,8 @@ public final class MineStep implements BlockWorkStep {
     if (local.getY() == -(local.getZ() - 2) && needsSeal(level, worldCell.above())) {
       return worldCell.above();
     }
-    if (Math.abs(local.getX()) == radius) {
-      int outward = local.getX() > 0 ? radius + 1 : -(radius + 1);
+    if (local.getX() == minX || local.getX() == maxX) {
+      int outward = local.getX() == minX ? minX - 1 : maxX + 1;
       BlockPos wallLocal = new BlockPos(outward, local.getY(), local.getZ());
       if (isDugSpace(wallLocal)) {
         return null; // an intentional rib doorway, not missing shaft lining
@@ -1624,7 +1637,7 @@ public final class MineStep implements BlockWorkStep {
 
   /**
    * Whether the open cursor cell wants a torch: the head-height cell of a ramp
-   * column on the corridor's edge (local x at the radius, y one above the column's
+   * column on either corridor edge, y one above the column's
    * bottom), with the walk cell under it already open, deep enough below the lit
    * mouth ({@link #TORCH_MIN_DEPTH}) and reading dimmer than
    * {@link #TORCH_LIGHT_FLOOR}, while the pack holds a torch to hang and a wall
@@ -1644,7 +1657,8 @@ public final class MineStep implements BlockWorkStep {
    */
   private boolean wantsTorch(RealPerson person, MineShaft shaft, BlockPos cell) {
     BlockPos local = this.offset;
-    if (Math.abs(local.getX()) != radius || local.getY() != -(local.getZ() + 1)) {
+    if ((local.getX() != minX && local.getX() != maxX)
+        || local.getY() != -(local.getZ() + 1)) {
       return false;
     }
     BlockPos mouth = shaft.mouth();
@@ -1674,7 +1688,7 @@ public final class MineStep implements BlockWorkStep {
   @Nullable
   private Direction torchWall(Level level, Rotation rotation, BlockPos cell) {
     for (Direction local : Direction.Plane.HORIZONTAL) {
-      if (MineShaft.withinCorridor(this.offset.relative(local), radius)) {
+      if (MineShaft.withinCorridor(this.offset.relative(local), minX, maxX)) {
         continue;
       }
       Direction worldDir = rotation.rotate(local);
@@ -1952,7 +1966,7 @@ public final class MineStep implements BlockWorkStep {
     // orientation. (Leaning -Z, which every prior angled version did, was Aaron's
     // long-standing "mining the wrong way" bug: the ramp ate back under the door.)
     // Every pick starts over at the mouth: the audit (see the class note).
-    this.offset = new BlockPos(-(radius + 1), -1, MineShaft.ENTRY_COLUMN);
+    this.offset = new BlockPos(minX - 1, -1, MineShaft.ENTRY_COLUMN);
     this.inward = 1;
     this.placeFloor = false;
     this.bailWater = false;
@@ -1968,11 +1982,11 @@ public final class MineStep implements BlockWorkStep {
         return RampScan.DRY_HOLE; // nothing solid within reach of the pattern; try again later
       }
       this.offset = this.offset.offset(1, 0, 0);
-      if (this.offset.getX() >= radius + 1) {
-        this.offset = new BlockPos(-radius, this.offset.getY(), this.offset.getZ() + 1);
+      if (this.offset.getX() > maxX) {
+        this.offset = new BlockPos(minX, this.offset.getY(), this.offset.getZ() + 1);
       }
       if (this.offset.getZ() >= MineShaft.RAMP_HEIGHT - 2 + this.inward) {
-        this.offset = new BlockPos(-radius, this.offset.getY() - 1, this.inward - 1);
+        this.offset = new BlockPos(minX, this.offset.getY() - 1, this.inward - 1);
         this.inward++;
       }
       facePos = face(mouth, rotation);

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineTopology.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/MineTopology.java
@@ -39,14 +39,23 @@ final class MineTopology {
    * one entrance marker, so a child gets a visible threshold without wasting a
    * torch on both walls.
    */
-  private final int radius;
+  private final int minX;
+  private final int maxX;
 
   MineTopology(int radius) {
-    this.radius = radius;
+    this(-radius, radius);
+  }
+
+  MineTopology(int minX, int maxX) {
+    if (minX > 0 || maxX < 0 || minX > maxX) {
+      throw new IllegalArgumentException("Mine corridor must contain local x 0");
+    }
+    this.minX = minX;
+    this.maxX = maxX;
   }
 
   List<BlockPos> entranceTorchCells() {
-    return List.of(new BlockPos(-radius, -1, 0), new BlockPos(radius, -1, 0));
+    return List.of(new BlockPos(minX, -1, 0), new BlockPos(maxX, -1, 0));
   }
 
   /** The walk-cell Y shared by a ramp column and any rib cut from it. */
@@ -65,7 +74,7 @@ final class MineTopology {
       int floor = floorY(z);
       int ceiling = Math.min(floor + MineShaft.RAMP_HEIGHT - 1, -1);
       for (int y = floor; y <= ceiling; y++) {
-        for (int x = -radius; x <= radius; x++) {
+        for (int x = minX; x <= maxX; x++) {
           cells.add(new BlockPos(x, y, z));
         }
       }
@@ -193,14 +202,14 @@ final class MineTopology {
 
   /** The five-cell-high descending shaft, capped below the surface structure. */
   boolean isRamp(BlockPos local) {
-    return MineShaft.withinCorridor(local, radius)
+    return MineShaft.withinCorridor(local, minX, maxX)
         && local.getY() >= -(local.getZ() + 2)
         && local.getY() <= -(local.getZ() - 2);
   }
 
   /** A one-cell-wide horizontal prospecting rib on one of the fixed grid lines. */
   boolean isRib(BlockPos local) {
-    return MineShaft.withinRib(local, radius);
+    return MineShaft.withinRib(local, minX, maxX);
   }
 
   /**
@@ -212,8 +221,8 @@ final class MineTopology {
     if (!isRib(local)) {
       return null;
     }
-    int side = Integer.signum(local.getX());
-    return new BlockPos(side * (radius + 1), local.getY(), local.getZ());
+    int doorwayX = local.getX() < minX ? minX - 1 : maxX + 1;
+    return new BlockPos(doorwayX, local.getY(), local.getZ());
   }
 
   /** Every cell the mine deliberately opens, whether it belongs to the ramp or a rib. */

--- a/src/main/java/com/quzzar/kithkyn/village/Village.java
+++ b/src/main/java/com/quzzar/kithkyn/village/Village.java
@@ -778,7 +778,8 @@ public class Village {
     // chest and its treasury with it.
     LocationValidator.Search search = LocationValidator.findValidLocation(level,
         BlockPos.of(getTownCenter().getCenterLocation()).below(), template,
-        Buildings.getByName(buildingName).getEntranceFacing(), List.of(Rotation.values()), this, random);
+        Buildings.getByName(buildingName).getEntranceFacing(), Buildings.getByName(buildingName).getSink(),
+        List.of(Rotation.values()), this, random);
     if (!search.found()) {
       // Remembered exactly as a real project's refusal is, so a dev-placed
       // building that finds no room leaves the village able to say so: that is
@@ -1544,7 +1545,7 @@ public class Village {
 
       LocationValidator.Search search = LocationValidator.findValidLocation(level,
           BlockPos.of(getTownCenter().getCenterLocation()).below(), template,
-          buildingInfo.getEntranceFacing(), List.of(Rotation.values()), this, random);
+          buildingInfo.getEntranceFacing(), buildingInfo.getSink(), List.of(Rotation.values()), this, random);
 
       if (!search.found()) {
         // Remember it, or the planner will keep choosing this and failing here

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/BuildingInfo.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/BuildingInfo.java
@@ -50,15 +50,17 @@ public class BuildingInfo {
     }
 
     public MineEntrance {
-      if (width != 3 && width != 5) throw new IllegalArgumentException("Mine width must be 3 or 5");
+      if (width != 2 && width != 3 && width != 5) {
+        throw new IllegalArgumentException("Mine width must be 2, 3 or 5");
+      }
     }
 
     public static final Codec<MineEntrance> CODEC = RecordCodecBuilder.create(inst -> inst.group(
         Direction.CODEC.optionalFieldOf("facing", Direction.SOUTH).forGetter(MineEntrance::facing),
         BlockPos.CODEC.optionalFieldOf("offset", BlockPos.ZERO).forGetter(MineEntrance::offset),
-        Codec.INT.validate(width -> width == 3 || width == 5
+        Codec.INT.validate(width -> width == 2 || width == 3 || width == 5
             ? com.mojang.serialization.DataResult.success(width)
-            : com.mojang.serialization.DataResult.error(() -> "Mine width must be 3 or 5"))
+            : com.mojang.serialization.DataResult.error(() -> "Mine width must be 2, 3 or 5"))
             .optionalFieldOf("width", 5).forGetter(MineEntrance::width)
     ).apply(inst, MineEntrance::new));
   }

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/FoundingLayout.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/FoundingLayout.java
@@ -33,7 +33,7 @@ public final class FoundingLayout {
       var template = village.getLevel().getStructureManager().getOrCreate(
           net.minecraft.resources.ResourceLocation.fromNamespaceAndPath(com.quzzar.kithkyn.Kithkyn.MODID, info.getPath()));
       var search = LocationValidator.findValidLocation(village.getLevel(), anchor, template,
-          info.getEntranceFacing(), List.of(Rotation.values()), village, context, random);
+          info.getEntranceFacing(), info.getSink(), List.of(Rotation.values()), village, context, random);
       if (!search.found()) return Optional.empty();
       var structure = new InstantBuildStructure(new Building(info.getName(), search.rotation()), random, village.getLevel())
           .withIdentity(village.getIdentity()).seatAtOrigin(search.site().below(info.getSink()), new HashSet<>());

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/LocationValidator.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/LocationValidator.java
@@ -156,7 +156,8 @@ public class LocationValidator {
    * whichever way slots in. Pass a single rotation to search one fixed facing.
    */
   public static Search findValidLocation(ServerLevelAccessor levelAccess, BlockPos centerPos,
-      StructureTemplate template, Direction entranceFacing, List<Rotation> rotations, Village village, Random random) {
+      StructureTemplate template, Direction entranceFacing, int sink, List<Rotation> rotations,
+      Village village, Random random) {
     List<BoundingBox> anchors = new ArrayList<>();
     for (Building building : village.getBuildings()) {
       BoundingBox local = BuildingUpgrade.footprintOf(levelAccess, building);
@@ -167,13 +168,14 @@ public class LocationValidator {
     PlacementContext context = new PlacementContext(anchors, village.getBuildings().size(),
         village.getTownCenter().getRadius(), (x, z) -> village.hasClaimed(new BlockPos(x, 0, z)),
         (ground, bounds) -> true);
-    return findValidLocation(levelAccess, centerPos, template, entranceFacing, rotations, village, context, random);
+    return findValidLocation(levelAccess, centerPos, template, entranceFacing, sink,
+        rotations, village, context, random);
   }
 
   /** The ordinary growth search, also usable against buildings reserved by an uncommitted founding plan. */
   public static Search findValidLocation(ServerLevelAccessor levelAccess, BlockPos centerPos,
-      StructureTemplate template, Direction entranceFacing, List<Rotation> rotations, Village village,
-      PlacementContext context, Random random) {
+      StructureTemplate template, Direction entranceFacing, int sink, List<Rotation> rotations,
+      Village village, PlacementContext context, Random random) {
     ServerLevel level = levelAccess.getLevel();
 
     // The village grows outwards as it builds, but the ring never collapses: a
@@ -197,7 +199,8 @@ public class LocationValidator {
       maxSpan = Math.max(maxSpan, Math.max(rotated.getXSpan(), rotated.getZSpan()));
     }
     HeightGrid grid = new HeightGrid(level, centerPos, sweepRadius + maxSpan);
-    Hunt hunt = new Hunt(level, village, context, boundsByRotation, grid, centerPos, entranceFacing, random);
+    Hunt hunt = new Hunt(level, village, context, boundsByRotation, grid, centerPos,
+        entranceFacing, sink, random);
 
     // City form comes from relationships, not a radial lot lottery. Try the
     // exact frontage slots at both lane widths around every completed building
@@ -355,6 +358,15 @@ public class LocationValidator {
   }
 
   /**
+   * Raised templates expose their lowest course above the surrounding ground.
+   * If the authored front meets a bank above the footprint's modal plane, seat
+   * the whole building against that approach instead of burying its entrance.
+   */
+  static int seatingPlane(int footprintPlane, int sink, int approachPlane) {
+    return sink < 0 ? Math.max(footprintPlane, approachPlane) : footprintPlane;
+  }
+
+  /**
    * Ground heights for the whole search square, read once from the chunk
    * heightmaps so every candidate's flatness is arithmetic rather than a block
    * scan (docs/site-selection.md, the first runtime mitigation). Chunks that
@@ -420,7 +432,7 @@ public class LocationValidator {
      * column happened to be a dip in an otherwise level plain.
      */
     @Nullable
-    Reading read(int originX, int originZ, BoundingBox bounds) {
+    Reading read(int originX, int originZ, BoundingBox bounds, int sink, Direction front) {
       int[] footprint = new int[bounds.getXSpan() * bounds.getZSpan()];
       int i = 0;
       for (int x = bounds.minX(); x <= bounds.maxX(); x++) {
@@ -443,6 +455,13 @@ public class LocationValidator {
           plane = footprint[j];
         }
       }
+      if (sink < 0) {
+        int approach = frontHeight(originX, originZ, bounds, front);
+        if (approach == NO_GROUND) {
+          return null;
+        }
+        plane = seatingPlane(plane, sink, approach);
+      }
       int steep = 0;
       int offPlane = 0;
       int levelOffPlane = 0;
@@ -456,6 +475,39 @@ public class LocationValidator {
         }
       }
       return new Reading(plane, footprint.length, steep, offPlane, levelOffPlane);
+    }
+
+    /** Modal ground immediately outside the authored front edge, ties to higher ground. */
+    private int frontHeight(int originX, int originZ, BoundingBox bounds, Direction front) {
+      int span = front.getAxis() == Direction.Axis.X ? bounds.getZSpan() : bounds.getXSpan();
+      int[] heights = new int[span];
+      int index = 0;
+      if (front.getAxis() == Direction.Axis.X) {
+        int x = originX + (front == Direction.WEST ? bounds.minX() - 1 : bounds.maxX() + 1);
+        for (int z = bounds.minZ(); z <= bounds.maxZ(); z++) {
+          heights[index++] = ground(x, originZ + z);
+        }
+      } else {
+        int z = originZ + (front == Direction.NORTH ? bounds.minZ() - 1 : bounds.maxZ() + 1);
+        for (int x = bounds.minX(); x <= bounds.maxX(); x++) {
+          heights[index++] = ground(originX + x, z);
+        }
+      }
+      if (Arrays.stream(heights).anyMatch(height -> height == NO_GROUND)) {
+        return NO_GROUND;
+      }
+      Arrays.sort(heights);
+      int mode = heights[0];
+      int run = 0;
+      int bestRun = 0;
+      for (int i = 0; i < heights.length; i++) {
+        run = i > 0 && heights[i] == heights[i - 1] ? run + 1 : 1;
+        if (run >= bestRun) {
+          bestRun = run;
+          mode = heights[i];
+        }
+      }
+      return mode;
     }
   }
 
@@ -486,6 +538,7 @@ public class LocationValidator {
     private final HeightGrid grid;
     private final BlockPos centre;
     private final Direction entranceFacing;
+    private final int sink;
     private final Random random;
 
     @Nullable
@@ -501,7 +554,7 @@ public class LocationValidator {
 
     Hunt(ServerLevel level, Village village, PlacementContext context,
         EnumMap<Rotation, BoundingBox> boundsByRotation, HeightGrid grid,
-        BlockPos centre, Direction entranceFacing, Random random) {
+        BlockPos centre, Direction entranceFacing, int sink, Random random) {
       this.level = level;
       this.village = village;
       this.context = context;
@@ -509,6 +562,7 @@ public class LocationValidator {
       this.grid = grid;
       this.centre = centre;
       this.entranceFacing = entranceFacing;
+      this.sink = sink;
       this.random = random;
     }
 
@@ -528,7 +582,7 @@ public class LocationValidator {
       int x = centre.getX() + relX;
       int z = centre.getZ() + relZ;
       BoundingBox bounds = boundsByRotation.get(rotation);
-      Reading reading = grid.read(x, z, bounds);
+      Reading reading = grid.read(x, z, bounds, sink, rotation.rotate(entranceFacing));
       if (reading == null) {
         unloaded++;
         return;

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/MineShaft.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/MineShaft.java
@@ -18,8 +18,9 @@ import net.minecraft.world.level.block.Rotation;
  * One frame in a mine's bounded shaft network, and the ramps and parent ribs
  * that form the way in and out.
  *
- * <p>The shaft is the corridor the miner's cursor digs (MineStep): {@link #RADIUS}
- * either side of the mouth's centre line, ramping one block down for every
+ * <p>The shaft is the corridor the miner's cursor digs (MineStep). Its authored
+ * transverse bounds may sit symmetrically around the mouth or, for a two-wide
+ * entrance, occupy local x -1 and 0. It ramps one block down for every
  * block forward, so the walk cell of column {@code z} sits {@code z + 2} below
  * the mouth. In the mine's own frame the mouth is the origin, forward is +z,
  * and a world position is read into that frame by undoing the shaft's rotation
@@ -41,7 +42,7 @@ import net.minecraft.world.level.block.Rotation;
  */
 public final class MineShaft {
 
-  /** Cells either side of the centre line the shaft is dug to: five wide. */
+  /** Default cells either side of the centre line: five wide. */
   public static final int RADIUS = 2;
 
   /** The threshold and ramp headroom do not shrink with the corridor width. */
@@ -65,7 +66,8 @@ public final class MineShaft {
   /** How near the mouth counts as standing at it, squared. */
   private static final double AT_MOUTH_SQR = 9.0D;
 
-  private final int radius;
+  private final int minX;
+  private final int maxX;
   private final BlockPos mouth;
   private final Rotation rotation;
   private final long rootStation;
@@ -74,9 +76,10 @@ public final class MineShaft {
   @Nullable
   private final MineBranch branch;
 
-  private MineShaft(BlockPos mouth, Rotation rotation, long rootStation, int radius,
+  private MineShaft(BlockPos mouth, Rotation rotation, long rootStation, int minX, int maxX,
       @Nullable MineShaft parent, @Nullable MineBranch branch) {
-    this.radius = radius;
+    this.minX = minX;
+    this.maxX = maxX;
     this.mouth = mouth;
     this.rotation = rotation;
     this.rootStation = rootStation;
@@ -89,13 +92,32 @@ public final class MineShaft {
     return root(mouth, rotation, rootStation, 5);
   }
 
-  /** A shaft with an authored odd corridor width. */
+  /** A shaft with an authored corridor width. Even widths keep the mouth in local x 0. */
   public static MineShaft root(BlockPos mouth, Rotation rotation, long rootStation, int width) {
-    if (width != 3 && width != 5) throw new IllegalArgumentException("Mine width must be 3 or 5");
-    return new MineShaft(mouth, rotation, rootStation, width / 2, null, null);
+    if (width != 2 && width != 3 && width != 5) {
+      throw new IllegalArgumentException("Mine width must be 2, 3 or 5");
+    }
+    int minX = -width / 2;
+    return new MineShaft(mouth, rotation, rootStation, minX, minX + width - 1, null, null);
   }
 
-  public int radius() { return radius; }
+  /** Largest transverse distance, retained for spacing older symmetric shafts. */
+  public int radius() { return Math.max(-minX, maxX); }
+
+  public int width() { return maxX - minX + 1; }
+
+  public int minX() { return minX; }
+
+  public int maxX() { return maxX; }
+
+  /** One rib cell counted out from the appropriate edge of this corridor. */
+  public int ribX(int side, int step) {
+    if (side != -1 && side != 1) {
+      throw new IllegalArgumentException("A mine branch side must be -1 or 1");
+    }
+    if (step < 1) throw new IllegalArgumentException("A mine rib step must be positive");
+    return side < 0 ? minX - step : maxX + step;
+  }
 
   /** The same authored frame for excavation, navigation, and child-shaft planning. */
   public static MineShaft root(Building building, BlockPos station) {
@@ -115,9 +137,10 @@ public final class MineShaft {
     if (root.parent != null || root.rootStation != branch.rootStation()) {
       throw new IllegalArgumentException("A child shaft must belong to its root work station");
     }
-    BlockPos mouth = childMouth(root.mouth, root.rotation, branch.sourceDepth(), branch.side(), root.radius);
+    BlockPos mouth = childMouth(root.mouth, root.rotation, branch.sourceDepth(), branch.side(),
+        root.minX, root.maxX);
     Rotation rotation = outwardRotation(root.rotation, branch.side());
-    return new MineShaft(mouth, rotation, root.rootStation, root.radius, root, branch);
+    return new MineShaft(mouth, rotation, root.rootStation, root.minX, root.maxX, root, branch);
   }
 
   public BlockPos mouth() {
@@ -173,7 +196,15 @@ public final class MineShaft {
 
   public static BlockPos childMouth(BlockPos rootMouth, Rotation rootRotation,
       int sourceDepth, int side, int radius) {
-    int end = side * (radius + RIB_LENGTH + 1);
+    return childMouth(rootMouth, rootRotation, sourceDepth, side, -radius, radius);
+  }
+
+  private static BlockPos childMouth(BlockPos rootMouth, Rotation rootRotation,
+      int sourceDepth, int side, int minX, int maxX) {
+    if (side != -1 && side != 1) {
+      throw new IllegalArgumentException("A mine branch side must be -1 or 1");
+    }
+    int end = side < 0 ? minX - RIB_LENGTH - 1 : maxX + RIB_LENGTH + 1;
     int y = floorY(sourceDepth) + 1;
     return rootMouth.offset(new BlockPos(end, y, sourceDepth).rotate(rootRotation));
   }
@@ -198,9 +229,14 @@ public final class MineShaft {
   }
 
   public static boolean withinCorridor(BlockPos local, int radius) {
+    return withinCorridor(local, -radius, radius);
+  }
+
+  public static boolean withinCorridor(BlockPos local, int minX, int maxX) {
     int floorY = local.getZ() < 0 ? -1 : -(local.getZ() + 2);
     int topY = Math.min(floorY + RAMP_HEIGHT - 1, -1);
-    return Math.abs(local.getX()) <= radius
+    return local.getX() >= minX
+        && local.getX() <= maxX
         && local.getZ() >= ENTRY_COLUMN
         && local.getY() >= floorY
         && local.getY() <= topY;
@@ -212,12 +248,18 @@ public final class MineShaft {
   }
 
   public static boolean withinRib(BlockPos local, int radius) {
+    return withinRib(local, -radius, radius);
+  }
+
+  public static boolean withinRib(BlockPos local, int minX, int maxX) {
     int z = local.getZ();
     if (z < RIB_MIN_LINE || z % RIB_PITCH != 0) {
       return false;
     }
-    int ax = Math.abs(local.getX());
-    if (ax < radius + 1 || ax > radius + RIB_LENGTH) {
+    int x = local.getX();
+    boolean left = x >= minX - RIB_LENGTH && x < minX;
+    boolean right = x > maxX && x <= maxX + RIB_LENGTH;
+    if (!left && !right) {
       return false;
     }
     int floorY = z < 0 ? -1 : -(z + 2);
@@ -233,12 +275,17 @@ public final class MineShaft {
   }
 
   public static boolean withinExcavation(BlockPos local, int radius) {
+    return withinExcavation(local, -radius, radius);
+  }
+
+  public static boolean withinExcavation(BlockPos local, int minX, int maxX) {
     int z = local.getZ();
     int floorY = z < 0 ? -1 : -(z + 2);
-    boolean betweenRampSteps = Math.abs(local.getX()) <= radius
+    boolean betweenRampSteps = local.getX() >= minX
+        && local.getX() <= maxX
         && z >= ENTRY_COLUMN
         && local.getY() == floorY - 1;
-    return withinCorridor(local, radius) || withinRib(local, radius)
+    return withinCorridor(local, minX, maxX) || withinRib(local, minX, maxX)
         || withinEntranceClearance(local) || betweenRampSteps;
   }
 
@@ -261,16 +308,21 @@ public final class MineShaft {
   }
 
   public static boolean belowExcavation(BlockPos local, int radius) {
+    return belowExcavation(local, -radius, radius);
+  }
+
+  public static boolean belowExcavation(BlockPos local, int minX, int maxX) {
     int z = local.getZ();
     int floorY = z < 0 ? -1 : -(z + 2);
-    boolean belowRamp = Math.abs(local.getX()) <= radius
+    boolean belowRamp = local.getX() >= minX
+        && local.getX() <= maxX
         && z >= ENTRY_COLUMN
         && local.getY() < floorY - 1;
-    int ax = Math.abs(local.getX());
+    int x = local.getX();
     boolean belowRib = z >= RIB_MIN_LINE
         && z % RIB_PITCH == 0
-        && ax >= radius + 1
-        && ax <= radius + RIB_LENGTH
+        && (x >= minX - RIB_LENGTH && x < minX
+            || x > maxX && x <= maxX + RIB_LENGTH)
         && local.getY() < floorY;
     return belowRamp || belowRib;
   }
@@ -409,7 +461,7 @@ public final class MineShaft {
       return false;
     }
     for (MineShaft shaft : shafts) {
-      if (belowExcavation(shaft.local(world), shaft.radius)) {
+      if (belowExcavation(shaft.local(world), shaft.minX, shaft.maxX)) {
         return true;
       }
     }
@@ -420,14 +472,14 @@ public final class MineShaft {
   private BlockPos hop(BlockPos from, BlockPos to) {
     BlockPos localFrom = local(from);
     BlockPos localTo = local(to);
-    boolean fromIn = withinExcavation(localFrom, radius);
+    boolean fromIn = withinExcavation(localFrom, minX, maxX);
     // The root mouth is also the surface work-station anchor. Its clearance
     // belongs to excavation, but approaching that station from outside must
     // not require walking into the first stair before it has been dug.
     if (this.parent == null && !fromIn && localTo.equals(BlockPos.ZERO)) {
       return null;
     }
-    boolean toIn = withinExcavation(localTo, radius);
+    boolean toIn = withinExcavation(localTo, minX, maxX);
     if (!fromIn && !toIn) {
       return null;
     }
@@ -440,7 +492,7 @@ public final class MineShaft {
       // route even though every planned footing is open, leaving the miner to
       // repeat the child target from the village center forever.
       if (localFrom.getZ() == localTo.getZ()
-          && (withinRib(localFrom, radius) || withinRib(localTo, radius))
+          && (withinRib(localFrom, minX, maxX) || withinRib(localTo, minX, maxX))
           && Math.abs(localTo.getX() - localFrom.getX()) > HOP) {
         return ribWalkCell(localFrom, localTo.getX());
       }
@@ -450,7 +502,7 @@ public final class MineShaft {
         // cell from the source line. The target is still far down the rib, so
         // first land on the ramp's centre doorway; the next request will begin
         // the adjacent horizontal hops above.
-        if (withinRib(localTo, radius)
+        if (withinRib(localTo, minX, maxX)
             && Math.abs(localTo.getX() - localFrom.getX()) > HOP) {
           return walkCell(localTo.getZ());
         }
@@ -459,7 +511,7 @@ public final class MineShaft {
       return walkCell(localFrom.getZ() + (ahead > 0 ? HOP : -HOP));
     }
     if (fromIn) {
-      if (withinRib(localFrom, radius)) {
+      if (withinRib(localFrom, minX, maxX)) {
         // First leave a rib through its doorway. Treating every non-corridor
         // target as outside the mine sent a miner UP the ramp while their work
         // waited four blocks farther along this same branch.
@@ -513,7 +565,7 @@ public final class MineShaft {
   }
 
   private boolean contains(BlockPos world) {
-    return withinExcavation(local(world), radius);
+    return withinExcavation(local(world), minX, maxX);
   }
 
   @Nullable
@@ -521,7 +573,7 @@ public final class MineShaft {
       boolean leaving) {
     for (MineShaft child : children) {
       BlockPos local = child.local(world);
-      if (withinExcavation(local, child.radius) && (!leaving || local.getZ() >= 0)) {
+      if (withinExcavation(local, child.minX, child.maxX) && (!leaving || local.getZ() >= 0)) {
         return child;
       }
     }
@@ -561,7 +613,7 @@ public final class MineShaft {
       int floor = floorY(z);
       int ceiling = Math.min(floor + RAMP_HEIGHT - 1, -1);
       for (int y = floor; y <= ceiling; y++) {
-        for (int x = -shaft.radius; x <= shaft.radius; x++) {
+        for (int x = shaft.minX; x <= shaft.maxX; x++) {
           BlockPos world = shaft.mouth.offset(new BlockPos(x, y, z).rotate(shaft.rotation));
           if (world.getY() >= minimumBuildY) {
             consumer.accept(world);
@@ -573,7 +625,7 @@ public final class MineShaft {
       }
       for (int side = 1; side >= -1; side -= 2) {
         for (int step = 1; step <= RIB_LENGTH; step++) {
-          int x = side * (shaft.radius + step);
+          int x = shaft.ribX(side, step);
           for (int y = floor; y < floor + RIB_HEIGHT; y++) {
             BlockPos world = shaft.mouth.offset(new BlockPos(x, y, z).rotate(shaft.rotation));
             if (world.getY() >= minimumBuildY) {

--- a/src/test/java/com/quzzar/kithkyn/entities/ai/goals/work/MineTopologyTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ai/goals/work/MineTopologyTest.java
@@ -18,6 +18,21 @@ class MineTopologyTest {
   private final MineTopology topology = new MineTopology(MineShaft.RADIUS);
 
   @Test
+  void twoWideTopologyKeepsItsAsymmetricRampAndRibsConnected() {
+    MineTopology twoWide = new MineTopology(-1, 0);
+    var cells = twoWide.rampCellsThrough(4);
+
+    assertTrue(cells.stream().allMatch(cell -> cell.getX() == -1 || cell.getX() == 0));
+    assertEquals(java.util.List.of(
+        new BlockPos(-1, -1, 0),
+        new BlockPos(0, -1, 0)), twoWide.entranceTorchCells());
+    assertTrue(twoWide.isRib(new BlockPos(-2, -6, 4)));
+    assertTrue(twoWide.isRib(new BlockPos(1, -6, 4)));
+    assertEquals(new BlockPos(-2, -6, 4), twoWide.ribDoorway(new BlockPos(-9, -6, 4)));
+    assertEquals(new BlockPos(1, -6, 4), twoWide.ribDoorway(new BlockPos(8, -6, 4)));
+  }
+
+  @Test
   void narrowShaftRetainsRampHeadroomAndEntryWhileMovingItsWallsAndRibs() {
     MineTopology narrow = new MineTopology(1);
     var cells = narrow.rampCellsThrough(12);

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/BuildingEntranceTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/BuildingEntranceTest.java
@@ -85,6 +85,16 @@ class BuildingEntranceTest {
   }
 
   @Test
+  void aTwoBlockAuthoredMineOpeningIsAccepted() {
+    var json = JsonParser.parseString("{\"facing\":\"south\",\"offset\":[0,1,1],\"width\":2}");
+    BuildingInfo.MineEntrance entrance = BuildingInfo.MineEntrance.CODEC
+        .parse(JsonOps.INSTANCE, json).getOrThrow();
+
+    assertEquals(2, entrance.width());
+    assertEquals(new BlockPos(0, 1, 1), entrance.offset());
+  }
+
+  @Test
   void legacyStorehousesKeepTheirActualGroundWhileFreshOnesGetTheRaisedStep() throws Exception {
     BuildingInfo info = definition("storehouse_birch_forest_1");
     Buildings.reload(Map.of(info.getName(), info));

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/LocationPreferenceTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/LocationPreferenceTest.java
@@ -10,6 +10,13 @@ import org.junit.jupiter.api.Test;
 
 class LocationPreferenceTest {
 
+  @Test
+  void raisedDoorstepTemplatesFollowAHigherFrontBank() {
+    assertEquals(64, LocationValidator.seatingPlane(62, -1, 64));
+    assertEquals(62, LocationValidator.seatingPlane(62, -1, 61));
+    assertEquals(62, LocationValidator.seatingPlane(62, 0, 64));
+  }
+
   private static LocationValidator.Fit fit(int gap, int inward, int cost, Rotation rotation) {
     return new LocationValidator.Fit(rotation, BlockPos.ZERO,
         new SitePreparation.SiteCost(cost, 0, 0, false, false, ""),

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/MineShaftTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/MineShaftTest.java
@@ -15,6 +15,28 @@ import net.minecraft.world.level.block.Rotation;
 class MineShaftTest {
 
   @Test
+  void twoWideShaftUsesOnlyTheTwoAuthoredColumnsInEveryRotation() {
+    for (Rotation rotation : Rotation.values()) {
+      BlockPos mouth = new BlockPos(30, 100, 40);
+      MineShaft root = MineShaft.root(mouth, rotation, 42L, 2);
+
+      assertEquals(2, root.width());
+      assertEquals(-1, root.minX());
+      assertEquals(0, root.maxX());
+      assertTrue(MineShaft.withinCorridor(new BlockPos(-1, -7, 5), root.minX(), root.maxX()));
+      assertTrue(MineShaft.withinCorridor(new BlockPos(0, -7, 5), root.minX(), root.maxX()));
+      assertFalse(MineShaft.withinCorridor(new BlockPos(1, -7, 5), root.minX(), root.maxX()));
+
+      MineShaft left = MineShaft.child(root, new MineBranch(42L, 8, -1, false));
+      MineShaft right = MineShaft.child(root, new MineBranch(42L, 8, 1, false));
+      assertEquals(mouth.offset(new BlockPos(-9, -10, 8).rotate(rotation)), left.entry());
+      assertEquals(mouth.offset(new BlockPos(8, -10, 8).rotate(rotation)), right.entry());
+      assertEquals(2, left.width());
+      assertEquals(2, right.width());
+    }
+  }
+
+  @Test
   void narrowRootAndChildrenKeepTheirWidthAndAdjacentEntryInEveryRotation() {
     for (Rotation rotation : Rotation.values()) {
       BlockPos mouth = new BlockPos(30, 100, 40);

--- a/tools/structure/swamp-catalog-20260911.json
+++ b/tools/structure/swamp-catalog-20260911.json
@@ -39,10 +39,6 @@
       ],
       "source": "run/swamp-full-review/approved-live-edits/NF01.2.nbt",
       "source_sha256": "f3754648af10ee49f1d9dfb9877bb3fe6a711d0ba0c86aad51d5b9fc23e6e3fb",
-      "asset": "run/swamp-integration/datapack/data/kithkyn/structure/village_center_swamp_1.nbt",
-      "asset_sha256": "e5848ddf5907ee4ded5284420af5d243e0e052eb219055327b86bef135da9570",
-      "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/village_center_swamp_1.json",
-      "definition_sha256": "8477f8f542807dbeb4f94a92466ef3d83a7074048f515d09e3df02cb1bded372",
       "approval_revision": {
         "recorded": "2026-09-11",
         "capture": "run/swamp-town-center-edit-20260911/capture/NF01.2-user-edit.nbt",
@@ -53,10 +49,15 @@
         ],
         "changes": [
           "hanging soul lantern changed to normal lantern at local 1,4,10",
-          "lower campfire lit at local 9,4,11"
+          "lower campfire lit at local 9,4,11",
+          "15 cobbled deepslate slabs and 5 cobbled deepslate stairs mapped to cobblestone equivalents"
         ],
         "verification": "same 25x15x22 envelope and 8,080 exported cells; no barrier or structure-void blocks"
-      }
+      },
+      "asset": "run/swamp-integration/datapack/data/kithkyn/structure/village_center_swamp_1.nbt",
+      "asset_sha256": "9ed72758f71b5a529c7dbfe07ae23aa0ba47e9dd822d8d43c354784ecd0bfe84",
+      "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/village_center_swamp_1.json",
+      "definition_sha256": "8477f8f542807dbeb4f94a92466ef3d83a7074048f515d09e3df02cb1bded372"
     },
     {
       "exhibit": "NE03.6",
@@ -73,7 +74,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/couple_cottage_swamp_1.nbt",
       "asset_sha256": "8bb48e8579e29f682c10740484929416deaf4829a489602e9c67987df46d2320",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/couple_cottage_swamp_1.json",
-      "definition_sha256": "3880a55dbaa70ba14fdaadb3d56e5e0e53d98524fbdc07201a4b766de20e1a1f"
+      "definition_sha256": "eee7c5b26bf7e36c1873f339214180ff34dd427faaaf7ed6c5bb848e4af4cc8b"
     },
     {
       "exhibit": "NE03.8",
@@ -90,7 +91,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/house_swamp_1__two_bed.nbt",
       "asset_sha256": "860d370b8fdcd66375e01576502bf1d984a97cc9dd6e6d2fc458943cd028cc54",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/house_swamp_1__two_bed.json",
-      "definition_sha256": "46b916f289f079dec71fa64eced0c26ce717e6f3a21565ee3492a765f17a9c15"
+      "definition_sha256": "eac73b1a51f8e4d5bb9dc4a9f0f68edbd93708d54dd43ca32049cd39edcede4a"
     },
     {
       "exhibit": "NE03.5",
@@ -107,7 +108,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/house_swamp_1.nbt",
       "asset_sha256": "0a4b0f7ce0acd578d1d332c7babffe9bba09805b9b801ef4c204336c127ee82e",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/house_swamp_1.json",
-      "definition_sha256": "e5f4a3c5bc0d23e22e04fa1814086382a566995fce36ec125e61bb9fb2218bdd"
+      "definition_sha256": "847eb295870dcf4fb82a09ef519da98c67c58fff6a8a58b917c1ecf6f584fce4"
     },
     {
       "exhibit": "NF04.4",
@@ -141,7 +142,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/church_swamp_1__cleric_couple_home.nbt",
       "asset_sha256": "3a398a12efe0a055fa4c7d24cf83b283c0d87581deb82a27a5d2712b36a05641",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/church_swamp_1__cleric_couple_home.json",
-      "definition_sha256": "ab601e4243f7a5f7d88cb686fb38fde10df135c8aa4b050a93c409ba2e0e4a1b"
+      "definition_sha256": "d269527eab31e47b0ff3d1ef63eac986fde849a7e309e387c1f21c7b3fc06f73"
     },
     {
       "exhibit": "NF04.2",
@@ -158,7 +159,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/church_swamp_1__cleric_mixed_home.nbt",
       "asset_sha256": "c92d5db699c8f3bf6d7cac963ae6fba445658d0e66706502bce0461a9d7a47d5",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/church_swamp_1__cleric_mixed_home.json",
-      "definition_sha256": "afba1db46baf44ab0367f3401ad0881acd9110bc579e8be353a6fe27e5ce0c70"
+      "definition_sha256": "57c43630b1e747742023d9b44cf940cab6f6b8894ae138483a99cb8908c0b7ce"
     },
     {
       "exhibit": "NF04.1",
@@ -192,7 +193,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/blacksmith_swamp_1.nbt",
       "asset_sha256": "385569348ff9dd2928360850e2655304e570ecf1ec38fc4d6b11c05aa63755b9",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/blacksmith_swamp_1.json",
-      "definition_sha256": "47d48d5041744d451e2dcf00a227b0fa1d0fa9e7464e6dde728b30cd68579024"
+      "definition_sha256": "61123c61dbe41d56b8d4a2a42524c76bced204b837c24d811b6a24fbc281db7c"
     },
     {
       "exhibit": "NE06.9",
@@ -243,7 +244,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/bakery_swamp_1.nbt",
       "asset_sha256": "9b4d4759e9e9fc0395ec775e27558f0a50ec7f4a0fd4bab48d6f6c9906d51c08",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/bakery_swamp_1.json",
-      "definition_sha256": "6870c0c6de611ea21c727252ac071d7fb2c6f2e1ff1e571a99ec2aab2124189a"
+      "definition_sha256": "8366c3645d526892aaa690944df476259ec06b10298a0dcbc2eb13fe2f7f5e8b"
     },
     {
       "exhibit": "NE04.3",
@@ -277,7 +278,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/tavern_swamp_1.nbt",
       "asset_sha256": "aede15d3adcbeeb190f9499d1af238b1ec49c6a23f97f81ab99f677d43855792",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/tavern_swamp_1.json",
-      "definition_sha256": "e7730ccc5b1638efa5ad2f3fd15ceb07ea511a77a1c234899a58fa71e7d48f1d"
+      "definition_sha256": "ee471a37433da126f11e7ea9fcbe7d5055bdfcaa1ba5b63d8197409761df1765"
     },
     {
       "exhibit": "NE01.8",
@@ -294,7 +295,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/watchtower_swamp_1.nbt",
       "asset_sha256": "9dc5b6ce54fde28c3925c46de50fc530d14655ca08cebd6dcefbcf07d73daf9a",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/watchtower_swamp_1.json",
-      "definition_sha256": "6c1f8384952aad74417a4e26776a16d6950e927e7d44b518e678ab8636298cfe"
+      "definition_sha256": "de699ef836234511c5ad5cad8dd0347aa4c992a2402f24f281219008e2e070fd"
     },
     {
       "exhibit": "NE05.1",
@@ -326,9 +327,9 @@
       "source": "run/swamp-full-review/approved-live-edits/NE01.6.nbt",
       "source_sha256": "2090c7545920886e0b31b04a69ab2d46a4df0b0ac246877c53ea3547d539bdb4",
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/mine_swamp_1.nbt",
-      "asset_sha256": "df3d3e01357e33a85816452a43746b810f654bc44c250ab47ae90e955ffc42a1",
+      "asset_sha256": "c29e59f628bff45f4ea109cc4c272cec0d6751b0c95c74ba60334f0c0cd14d87",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/mine_swamp_1.json",
-      "definition_sha256": "592f17ea27fa4c89422a3e3cd4dec9563090d6283e466260bc68bb40a57151f1"
+      "definition_sha256": "db5f5c63a852ec5200f4f4036448a83d040bbfc525742a1c0eef6c5565543be5"
     },
     {
       "exhibit": "NE03.2",
@@ -345,7 +346,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/storehouse_swamp_1.nbt",
       "asset_sha256": "5a922d9ee5313932e54b0866df65da27ce9be5a024c7783a01969bd743e4eec9",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/storehouse_swamp_1.json",
-      "definition_sha256": "a14c6199cf323b41de863c3a74e5dc671a3980cf0f269ac0550819a1a9fa8924"
+      "definition_sha256": "00b7246e3cb021ea4ba3d51f067db911630b9ff9b51a1d3b94bb41828f4bd91d"
     },
     {
       "exhibit": "NF02.5",
@@ -362,7 +363,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/stoneworks_swamp_1.nbt",
       "asset_sha256": "f1426118d52c9c4d2892f1f8fb8e958b980d61b2557499ce495e8c15eb939d59",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/stoneworks_swamp_1.json",
-      "definition_sha256": "4627d172e0eb7625b93aae4fb27b8e7f12560c46b859caa1a5b1c1693220b7ab"
+      "definition_sha256": "d4071e9173801ade0d3cfff5f0ab19f3df91ba9d46c273f79ce30b7009002bd6"
     },
     {
       "exhibit": "NF02.7",
@@ -413,7 +414,7 @@
       "asset": "run/swamp-integration/datapack/data/kithkyn/structure/hunting_lodge_swamp_1.nbt",
       "asset_sha256": "756ecaf3d8ced3f1d48a8a4a48739c161c09159282c2acc19b29f37b1fcbc7b6",
       "definition": "run/swamp-integration/datapack/data/kithkyn/kithkyn/buildings/hunting_lodge_swamp_1.json",
-      "definition_sha256": "70eb0aaadd4296ae5aacaf1fd33d4d3b9ee8790db6543a08cecebbe3d1775025"
+      "definition_sha256": "008dd219781c1a419c54b3395ad2a7725f92ebf512fa182a8d46e4d9cd8b1cb2"
     },
     {
       "exhibit": "NE02.9",
@@ -513,5 +514,28 @@
     "merchant": "run/swamp-integration/merchant/verification.json: conserved buy and sell flows",
     "custody": "run/swamp-integration/custody/verification.json: arrest, evidence, sentence, escape and release",
     "visual_review": "run/swamp-integration/market-render/capture/client/screenshots/"
-  }
+  },
+  "revisions": [
+    {
+      "date": "2026-09-11",
+      "change": "Correct Swamp seating, center masonry and mine width",
+      "raised_structures": [
+        "couple_cottage_swamp_1",
+        "house_swamp_1",
+        "house_swamp_1__two_bed",
+        "church_swamp_1__cleric_couple_home",
+        "church_swamp_1__cleric_mixed_home",
+        "blacksmith_swamp_1",
+        "bakery_swamp_1",
+        "tavern_swamp_1",
+        "watchtower_swamp_1",
+        "storehouse_swamp_1",
+        "stoneworks_swamp_1",
+        "hunting_lodge_swamp_1"
+      ],
+      "placement": "negative-sink structures follow higher public-front ground to keep their lowest course exposed",
+      "mine": "mine_swamp_1 uses two transverse cells, local x -1 and 0, matching its authored opening",
+      "center": "cobbled deepslate stairs and slabs replaced with cobblestone equivalents"
+    }
+  ]
 }


### PR DESCRIPTION
Swamp buildings with exposed bottom steps could seat one or two blocks into uneven ground, while the authored mine opening was two blocks wide but the runtime always excavated at least three. The Swamp town center also retained cobbled deepslate trim that no longer matched the chosen palette.

This change records the corrected Swamp structures, seats raised templates against the higher ground at their public entrance, and supports an exact two-wide mine through excavation, sealing, side cuts, supports, lighting, routing, and child shafts. The town-center stairs and slabs are now cobblestone.

Validation:
- `./gradlew clean build`
- 38 bundled templates audited with no barrier states or out-of-bounds blocks
- 27 private Swamp template hashes verified
- 216 native Minecraft placements passed across instant/construction paths and all four rotations
- complete Swamp founding passed in all four rotations
