### PR TITLE
Keep Aaron's Mediterranean builds by fixing the rules that rejected them

### DIFF
--- a/docs/castles.md
+++ b/docs/castles.md
@@ -112,9 +112,11 @@ its provenance. It keeps the Desert model: four beds, the ruler's double bed wit
 barrel behind the fenced west room, a baker's corner (cake, cauldron, furnace) and a smithy
 (smithing table, grindstone) that share one chest between their two north bedrooms, seven
 barrels and two chests of village storage, and nine authored banner slots. The jail is the
-tower's upper floor: the cell behind iron bars, two evidence barrels beside it, the release point
+tower's upper floor: the cell behind iron bars, two evidence chests beside it, the release point
 and the jailer's post on the same floor at the top of the ladder. Four sword guards patrol the
-north gate, the south gate and the two halves of the yard. It has no merchant stall.
+north gate, the south gate and the two halves of the yard. It has no merchant stall. Evidence
+lives in whichever containers a castle layout names: barrels in the Desert and Swamp castles,
+chests here.
 
 ## Ruler decisions
 
@@ -160,8 +162,9 @@ An unavailable or damaged castle cannot silently strand an active prisoner.
 The two evidence barrels are stacked at castle-local `[9,11,19]` and `[9,12,19]`. The release position
 is `[8,11,17]`; the cell is `[6,11,18]`. All coordinates rotate and translate with the castle.
 
-Confiscation transfers eligible death-drop items into available barrel space, including normal
-inventory, armor, offhand and supported accessory slots. Existing barrel contents are never
+Confiscation transfers eligible death-drop items into available space in the layout's evidence
+containers (barrels or chests), including normal
+inventory, armor, offhand and supported accessory slots. Existing evidence contents are never
 erased. Only quantities successfully inserted are removed from the player; anything that does
 not fit remains with them. Item components, names, enchantments and container contents remain
 on the moved stacks. Items are not automatically returned at release; players retrieve them.

--- a/docs/mediterranean-village.md
+++ b/docs/mediterranean-village.md
@@ -16,8 +16,8 @@ The private datapack contains 24 definitions:
 
 | Id | Use |
 | --- | --- |
-| `village_center_mediterranean_1` | M06.1 church; no beds; quartermaster, builder, guard captain and miner vacancies plus a cleric at the altar's brewing stand; the meeting point and one campfire on the forecourt |
-| `mine_mediterranean_1` | M07.8 library turned mine: the miner's station barrel under the bookshelf, a three-wide shaft dropping south from the sunken room, and a general bed with its barrel upstairs |
+| `village_center_mediterranean_1` | M06.1 church; no beds; quartermaster, builder and guard captain vacancies plus a cleric at the altar's brewing stand; the meeting point and one campfire on the forecourt |
+| `mine_mediterranean_1` | M07.8 library turned mine: it employs the miner at the station barrel under the bookshelf, digs a three-wide shaft south from the sunken room, and houses the miner in the bed with its barrel upstairs |
 | `storehouse_mediterranean_1` | M07.5 fisher's house converted to four village containers with the quartermaster's physical worksite |
 | `house_mediterranean_1` | M06.5 one-bed home with a barrel set into the floor |
 | `house_mediterranean_1__two_bed` | M06.3 two single beds on two floors, a barrel and a chest |
@@ -31,12 +31,12 @@ The private datapack contains 24 definitions:
 | `hunting_lodge_mediterranean_1` | M07.6 hunter and smith: fletching and smithing tables downstairs, two beds sharing one chest upstairs |
 | `bakery_mediterranean_1` | M07.7 bakery with the baker's room and barrel, three village chests and a quartermaster's worksite: the second storehouse the village can build |
 | `farm_mediterranean_1` | M05.3 CTOV small farm as Aaron edited it, with its field barrel |
