### PR TITLE
Stop Swamp buildings from floating on water

### DIFF
--- a/docs/site-selection.md
+++ b/docs/site-selection.md
@@ -128,6 +128,13 @@ labour is deliberate. The village holds the
 surface-not-shape line; a player is free to break it, and a slope they level is found on the
 next search once the refusal expires. The refusal is logged at INFO with the same sentence.
 
+Water covering the proposed build plane is never a land-building site. The motion-blocking
+heightmap includes a swamp's water surface, so the exact scan must reject fluid at that plane
+instead of looking through it and pricing the mud below. Fluid strictly below a dry build plane
+can still be filled as a local depression within the ordinary terrain budget. This keeps a
+building beside or above a small filled hollow possible without letting its foundation float on
+one block of water or silently accepting a deeper pool.
+
 `SitePreparation.score` prices any candidate
 footprint in blocks moved (clear, cut, fill, or impossible) using the
 `kithkyn:clearable` whitelist tag, the per-column and average levelling budgets below,

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/SitePreparation.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/SitePreparation.java
@@ -161,12 +161,15 @@ public final class SitePreparation {
           if (level.getBlockEntity(pos) != null) {
             return PrepWork.impossible();
           }
-          if (state.is(CLEARABLE)) {
-            toBreak.add(pos.asLong());
+          if (!state.getFluidState().isEmpty()) {
+            if (fluidCoversSitePlane(y, plane)) {
+              return PrepWork.impossible();
+            }
             y--;
             continue;
           }
-          if (!state.getFluidState().isEmpty()) {
+          if (state.is(CLEARABLE)) {
+            toBreak.add(pos.asLong());
             y--;
             continue;
           }
@@ -259,12 +262,15 @@ public final class SitePreparation {
           if (level.getBlockEntity(pos) != null) {
             return SiteCost.impossible("something with contents is in the way at " + pos.toShortString());
           }
-          if (state.is(CLEARABLE)) {
-            clear++;
+          if (!state.getFluidState().isEmpty()) {
+            if (fluidCoversSitePlane(y, plane)) {
+              return SiteCost.impossible("water covers the build plane at " + pos.toShortString());
+            }
             y--;
             continue;
           }
-          if (!state.getFluidState().isEmpty()) {
+          if (state.is(CLEARABLE)) {
+            clear++;
             y--;
             continue;
           }
@@ -292,6 +298,11 @@ public final class SitePreparation {
       return SiteCost.earthwork(assessment.reason());
     }
     return new SiteCost(clear, cut, fill, false, false, "");
+  }
+
+  /** Water at the proposed surface would leave the authored foundation floating or flooded. */
+  static boolean fluidCoversSitePlane(int fluidY, int plane) {
+    return fluidY >= plane;
   }
 
 }

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/SiteTerrainPolicyTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/SiteTerrainPolicyTest.java
@@ -76,6 +76,13 @@ class SiteTerrainPolicyTest {
     assertTrue(new LocationValidator.Reading(65, 8, 2, 8, 0).screenedOut() != null);
   }
 
+  @Test
+  void waterSurfaceIsNotBuildableButWaterBelowThePlaneCanBeFilled() {
+    assertTrue(SitePreparation.fluidCoversSitePlane(62, 62));
+    assertTrue(SitePreparation.fluidCoversSitePlane(63, 62));
+    assertFalse(SitePreparation.fluidCoversSitePlane(61, 62));
+  }
+
   private static List<SiteTerrainPolicy.Column> levelFootprint(int width, int depth) {
     List<SiteTerrainPolicy.Column> columns = new ArrayList<>();
     for (int x = 0; x < width; x++) {


### PR DESCRIPTION
Swamp founding could select the water surface as a building plane, then interpret the mud below as preparable ground. Raised structures such as Swamp homes and the storehouse consequently floated on the water.

This change rejects a site when fluid covers its proposed build plane in both the scoring and execution passes. Water below a dry plane remains fillable as a bounded local depression, preserving the existing town-center behavior.

Validation:

- Reproduced against Nerrowen's pre-placement snapshot: all seven founding footprints contained one-block water, including 22 to 38 wet columns per home and 42 of 56 for the storehouse.
- `./gradlew test --tests com.quzzar.kithkyn.village.buildings.SiteTerrainPolicyTest`
- `./gradlew check`
