### PR TITLE
Make all village beds use dynamic colors

### DIFF
--- a/docs/birch-village.md
+++ b/docs/birch-village.md
@@ -36,7 +36,7 @@ Amenities come from the actual selected definition, not a global bed or chest co
 
 The bakery grants BREAD and employs the baker. The separate tavern grants WANDERERS and
 employs the innkeeper. Its back-room bed is the only assigned housing slot; the other three
-authored beds remain furnishings.
+authored beds remain furnishings and follow the village's secondary color.
 This integration does not add a new physical innkeeper food-service loop or new hospitality bonuses.
 
 ## Biome selection
@@ -76,6 +76,8 @@ Tower beds follow the same one/two rule. The hunter and butcher use secondary. S
 center, storehouse and mine banners become the village's saved flag. Decorative market
 banners are not identity slots. Neutral white in the exported source marks dynamic slots;
 both instant and incremental placement resolve the actual colors while placing the blocks.
+Every physical bed is an identity slot even when it is furnishing rather than an assignable
+housing slot, so no authored bed color survives into a completed village.
 
 Containers start empty. Personal chests are excluded from communal storage. The butcher's
 six initial animals are marked as village stock; the center's golem remains ordinary until

--- a/src/main/resources/data/kithkyn/kithkyn/buildings/tavern_birch_forest_1.json
+++ b/src/main/resources/data/kithkyn/kithkyn/buildings/tavern_birch_forest_1.json
@@ -46,7 +46,23 @@
         16
       ]
     ],
-    "secondary_blocks": [],
+    "secondary_blocks": [
+      [
+        7,
+        1,
+        2
+      ],
+      [
+        10,
+        1,
+        2
+      ],
+      [
+        14,
+        5,
+        16
+      ]
+    ],
     "banners": []
   }
 }

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/BirchAssetsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/BirchAssetsTest.java
@@ -59,7 +59,7 @@ class BirchAssetsTest {
   }
 
   @Test
-  void everyDeclaredAmenityExistsAndAllDynamicBedsHaveOneRole() throws Exception {
+  void everyDeclaredAmenityExistsAndEveryPhysicalBedHasOneDynamicColorRole() throws Exception {
     int count = 0;
     int tallGrass = 0;
     Path dataRoot = data();
@@ -149,6 +149,23 @@ class BirchAssetsTest {
             assertEquals("east", rear.getCompound("Properties").getString("facing"));
           }
         }
+        Set<BlockPos> primary = Set.copyOf(info.getVillageIdentitySlots().primaryBlocks());
+        Set<BlockPos> secondary = Set.copyOf(info.getVillageIdentitySlots().secondaryBlocks());
+        for (var entry : states.entrySet()) {
+          CompoundTag state = entry.getValue();
+          if (!state.getString("Name").endsWith("_bed")
+              || !state.getCompound("Properties").getString("part").equals("head")) {
+            continue;
+          }
+          var facing = net.minecraft.core.Direction.byName(
+              state.getCompound("Properties").getString("facing"));
+          assertNotNull(facing, file + " bed has no facing at " + entry.getKey());
+          BlockPos foot = entry.getKey().relative(facing.getOpposite());
+          boolean usesPrimary = primary.contains(entry.getKey()) || primary.contains(foot);
+          boolean usesSecondary = secondary.contains(entry.getKey()) || secondary.contains(foot);
+          assertTrue(usesPrimary ^ usesSecondary,
+              file + " bed must use exactly one village color at " + entry.getKey());
+        }
         for (long packed : info.getBedLocations()) {
           CompoundTag state = states.get(BlockPos.of(packed));
           assertNotNull(state, file+" bed "+BlockPos.of(packed));
@@ -157,8 +174,12 @@ class BirchAssetsTest {
         }
         List<BlockPos> roles = new ArrayList<>(info.getVillageIdentitySlots().primaryBlocks());
         roles.addAll(info.getVillageIdentitySlots().secondaryBlocks());
-        assertEquals(info.getBedLocations().size(), roles.size(), file.toString());
         assertEquals(roles.size(), new HashSet<>(roles).size());
+        for (long packed : info.getBedLocations()) {
+          BlockPos bed = BlockPos.of(packed);
+          assertTrue(primary.contains(bed) ^ secondary.contains(bed),
+              file + " declared bed must use exactly one village color at " + bed);
+        }
         Set<Long> shared = new HashSet<>(info.getContainerLocations());
         for (long packed : info.getPersonalContainerLocations()) assertFalse(shared.contains(packed), file.toString());
         shared.addAll(info.getPersonalContainerLocations());
@@ -182,6 +203,8 @@ class BirchAssetsTest {
     assertEquals(Set.of(com.quzzar.kithkyn.village.Occupation.BAKER), Set.copyOf(bakery.getWorkLocations().values()));
     assertEquals(List.of(new BlockPos(14,1,16).asLong()), tavern.getBedLocations());
     assertEquals(Set.of(com.quzzar.kithkyn.village.Occupation.INNKEEPER), Set.copyOf(tavern.getWorkLocations().values()));
+    assertEquals(Set.of(new BlockPos(7,1,2), new BlockPos(10,1,2), new BlockPos(14,5,16)),
+        Set.copyOf(tavern.getVillageIdentitySlots().secondaryBlocks()));
     long ceilingBarrel = new BlockPos(13,4,16).asLong();
     assertEquals(List.of(ceilingBarrel), tavern.getPersonalContainerLocations());
     assertFalse(tavern.getContainerLocations().contains(ceilingBarrel));


### PR DESCRIPTION
Every physical bed should resolve to either the village's primary or secondary color. A complete audit of the 153 loaded definitions found that three furnishing beds in the Birch tavern were the only fixed-color exception.

The tavern's innkeeper bed remains the sole assignable housing slot and keeps the primary color. Its three furnishing beds now use the secondary color. The Birch asset contract now checks every physical bed pair, including unassignable furnishings, for exactly one dynamic color role.

Validation:

- Audited 153 loaded definitions across six catalogs and all 160 physical bed pairs; zero unresolved or conflicting color roles.
- `./gradlew test --tests com.quzzar.kithkyn.village.buildings.BirchAssetsTest.everyDeclaredAmenityExistsAndEveryPhysicalBedHasOneDynamicColorRole --tests com.quzzar.kithkyn.village.buildings.BirchAssetsTest.separateBakeryAndTavernKeepTheirOwnWorkerHousingAndPrivateStorage`
- `./gradlew check`