-| `farm_mediterranean_2` | M08.2 large sweet-berry field, built on its own site rather than replacing the small farm |
-| `butchery_mediterranean_1` | M04.2 farm and pasture: a farmer picking glow berries from the trellised cave vines, a butcher with three cows and three sheep, one barrel each |
+| `farm_mediterranean_2` | M08.2 large sweet-berry field, the small farm's upgrade |
+| `butchery_mediterranean_1` | M04.2 farm and pasture: a farmer picking glow berries from the trellised cave vines, and a butcher who works the pen whole (breeding, shearing and slaughter above six of a kind) with three cows and three sheep, one barrel each |
 | `lumberjack_mediterranean_1` | M08.3 timber yard: one barrel is the lumberjack's station, the two hook-trimmed barrels are decoration, the other four are village storage with a quartermaster's worksite |
 | `well_mediterranean_1` | M08.6 planter rebuilt by Aaron as a small well |
 | `market_mediterranean_1`, `_2`, `_3` | The shared market geometry in quartz bricks and pillars, spruce rails and plain candles, keeping the stripe-matched awning stairs and the authored fabric colours |
-| `castle_mediterranean_1` | M08.1 fort: ruler's double bed, baker and blacksmith with a shared chest, jail cell with two evidence barrels upstairs, a jailer post, and four sword guards patrolling the gates and the yard; it has no stall, so the castle merchant systems do not apply |
+| `castle_mediterranean_1` | M08.1 fort: ruler's double bed, baker and blacksmith with a shared chest, jail cell with two evidence chests upstairs, a jailer post, and four sword guards patrolling the gates and the yard; it has no stall, so the castle merchant systems do not apply |
 
 The two farms and the stoneworks all grant grain: the Mediterranean village is mainly a berry
 village, and its farmers pick sweet berries and glow berries alike (docs/worker-loops.md).
@@ -44,10 +44,10 @@ village, and its farmers pick sweet berries and glow berries alike (docs/worker-
 ## Founding and village identity
 
 The centre has no beds. Its founding companions are the mine, the storehouse, three one-bed
-homes and the two-bed home, placed through the normal planner: six beds for the five centre
-workers (quartermaster, builder, captain, miner and cleric), the sixth being the general bed
-upstairs in the mine. The quartermaster and miner route to their physical worksites in the
-storehouse and mine.
+homes and the two-bed home, placed through the normal planner: five beds in the homes for the
+four centre workers (quartermaster, builder, captain and cleric), and the miner's own bed
+upstairs in the mine, which employs them. The quartermaster routes to the physical worksite in
+the storehouse.
 
 The church forecourt is the civic meeting point and carries the one authored campfire. Every
 assigned bed is neutral in the template and becomes the village primary or secondary colour;
@@ -67,9 +67,9 @@ wall stage, paid for with cobblestone.
 The castle uses the same ruler and custody systems as the Desert and Swamp castles with its own
 M08.1 layout: four beds including the ruler's couple room, a baker's corner and a smithy sharing
 one chest, the jail cell behind iron bars on the tower's upper floor with its two evidence
-barrels (Aaron's chests, made barrels because the custody system keeps evidence in barrels), a
-jailer post beside it, and four sword-guard posts whose routes cover the north gate, the south
-gate and both halves of the yard. Its nine authored pillager banners are village banner slots.
+chests (the custody system takes any container the layout names, barrel or chest), a jailer
+post beside it, and four sword-guard posts whose routes cover the north gate, the south gate
+and both halves of the yard. Its nine authored pillager banners are village banner slots.
 Unlike the Desert and Swamp castles it has no merchant stall.
 
 ## Authoring and installation
@@ -80,12 +80,13 @@ barrier rings and two empty glow item frames), then exports them with
 `tools/structure/VillageTemplateExport.java`: neutral beds, banners and awnings, the mine's
 sunken pit carved as ground, the forecourt campfire, the six captured livestock, and the three
 markets derived from the Desert set. Every station, worksite, meeting point, custody cell and
-patrol point is checked to be a standable cell of its capture before export, and a carpet in
-such a cell is cleared, because a worker's body is measured from the floor block below it. Three
-name-plate signs around the stoneworks farmer's bed are cleared too: the pathfinder treats a
-sign as a wall, and they sealed the room. Containers no standing cell can see, the fort's buried
-north-west chest and the barrels under other barrels in its nook and the timber yard, are left
-as decoration rather than declared storage. The catalog hashes
+patrol point is checked to be a standable cell of its capture before export. Two runtime rules
+were corrected for this catalog rather than editing the buildings around them: a worker's
+footing now stands on a carpet instead of colliding with it, and a person can be sent to a cell
+holding a sign or banner (vanilla's ground navigation counts those as solid although they have no
+collision, and aimed one block above them, where nobody can stand). Containers no standing cell
+can see, the fort's buried north-west chest and the barrels under other barrels in its nook and
+the timber yard, are left as decoration rather than declared storage. The catalog hashes
 and source record are in `tools/structure/mediterranean-catalog-20260912.json`. Third-party
 building templates stay in the private local datapack; only the wall family is bundled.
 
@@ -94,17 +95,19 @@ founding on a temperate plain uses the same selector and founding path.
 
 ## Verification
 
-The September 12 native runs loaded all 24 strict templates and passed natural Plains selection,
-all four founding rotations, eight supported in-place market upgrades and codec reloads, with six
-founding beds and five founding positions. Placement covered 192 instant and incremental/reload
-builds; a real server restart retained all 192 saved buildings and 64 authored entities.
-Full-size adult villagers passed 392 access routes across 92 rotated non-centre layouts,
-including 96 room walks and assigned-bed sleeps, 96 personal-container deposits, 120 shared
-deposits, 100 station walks and both mine directions. The centre added twenty station walks.
+The September 12 native runs, repeated on the final build after the follow-up fixes, loaded all
+24 strict templates and passed natural Plains selection, all four founding rotations, twelve
+supported in-place upgrades (the three market steps and the small farm to the large field) and
+codec reloads, with six founding beds and five founding positions. Placement covered 192 instant
+and incremental/reload builds; a real server restart retained all 192 saved buildings and 64
+authored entities. Full-size adult villagers passed 396 access routes across 92 rotated
+non-centre layouts, including 96 room walks and assigned-bed sleeps, 96 personal-container
+deposits, 120 shared deposits, 100 station walks and both mine directions, with the carpets and
+name-plate signs in place. The centre added twenty station walks.
 
-The castle runs covered a paid incremental build with protected evidence, sixteen sentry
-patrols over every authored route level in four rotations, and the full custody matrix: melee
-and arrow arrest, private minute notices, saved expiry, evidence capacity and identity, escape,
-damaged-cell release, full-cell fallback and village-only grace. The castle merchant check does
-not apply: the fort has no stall. The wall family's own checks are in
+The castle runs covered a paid incremental build with protected evidence in the two jail chests,
+sixteen sentry patrols over every authored route level in four rotations, and the full custody
+matrix: melee and arrow arrest, private minute notices, saved expiry, evidence capacity and
+identity, escape, damaged-cell release, full-cell fallback and village-only grace. The castle
+merchant check does not apply: the fort has no stall. The wall family's own checks are in
 [walls.md](walls.md) and `tools/structure/mediterranean-walls-20260912.json`.

--- a/src/main/java/com/quzzar/kithkyn/dev/BadlandsVillageVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/BadlandsVillageVerification.java
@@ -91,13 +91,15 @@ public final class BadlandsVillageVerification {
         new String[][] {{id("market", 1), id("market", 2)}, {id("market", 2), id("market", 3)},
             {id("farm", 1), id("farm", 2)}},
         7, 4, 4, 1, 4, 0, 0, new BlockPos(12, 4, 13), new BlockPos(14, 6, 11), 2, Biomes.SWAMP);
-    // The Mediterranean centre is the church: its founding jobs add a cleric to the
-    // usual quartermaster, builder, captain and miner; its four founding homes are
-    // three one-bed houses and the two-bed house, and the mine adds a general bed.
+    // The Mediterranean centre is the church: quartermaster, builder, captain and a cleric.
+    // The mine employs and houses its own miner, so the fifth founding job and the sixth
+    // founding bed are the mine's; the founding homes are three one-bed houses and the
+    // two-bed house.
     case MEDITERRANEAN -> new Catalog("[mediterranean-verify]", 24, 6, 10, new int[] {6, 0, 0},
         Map.of("house_mediterranean_1__couple_room", 1), List.of(), false,
-        new String[][] {{id("market", 1), id("market", 2)}, {id("market", 2), id("market", 3)}},
-        7, 6, 5, 1, 5, 0, 0, new BlockPos(12, 1, 1), new BlockPos(12, 3, 2), 1, Biomes.PLAINS);
+        new String[][] {{id("market", 1), id("market", 2)}, {id("market", 2), id("market", 3)},
+            {id("farm", 1), id("farm", 2)}},
+        7, 6, 5, 1, 4, 0, 0, new BlockPos(12, 1, 1), new BlockPos(12, 3, 2), 1, Biomes.PLAINS);
     case BIRCH_FOREST -> null;
   };
   /** Centre jobs beyond the founding four that a catalog's centre also opens at founding. */
@@ -410,7 +412,9 @@ public final class BadlandsVillageVerification {
         && village.getUnassignedBeds().size() == CATALOG.foundingBeds() - CATALOG.foundingJobs(),
         "Founding workers did not receive distinct beds");
     if (STYLE == VillageStyle.JUNGLE || STYLE == VillageStyle.SWAMP || STYLE == VillageStyle.MEDITERRANEAN) {
-      verifyRoutedWorksite(village, residents, Occupation.MINER, "mine");
+      if (STYLE != VillageStyle.MEDITERRANEAN) {
+        verifyRoutedWorksite(village, residents, Occupation.MINER, "mine");
+      }
       verifyRoutedWorksite(village, residents, Occupation.QUARTERMASTER, "storehouse");
       Building mine = village.getBuildings().stream()
           .filter(building -> building.getInfo().getCategory().equals("mine")).findFirst().orElseThrow();

--- a/src/main/java/com/quzzar/kithkyn/dev/CastleConstructionVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/CastleConstructionVerification.java
@@ -232,7 +232,7 @@ public final class CastleConstructionVerification {
     }
     for (BlockPos local : castle.getInfo().getCastleLayout().evidenceContainers()) {
       BlockPos world = origin.offset(local.rotate(castle.getRotation()));
-      check(level.getBlockState(world).is(Blocks.BARREL), "Incremental build lost an evidence barrel");
+      check(level.getBlockEntity(world) instanceof net.minecraft.world.Container, "Incremental build lost an evidence container");
       check(!village.getVillageContainerPositions().contains(world), "Evidence became shared storage after completion");
     }
   }

--- a/src/main/java/com/quzzar/kithkyn/dev/CustodyVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/CustodyVerification.java
@@ -95,7 +95,7 @@ public final class CustodyVerification {
     check(VillageCustody.validCell(level, cell), "Authored cell is not enclosed and safe: " + cell);
     List<Container> evidence = castle.getInfo().getCastleLayout().evidenceContainers().stream()
         .map(local -> (Container) level.getBlockEntity(origin.offset(local))).toList();
-    check(evidence.size() == 2 && evidence.stream().allMatch(java.util.Objects::nonNull), "Two authored evidence barrels missing");
+    check(evidence.size() == 2 && evidence.stream().allMatch(java.util.Objects::nonNull), "Two authored evidence containers missing");
     verifyEvidenceTheft(level, village, evidence, release);
     verifyInventory(level, evidence, release, level.damageSources().mobAttack(guard));
 

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
@@ -138,6 +138,11 @@ public final class PersonPathNavigation extends GroundPathNavigation {
     return route;
   }
 
+  private boolean isSolidWithoutCollision(BlockPos pos) {
+    BlockState state = this.level.getBlockState(pos);
+    return state.isSolid() && state.getCollisionShape(this.level, pos).isEmpty();
+  }
+
   /**
    * The path to {@code pos}, or to the next ramp waypoint on the way when this
    * walk starts or ends down one of the village's mine shafts. The goal keeps
@@ -207,6 +212,13 @@ public final class PersonPathNavigation extends GroundPathNavigation {
       // A doorway can be the final approach to a closet container. Ground
       // navigation otherwise lifts this solid target above the door and roof.
       return super.createPath(Set.of(pos), accuracy);
+    }
+    // Vanilla aims one block above any target flagged solid, and a sign or a banner is
+    // flagged solid although it has no collision: a name plate beside a bed made the cell
+    // in front of it unreachable, while a player walks straight into it. A cell open to
+    // the body is the target as given.
+    if (isSolidWithoutCollision(pos)) {
+      return createPath(java.util.Set.of(pos), 8, false, accuracy);
     }
     return super.createPath(pos, accuracy);
   }

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/WorkerFooting.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/WorkerFooting.java
@@ -14,6 +14,13 @@ import net.minecraft.world.phys.shapes.Shapes;
 
 /** Shared physical footing checks; each construction job owns its own site and reach policy. */
 public final class WorkerFooting {
+  /**
+   * The tallest thing in a cell that is still floor rather than obstacle: a carpet or a
+   * pressure plate (a sixteenth), a single layer of snow (two). Anything taller is a step
+   * the path planner reasons about separately.
+   */
+  private static final double THIN_COVERING = 0.125D;
+
   private WorkerFooting() { }
 
   /** Dry, supported ground with clearance for this worker's actual collision box. */
@@ -42,12 +49,20 @@ public final class WorkerFooting {
     if (support.isEmpty()) return null;
     double top = support.max(Direction.Axis.Y);
     if (top > 1.0D) return null;
+    // A carpet in the cell itself lifts the feet onto it, the way a player stands on one;
+    // measuring the body from the floor block below made every carpet a collision.
+    var covering = level.getBlockState(position).getCollisionShape(level, position);
+    double lift = 0.0D;
+    if (!covering.isEmpty()) {
+      lift = covering.max(Direction.Axis.Y);
+      if (lift > THIN_COVERING) return null;
+    }
     double half = width / 2.0D;
     // The whole footprint must rest on the surface; a fence tip or a stair edge is insufficient.
     var sole = Shapes.box(0.5D - half, top - 0.000001D, 0.5D - half,
         0.5D + half, top, 0.5D + half);
     if (Shapes.joinIsNotEmpty(sole, support, BooleanOp.ONLY_FIRST)) return null;
-    double feetY = below.getY() + top;
+    double feetY = below.getY() + top + lift;
     AABB body = new AABB(position.getX() + 0.5D - half, feetY, position.getZ() + 0.5D - half,
         position.getX() + 0.5D + half, feetY + height, position.getZ() + 0.5D + half);
     return level.noCollision(entity, body) ? new Vec3(position.getX() + 0.5D, feetY, position.getZ() + 0.5D) : null;

--- a/src/main/java/com/quzzar/kithkyn/wrongdoing/VillageCustody.java
+++ b/src/main/java/com/quzzar/kithkyn/wrongdoing/VillageCustody.java
@@ -37,7 +37,6 @@ import net.minecraft.world.entity.animal.AbstractGolem;
 import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.saveddata.SavedData;
-import net.minecraft.world.level.block.entity.BarrelBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.phys.Vec3;
@@ -112,8 +111,10 @@ public final class VillageCustody extends SavedData {
           .anyMatch(sentence -> sentence.occupies(village.getID(), castle.getUUID().toString(), now))) continue;
       BlockPos release = safeReleasePoint(level, cell, world(castle, layout.releasePoint()));
       if (release == null) continue;
+      // Any authored container holds evidence: the Desert and Swamp castles use barrels,
+      // the Mediterranean fort keeps Aaron's two chests.
       List<Container> evidence = layout.evidenceContainers().stream().map(local -> level.getBlockEntity(world(castle, local)))
-          .filter(entity -> entity instanceof BarrelBlockEntity).map(entity -> (Container) entity).distinct().toList();
+          .filter(entity -> entity instanceof Container).map(entity -> (Container) entity).distinct().toList();
       if (!EvidenceInventory.canArrestWithoutDrops(player, evidence)) continue;
       MobEffectInstance fatigue = player.getEffect(MobEffects.DIG_SLOWDOWN);
       CompoundTag previous = fatigue == null ? null : (CompoundTag) fatigue.save();
@@ -129,7 +130,7 @@ public final class VillageCustody extends SavedData {
       clearGuardTargets(level, village, player);
       player.sendSystemMessage(Component.literal("The guards of " + village.getName()
           + " have taken you into custody. You have 5 minutes remaining. "
-          + confiscated + " items were placed in the evidence barrels; anything that did not fit remains with you."));
+          + confiscated + " items were placed in the evidence store; anything that did not fit remains with you."));
       Kithkyn.LOGGER.info("[custody] {} apprehended by {} until game tick {}", player.getUUID(), village.getID(), sentence.releaseAt());
       return true;
     }

--- a/tools/structure/mediterranean-catalog-20260912.json
+++ b/tools/structure/mediterranean-catalog-20260912.json
@@ -16,7 +16,8 @@
       "house_mediterranean_1",
       "house_mediterranean_1__two_bed"
     ],
-    "starting_beds": 6
+    "starting_beds": 6,
+    "note": "the centre employs quartermaster, builder, captain and cleric; the mine employs and houses its own miner"
   },
   "identity": {
     "beds": "primary or secondary village color; couple halves share primary",
@@ -43,17 +44,11 @@
       "source_sha256": "3fdc8c955b0b447e90e0f11ecf43357c155dd998938cf6362b406e920098c95e",
       "capture": "run/mediterranean-integration/selection-capture-20260912-022651/captures/M06_1.nbt",
       "entities": 0,
-      "carpets_cleared_under_stations": [
-        [
-          12,
-          1,
-          12
-        ]
-      ],
+      "carpets_cleared_under_stations": [],
       "asset": "run/mediterranean-integration/datapack/data/kithkyn/structure/village_center_mediterranean_1.nbt",
-      "asset_sha256": "b90ee558a4bc84f45c07b12d8fd89d698b254f7c0a773a8d1f94545fd865550b",
+      "asset_sha256": "5a2712a2738e25fed6f26ef38d15ace09828b1265cb2cbfb939629461143c985",
       "definition": "run/mediterranean-integration/datapack/data/kithkyn/kithkyn/buildings/village_center_mediterranean_1.json",
-      "definition_sha256": "6acefb285bf40803fd774f5ef4ad3bc609abc873045c6bfe11b8ab92fe6803b8"
+      "definition_sha256": "441e2dc61b2f84b0a7e9373d9e47a3ea2dfe2496a05cc6f9fc82e47cc43757b8"
     },
     {
       "exhibit": "M06.5",
@@ -229,15 +224,9 @@
       "source_sha256": "cb7d9364802509a6455e210ef0a016e33afbf11ac3ed6d55bb33770cd9969454",
       "capture": "run/mediterranean-integration/selection-capture-20260912-022651/captures/M07_3.nbt",
       "entities": 0,
-      "carpets_cleared_under_stations": [
-        [
-          2,
-          5,
-          2
-        ]
-      ],
+      "carpets_cleared_under_stations": [],
       "asset": "run/mediterranean-integration/datapack/data/kithkyn/structure/watchtower_mediterranean_1.nbt",
-      "asset_sha256": "67679c0a69924a2bb4d479dd4936e4b496b00b1b11ff5d9cf17b7eb8422270e4",
+      "asset_sha256": "be27ababd73b277fa55d31de0bc117f39e86f2177a9cf2047c7f3e20fffa5c5b",
       "definition": "run/mediterranean-integration/datapack/data/kithkyn/kithkyn/buildings/watchtower_mediterranean_1.json",
       "definition_sha256": "699bfa7a4f5a0f1b099aecf40d23574311e729b2753522becc8ed6b21100d44c"
     },
@@ -257,7 +246,7 @@
       "entities": 0,
       "carpets_cleared_under_stations": [],
       "asset": "run/mediterranean-integration/datapack/data/kithkyn/structure/stoneworks_mediterranean_1.nbt",
-      "asset_sha256": "dabcae07605ed24a9fecaa111ae155b487220b29897c0ee343a06f3a88431b20",
+      "asset_sha256": "fb6afee9a8e1415898e5037aa726a0bf96498af0308d47d78a9ae227551d18d8",
       "definition": "run/mediterranean-integration/datapack/data/kithkyn/kithkyn/buildings/stoneworks_mediterranean_1.json",
       "definition_sha256": "706da074e50ddeddf1ae5dbf5cee6807e4418db53efc2798ccd918bb4b3b5493"
     },
@@ -315,15 +304,9 @@
       "source_sha256": "51f0543e0e7db0b133651f1ac30502a02b0e123873c29bc9c037a6b861976f27",
       "capture": "run/mediterranean-integration/selection-capture-20260912-022651/captures/M07_7.nbt",
       "entities": 0,
-      "carpets_cleared_under_stations": [
-        [
-          4,
-          1,
-          7
-        ]
-      ],
+      "carpets_cleared_under_stations": [],
       "asset": "run/mediterranean-integration/datapack/data/kithkyn/structure/bakery_mediterranean_1.nbt",
-      "asset_sha256": "9ee09df7fffd7d0091f26bb600a015bca3671cf9fa0a418a173cb4da4c8297b5",
+      "asset_sha256": "d3b95f39a237851418a5b7bf7587c949c7318abc9daed1bdba884fff40bb6ce7",
       "definition": "run/mediterranean-integration/datapack/data/kithkyn/kithkyn/buildings/bakery_mediterranean_1.json",
       "definition_sha256": "394c05bebc2ce6242c6edda0ae9922de12be36a7ddd8ba32511f0842cec67a72"
     },
@@ -345,7 +328,7 @@
       "asset": "run/mediterranean-integration/datapack/data/kithkyn/structure/mine_mediterranean_1.nbt",
       "asset_sha256": "20c081fe702024b764e3b6e956f74befedb5ea437b44fac141ca671ccb096548",
       "definition": "run/mediterranean-integration/datapack/data/kithkyn/kithkyn/buildings/mine_mediterranean_1.json",
-      "definition_sha256": "1d67635e0b4b529c1bc6cf575984d0d7d8ed63cef3bde78a3cd8856420a1a013"
+      "definition_sha256": "9e741110fcdbceca3afaca446ed3a77f11dd1a5e69a4b001a693b9d4aa6f7646"
     },
     {
       "exhibit": "M08.1",
@@ -361,55 +344,9 @@
       "source_sha256": "54b678eee20e4038def560b1c7872fc2190715cb32524dc738378deaac058e39",
       "capture": "run/mediterranean-integration/selection-capture-20260912-022651/captures/M08_1.nbt",
       "entities": 0,
-      "carpets_cleared_under_stations": [
-        [
-          10,
-          2,
-          14
-        ],
-        [
-          13,
-          2,
-          11
-        ],
-        [
-          8,
-          2,
-          7
-        ],
-        [
-          9,
-          2,
-          16
-        ],
-        [
-          9,
-          2,
-          14
-        ],
-        [
-          7,
-          2,
-          14
-        ],
-        [
-          7,
-          2,
-          4
-        ],
-        [
-          9,
-          2,
-          7
-        ],
-        [
-          11,
-          2,
-          9
-        ]
-      ],
+      "carpets_cleared_under_stations": [],
       "asset": "run/mediterranean-integration/datapack/data/kithkyn/structure/castle_mediterranean_1.nbt",
-      "asset_sha256": "dd71aa647438cfe1c1db0d2ceb2753cf0f51c78fe54534350395ad0d98aa808c",
+      "asset_sha256": "3a75502c236268ed47ed4aef4ad9bbc56b2c702a245cf90d7e60825b2c8d67dc",
       "definition": "run/mediterranean-integration/datapack/data/kithkyn/kithkyn/buildings/castle_mediterranean_1.json",
       "definition_sha256": "d42de1e36cba5f8e017b840f751912b0be84ba4510f61c2f19e5a6118a33f9fa"
     },
@@ -451,7 +388,7 @@
       "asset": "run/mediterranean-integration/datapack/data/kithkyn/structure/farm_mediterranean_2.nbt",
       "asset_sha256": "fa33736a5647d7ea2f43c96c897a24b844363de50755c8a674b8bf4074243b81",
       "definition": "run/mediterranean-integration/datapack/data/kithkyn/kithkyn/buildings/farm_mediterranean_2.json",
-      "definition_sha256": "13967018e23811da1efa36a30a9813e085eed862d7ddf0c63377194a909c61ec"
+      "definition_sha256": "b71db7c115d6eb27959f88ab114be24e9dd6c831f75de68d2132d28f81f90daa"
     },
     {
       "exhibit": "M08.3",
@@ -571,10 +508,10 @@
   "verification": {
     "placement": "PASS: [building-placement-verify] RESULT PASS: 192 real-template placements, both paths, four rotations, colors, frames, entity/save receipts and upgrade preservation",
     "restart": "PASS: [building-placement-verify] RESTART PASS: 192 saved buildings and 64 original entities survived real server shutdown/restart without replenishment",
-    "founding": "PASS: [mediterranean-verify] RESULT PASS: 24 strict native templates, 6 housing alternatives, 8 upgrade fits, four founding rotations and codec reloads, natural biome selection, 6 beds, 5 positions, distinct meeting/fire locations and village identity",
-    "center": "PASS: [approved-house-verify] RESULT PASS: 4 rotated structures, 24 access routes, 0 physical room walks and assigned-bed sleeps, 0 physical personal-container deposits, 0 failed placements; probe size=18; station walks=20, shared deposits=4, mine walks=0, review walks=0",
-    "access": "PASS: [approved-house-verify] RESULT PASS: 92 rotated structures, 392 access routes, 96 physical room walks and assigned-bed sleeps, 96 physical personal-container deposits, 0 failed placements; probe size=18; station walks=100, shared deposits=120, mine walks=8, review walks=0",
-    "construction": "PASS: [castle-construction-verify] RESULT PASS: physical two-storehouse recipe collection, ordinary walking GatherStep/BuildStep, incremental paid castle, authored jobs and beds published only after completion, protected evidence; ticks=28459 walked=134",
+    "founding": "PASS: [mediterranean-verify] RESULT PASS: 24 strict native templates, 6 housing alternatives, 12 upgrade fits, four founding rotations and codec reloads, natural biome selection, 6 beds, 5 positions, distinct meeting/fire locations and village identity",
+    "center": "PASS: [approved-house-verify] RESULT PASS: 4 rotated structures, 20 access routes, 0 physical room walks and assigned-bed sleeps, 0 physical personal-container deposits, 0 failed placements; probe size=18; station walks=16, shared deposits=4, mine walks=0, review walks=0",
+    "access": "PASS: [approved-house-verify] RESULT PASS: 92 rotated structures, 396 access routes, 96 physical room walks and assigned-bed sleeps, 96 physical personal-container deposits, 0 failed placements; probe size=18; station walks=104, shared deposits=120, mine walks=8, review walks=0",
+    "construction": "PASS: [castle-construction-verify] RESULT PASS: physical two-storehouse recipe collection, ordinary walking GatherStep/BuildStep, incremental paid castle, authored jobs and beds published only after completion, protected evidence; ticks=29059 walked=139",
     "patrol": "PASS: [castle-operations-verify] RESULT PASS: 16 real sentries visited all authored patrol levels in four rotations and retained loadouts",
     "merchant": "not applicable: the M08.1 fort has no merchant stall, so the castle merchant systems and their check do not apply",
     "custody": "PASS: [custody-verify] RESULT PASS: real melee/arrow arrest, private minute notices, saved expiry, inventory capacity and identity, escape and damaged-cell release, full-cell fallback and village-only grace",


### PR DESCRIPTION
## Summary
Aaron asked why the Mediterranean close-out had changed his builds to satisfy checks. Three of those were rules that contradicted the game, so this fixes the rules and restores his blocks; two were definition choices, corrected to his design.

- **Evidence in any container**: `VillageCustody` filtered the castle's evidence containers to barrel block entities, so a chest was silently ignored and an arrest could not stow anything. It now takes any container the layout names; the construction and custody harnesses check the same. The fort keeps its two jail chests.
- **A person can be sent to a sign's cell**: vanilla's ground navigation retargets a path whose goal block is "solid" to the cell above it, and signs and banners are flagged solid although they have no collision, so an approach cell beside the stoneworks bed became unreachable while a player walks through it. `PersonPathNavigation` keeps the target when the block has no collision. The three signs by that bed are back.
- **Footing stands on carpets**: `WorkerFooting` measured a worker's body from the floor block under a carpet and collided with the carpet above the feet. It now lifts the feet onto a thin covering (carpet, pressure plate, one snow layer). The carpets under five stations are back.
- **The mine employs and houses its miner**: the church centre no longer routes a miner; the mine has its own MINER station under the bookshelf and its upstairs bed is the miner's. The reviewed-village check expects four centre jobs plus the mine's.
- **Small farm to large farm** is an ordinary upgrade again, not a standalone level two; the check verifies the fit in four rotations.
- Docs: `mediterranean-village.md` and `castles.md` describe the real rules; the catalog record carries the rerun verifications.

## Test plan
- [x] `./gradlew check` green.
- [x] Native reruns on the re-exported datapack: placement, restart, founding (with the farm upgrade fit), centre, access (carpets and signs in place), castle construction and custody with chests, patrol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
