### PR TITLE
Cleric: potions as stock, brewing at the station, hex loadouts, hurt villagers seek the cleric

### DIFF
--- a/docs/building-spec.md
+++ b/docs/building-spec.md
@@ -545,6 +545,15 @@ library variant the village built, or whether a future datapack adds a third way
 | `requires_capability` | When the village's capability set is recomputed, on a building finishing or being lost | Static. Either the village has `LEARNING` or it does not. |
 | `requires_supply` | On the brain's slow tick, against real container contents | Dynamic. An inn with no ale grants nothing this tick and grants again when the brewery catches up. |
 
+**A station declares its grant.** A definition that adds a work station also carries the
+grant that post stands for: a cleric station comes with `HEALING`, a blacksmith station with
+`REPAIR`, and a building with both carries both (Aaron, 2026-09-12: "the planner knows what
+buildings will do what"). The table lives in `StationGrants`. The loader warns about every
+station whose grant is missing rather than rejecting the building, so a private datapack still
+loads and its author sees the gap in the log; a test holds the bundled catalog to zero
+warnings. Guard, builder and leader stations are exempt: the watchtower's guards grant
+`PROTECTION` while the centre's captain does not, and that is a planning choice.
+
 Capability resolution is a fixed point: grant everything unconditional, then re-evaluate
 `grants_if` until nothing new appears. Two buildings that each require the other's capability
 simply never grant, which is the correct and quiet failure.

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -380,7 +380,8 @@ The last bottle of a brew is the **seed**. It is never thrown and never given aw
 conversation, because a cleric who parts with it has lost the brew for good and would have to
 be handed another before making more. The clean half of that rule is in the chat briefing: a
 cleric is told the bottles they can spare of each brew, "you have this many minus one", so a
-model that gives only what it was told it has never offers the seed. The take itself
+model that gives only what it was told it has never offers the seed, and a separate line names
+the brews held in reserve and why, so the cleric also knows what they can brew. The take itself
 (`PersonChatDispatcher.takeFromSlots`) caps at the spare as a backstop, the one exception to
 "anything goes". Above the seed, potions are theirs to give like anything else.
 

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -377,9 +377,12 @@ decides what they can do:
   Potions do not stack, so each bottle needs a pack slot, and a full pack waits.
 
 The last bottle of a brew is the **seed**. It is never thrown and never given away in
-conversation (the one exception to "anything goes" in `PersonChatDispatcher.takeFromSlots`),
-because a cleric who parts with it has lost the brew for good and would have to be handed
-another before making more. Above the seed, potions are theirs to give like anything else.
+conversation, because a cleric who parts with it has lost the brew for good and would have to
+be handed another before making more. The clean half of that rule is in the chat briefing: a
+cleric is told the bottles they can spare of each brew, "you have this many minus one", so a
+model that gives only what it was told it has never offers the seed. The take itself
+(`PersonChatDispatcher.takeFromSlots`) caps at the spare as a backstop, the one exception to
+"anything goes". Above the seed, potions are theirs to give like anything else.
 
 The loadout is issued, not authored. Every cleric starts with a splash of regeneration and a
 splash of healing (`SignatureGear`). At bedtime, before the pack is shelved (their potions are

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -342,6 +342,53 @@ sleep, a missing or doused fire, and an existing regeneration effect all prevent
 starting. Each person's one-minute cooldown is persisted on the entity, so changing jobs or
 reloading cannot reset it.
 
+### Seeking the cleric
+
+Built 2026-09-12. A badly hurt villager with a cleric in reach goes to the cleric instead of
+the fire (Aaron: if there is a cleric nearby, they are a better source of healing than eating
+or the campfire). `SeekClericGoal` finds the nearest awake cleric of the villager's own village
+within forty-eight blocks, walks to within five, and stands there; the cleric's own round sees a
+hurt neighbour inside ten blocks and throws. It shares fetching food's priority and is
+registered ahead of it, so a villager goes to the cleric when one is near and fetches food when
+none is. Eating is not displaced: it holds no movement flag, so a villager with a meal eats on
+the way and while they wait. The visit ends when the patient is back over the line or already
+regenerating, when the cleric sleeps or leaves, at night, or after a minute beside a cleric who
+has not thrown, so a cleric out of potions cannot pin a patient for the day.
+
+## The cleric's potions are stock
+
+Decided 2026-09-12. A cleric's potions are real items, not a spell (`ClericPotions`). Every
+throw consumes one splash potion from the cleric's hands or pack, and what the cleric carries
+decides what they can do:
+
+- **Healing** (`HealStep`): a hurt villager or player within ten blocks gets a splash of
+  healing when nearly dead and regeneration otherwise, whichever the cleric carries, and
+  nothing when they carry neither to spare.
+- **Harm** (`ThrowPotionAttackGoal`): a cleric carrying a harmful splash potion (harming,
+  poison, weakness, slowness: every effect of it hurts) acquires hostile mobs as targets and
+  throws it at them. A cleric carrying only healing never acquires a target. Two rules are
+  absolute: harm is never thrown while an ally stands inside the burst around the target, and
+  never through a friend in the way; the cleric closes in and waits for a clear throw instead.
+  Harm sits ahead of healing at the same priority, so a cleric with both fights first and tends
+  after.
+- **Brewing** (`BrewStep`): at their station, a cleric turns one carried potion of a brew into
+  three more of it, in a session as long as a brewing stand's. The stand needs nothing put in
+  it: the carried bottle is the recipe. The brew furthest below four carried is made first.
+  Potions do not stack, so each bottle needs a pack slot, and a full pack waits.
+
+The last bottle of a brew is the **seed**. It is never thrown and never given away in
+conversation (the one exception to "anything goes" in `PersonChatDispatcher.takeFromSlots`),
+because a cleric who parts with it has lost the brew for good and would have to be handed
+another before making more. Above the seed, potions are theirs to give like anything else.
+
+The loadout is issued, not authored. Every cleric starts with a splash of regeneration and a
+splash of healing (`SignatureGear`). At bedtime, before the pack is shelved (their potions are
+kept, like a guard's weapons), a cleric lifts one bottle of every splash brew the village stores
+hold that they do not yet carry. So a player who leaves a splash of harming in a village chest
+has armed the cleric, and the swamp's witch circle is a cleric someone handed harm. The
+authored-per-station alternative, marking a church's station healer or battle-cleric, was
+considered and set aside for this.
+
 ## The builder builds, and between builds it makes the village walkable
 
 **Damage maintenance, 2026-09-09.** Between construction projects the builder repairs

--- a/src/main/java/com/quzzar/kithkyn/chat/PersonChatContext.java
+++ b/src/main/java/com/quzzar/kithkyn/chat/PersonChatContext.java
@@ -380,6 +380,10 @@ public final class PersonChatContext {
     }
     String pockets = pocketsSummary(person);
     system.append("Your pockets: ").append(pockets.isEmpty() ? "empty" : pockets).append(".\n");
+    String reserve = potionReserveLine(person);
+    if (!reserve.isEmpty()) {
+      system.append(reserve).append('\n');
+    }
     system.append(personalHousingLine(person)).append('\n');
     // Their own chest at home, stated on the same rule as the pockets: what it
     // holds when it is in sight, and that they have none when they have none,
@@ -575,6 +579,27 @@ public final class PersonChatContext {
     List<String> parts = new ArrayList<>();
     counts.forEach((name, count) -> parts.add(count + " " + name));
     return String.join(", ", parts);
+  }
+
+  /**
+   * A cleric's seeds, said plainly: one bottle of each brew is kept back as the
+   * recipe they brew more from at their station, and is not for giving. This
+   * is the context behind the spare counts in the pockets line, and it tells
+   * the cleric what they can make (Aaron, 2026-09-12). Empty for anyone else.
+   */
+  private static String potionReserveLine(RealPerson person) {
+    if (!ClericPotions.isCleric(person)) {
+      return "";
+    }
+    List<String> brews = new ArrayList<>();
+    for (ClericPotions.Stock stock : ClericPotions.stock(person)) {
+      brews.add(itemName(stock.sample()));
+    }
+    if (brews.isEmpty()) {
+      return "You carry no potions at all, so there is nothing you can brew more of until someone hands you a bottle.";
+    }
+    return "In reserve, not counted above and not for giving: one " + String.join(", one ", brews)
+        + ". Each is the recipe you brew three more of at your station; give the last one away and that brew is lost to you.";
   }
 
   /**

--- a/src/main/java/com/quzzar/kithkyn/chat/PersonChatContext.java
+++ b/src/main/java/com/quzzar/kithkyn/chat/PersonChatContext.java
@@ -14,6 +14,7 @@ import com.quzzar.kithkyn.compat.AccessoryCompat;
 import com.quzzar.kithkyn.entities.MarriageStatus;
 import com.quzzar.kithkyn.entities.PersonalLogData;
 import com.quzzar.kithkyn.entities.UndertakingData;
+import com.quzzar.kithkyn.entities.ClericPotions;
 import com.quzzar.kithkyn.entities.RealPerson;
 import com.quzzar.kithkyn.entities.KithkynAttachments;
 import com.quzzar.kithkyn.llm.LlmService.FewShotExample;
@@ -547,15 +548,30 @@ public final class PersonChatContext {
     return String.join(" and ", parts);
   }
 
-  /** The FULL pocket contents, aggregated by item — they know their own bags. */
+  /**
+   * The FULL pocket contents, aggregated by item — they know their own bags.
+   * With one omission: a cleric is told the bottles they can spare of each
+   * brew, never the seed ({@link ClericPotions#sparePackCount}). A model that
+   * gives only what the briefing says it has then never offers the last bottle,
+   * which is the cleaner half of the rule; the take in
+   * {@code PersonChatDispatcher.takeFromSlots} is the backstop.
+   */
   private static String pocketsSummary(RealPerson person) {
     Map<String, Integer> counts = new LinkedHashMap<>();
+    boolean cleric = ClericPotions.isCleric(person);
     for (int i = 0; i < person.personMainInv.getContainerSize(); i++) {
       ItemStack stack = person.personMainInv.getItem(i);
-      if (!stack.isEmpty()) {
-        counts.merge(itemName(stack), stack.getCount(), Integer::sum);
+      if (stack.isEmpty()) {
+        continue;
       }
+      if (cleric && ClericPotions.isThrowable(stack)) {
+        // Counted once per brew, as the spare, however many slots it fills.
+        counts.putIfAbsent(itemName(stack), ClericPotions.sparePackCount(person, stack));
+        continue;
+      }
+      counts.merge(itemName(stack), stack.getCount(), Integer::sum);
     }
+    counts.values().removeIf(count -> count <= 0);
     List<String> parts = new ArrayList<>();
     counts.forEach((name, count) -> parts.add(count + " " + name));
     return String.join(", ", parts);

--- a/src/main/java/com/quzzar/kithkyn/chat/PersonChatDispatcher.java
+++ b/src/main/java/com/quzzar/kithkyn/chat/PersonChatDispatcher.java
@@ -18,6 +18,7 @@ import com.quzzar.kithkyn.Kithkyn;
 import com.quzzar.kithkyn.chat.PersonChatContext.AssembledChat;
 import com.quzzar.kithkyn.chat.PersonChatContext.Turn;
 import com.quzzar.kithkyn.configuration.KithkynConfig;
+import com.quzzar.kithkyn.entities.ClericPotions;
 import com.quzzar.kithkyn.entities.RealPerson;
 import com.quzzar.kithkyn.entities.UndertakingData;
 import com.quzzar.kithkyn.entities.UndertakingService;
@@ -836,6 +837,11 @@ public final class PersonChatDispatcher {
    * own tool or token included: a villager parting with what they work with is
    * their business, and by day the tool-tending pass draws it back
    * ({@link RealPerson#tendJobTool}, {@link RealPerson#tendSignatureGear}).
+   *
+   * <p>The one exception is the cleric's last potion of a brew. Potions are
+   * stock the cleric can only grow from a bottle they already hold
+   * ({@link ClericPotions}), so giving the last one away loses the brew for
+   * good; everything above that seed is theirs to give like anything else.
    */
   private static int takeFromSlots(RealPerson person, net.minecraft.world.item.Item item, int want) {
     int collected = 0;
@@ -845,7 +851,7 @@ public final class PersonChatDispatcher {
       }
       ItemStack worn = person.getItemBySlot(eq);
       if (!worn.isEmpty() && worn.getItem() == item) {
-        int take = Math.min(want - collected, worn.getCount());
+        int take = Math.min(want - collected, giveable(person, worn));
         worn.shrink(take);
         person.setItemSlot(eq, worn.isEmpty() ? ItemStack.EMPTY : worn);
         collected += take;
@@ -854,12 +860,17 @@ public final class PersonChatDispatcher {
     for (int i = 0; i < person.personMainInv.getContainerSize() && collected < want; i++) {
       ItemStack stack = person.personMainInv.getItem(i);
       if (!stack.isEmpty() && stack.getItem() == item) {
-        int take = Math.min(want - collected, stack.getCount());
+        int take = Math.min(want - collected, giveable(person, stack));
         person.personMainInv.removeItem(i, take);
         collected += take;
       }
     }
     return collected;
+  }
+
+  /** How much of a stack may leave: all of it, except a cleric's seed potion. */
+  private static int giveable(RealPerson person, ItemStack stack) {
+    return ClericPotions.isCleric(person) ? ClericPotions.giveable(person, stack) : stack.getCount();
   }
 
   /** How many of {@code item} the villager holds across every slot. */

--- a/src/main/java/com/quzzar/kithkyn/chat/PersonChatDispatcher.java
+++ b/src/main/java/com/quzzar/kithkyn/chat/PersonChatDispatcher.java
@@ -719,20 +719,12 @@ public final class PersonChatDispatcher {
   }
 
   /**
-   * A give is honoured only for an item actually in the villager's pockets, and
-   * only once in a while.
-   *
-   * The pockets check was the ONLY gate, which turned out not to be a gate at
-   * all: the model offers items on ordinary conversational turns - a torch when
-   * asked how business is, a diamond when asked what is in her inventory - and
-   * anything a villager happened to be carrying could be handed over on any
-   * turn. Aaron was given a diamond for asking a question.
-   *
-   * The prompt now tells them to give only when asked, which helps and cannot
-   * be relied on: it is a request to a 3B model, not a rule. This is the rule.
-   * A villager parting with something occasionally is the charm; a villager
-   * emptying their pockets over a conversation is the bug, and a cooldown
-   * bounds the second without touching the first.
+   * A give is honoured for any item actually in the villager's pockets, as
+   * often as they like: a villager's things are theirs to part with (Aaron,
+   * 2026-09-12: no cooldown, and no guard on the job's own gear). The model
+   * once offered items on ordinary turns, a torch when asked how business is,
+   * a diamond for asking a question; the prompt now tells them to give only
+   * when asked, and that is the only brake on how often.
    */
   private static void executeGive(RealPerson person, ServerPlayer player, String itemId, int requestedCount) {
     ResourceLocation id = ResourceLocation.tryParse(itemId.contains(":") ? itemId : "minecraft:" + itemId);

--- a/src/main/java/com/quzzar/kithkyn/entities/ClericPotions.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ClericPotions.java
@@ -1,0 +1,321 @@
+package com.quzzar.kithkyn.entities;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import com.quzzar.kithkyn.village.Occupation;
+
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.util.Mth;
+import net.minecraft.world.Container;
+import net.minecraft.world.effect.MobEffectCategory;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.ThrownPotion;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * A cleric's potions are stock, not a spell (Aaron, 2026-09-12).
+ *
+ * <p>Every throw consumes one real splash potion from the cleric's hands or
+ * pack, and what the cleric carries decides what they can do: a splash of
+ * regeneration makes a healer, a splash of harming makes a hexer, and a cleric
+ * carrying both chooses by target. Nothing is conjured. Stock is grown the one
+ * way a cleric has, at their station ({@code BrewStep}): one carried potion of
+ * a brew stands for the recipe, and a brewing session yields {@link #BREW_YIELD}
+ * more of it. That seed is why the last potion of a brew is never thrown and
+ * never given away ({@link #giveable}): a cleric who parts with it has lost the
+ * brew for good, and would have to be handed another before making more.
+ *
+ * <p>A brew is the item plus its {@link PotionContents}: a splash of healing
+ * and a splash of harming are both splash potions and are never confused. The
+ * static helpers take the three places a villager keeps things so the rules
+ * can be tested on plain containers; the {@link RealPerson} overloads read the
+ * villager's own.
+ */
+public final class ClericPotions {
+
+  /** Carried potions of one brew a cleric brews back up to. */
+  public static final int STOCK_TARGET = 4;
+
+  /** Potions one brewing session yields, the three bottles of a brewing stand. */
+  public static final int BREW_YIELD = 3;
+
+  /** A brewing session takes as long as the stand does: twenty seconds. */
+  public static final int BREW_TICKS = 400;
+
+  /** The items a cleric's stock is kept in overnight rather than shelved with the rest of the pack. */
+  public static final Set<Item> STOCK_ITEMS = Set.of(Items.SPLASH_POTION, Items.LINGERING_POTION);
+
+  /** Below this the cleric reaches for instant healing over regeneration. */
+  private static final float NEARLY_DEAD = 4.0F;
+
+  private ClericPotions() {
+  }
+
+  /** One brew the cleric carries, with a sample stack and the count across every slot. */
+  public record Stock(ItemStack sample, int count) {
+  }
+
+  /** A potion that can be thrown at all: a splash or lingering potion that does something. */
+  public static boolean isThrowable(ItemStack stack) {
+    if (stack.isEmpty() || !STOCK_ITEMS.contains(stack.getItem())) {
+      return false;
+    }
+    PotionContents contents = stack.get(DataComponents.POTION_CONTENTS);
+    return contents != null && contents.getAllEffects().iterator().hasNext();
+  }
+
+  /** A throwable brew whose every effect hurts: what a cleric throws at an enemy and never at a friend. */
+  public static boolean isHarmful(ItemStack stack) {
+    if (!isThrowable(stack)) {
+      return false;
+    }
+    for (MobEffectInstance effect : stack.get(DataComponents.POTION_CONTENTS).getAllEffects()) {
+      if (effect.getEffect().value().getCategory() != MobEffectCategory.HARMFUL) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** A throwable brew with nothing harmful in it: what a cleric throws over the hurt. */
+  public static boolean isBeneficial(ItemStack stack) {
+    if (!isThrowable(stack)) {
+      return false;
+    }
+    for (MobEffectInstance effect : stack.get(DataComponents.POTION_CONTENTS).getAllEffects()) {
+      if (effect.getEffect().value().getCategory() == MobEffectCategory.HARMFUL) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Whether the brew carries this effect, whatever else it does. */
+  public static boolean has(ItemStack stack, net.minecraft.core.Holder<net.minecraft.world.effect.MobEffect> effect) {
+    if (!isThrowable(stack)) {
+      return false;
+    }
+    for (MobEffectInstance instance : stack.get(DataComponents.POTION_CONTENTS).getAllEffects()) {
+      if (instance.getEffect().equals(effect)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** The same item with the same potion inside: the identity of a brew. */
+  public static boolean sameBrew(ItemStack a, ItemStack b) {
+    if (a.isEmpty() || b.isEmpty() || a.getItem() != b.getItem()) {
+      return false;
+    }
+    PotionContents ca = a.get(DataComponents.POTION_CONTENTS);
+    PotionContents cb = b.get(DataComponents.POTION_CONTENTS);
+    return ca != null && ca.equals(cb);
+  }
+
+  /** Every throwable stack across the hands and the pack, live, in that order. */
+  static List<ItemStack> stacks(ItemStack mainHand, ItemStack offHand, Container pack) {
+    List<ItemStack> out = new ArrayList<>();
+    if (isThrowable(mainHand)) {
+      out.add(mainHand);
+    }
+    if (isThrowable(offHand)) {
+      out.add(offHand);
+    }
+    for (int slot = 0; slot < pack.getContainerSize(); slot++) {
+      ItemStack stack = pack.getItem(slot);
+      if (isThrowable(stack)) {
+        out.add(stack);
+      }
+    }
+    return out;
+  }
+
+  /** What the cleric carries, one entry per brew. */
+  public static List<Stock> stock(ItemStack mainHand, ItemStack offHand, Container pack) {
+    List<Stock> tally = new ArrayList<>();
+    for (ItemStack stack : stacks(mainHand, offHand, pack)) {
+      boolean counted = false;
+      for (int index = 0; index < tally.size(); index++) {
+        Stock entry = tally.get(index);
+        if (sameBrew(entry.sample(), stack)) {
+          tally.set(index, new Stock(entry.sample(), entry.count() + stack.getCount()));
+          counted = true;
+          break;
+        }
+      }
+      if (!counted) {
+        tally.add(new Stock(stack.copyWithCount(1), stack.getCount()));
+      }
+    }
+    return tally;
+  }
+
+  /** How many of this brew are carried altogether. */
+  public static int carried(ItemStack mainHand, ItemStack offHand, Container pack, ItemStack brew) {
+    int count = 0;
+    for (ItemStack stack : stacks(mainHand, offHand, pack)) {
+      if (sameBrew(stack, brew)) {
+        count += stack.getCount();
+      }
+    }
+    return count;
+  }
+
+  /**
+   * The stack to throw one of, for the first brew that passes the test and has
+   * a potion to spare, or null when none does. The seed is protected here: a
+   * brew with a single potion left is never offered, so throwing can never end
+   * a brew. Hands are preferred over the pack, which is where the mark of the
+   * trade already sits.
+   */
+  @Nullable
+  public static ItemStack throwable(ItemStack mainHand, ItemStack offHand, Container pack,
+      Predicate<ItemStack> kind) {
+    for (ItemStack stack : stacks(mainHand, offHand, pack)) {
+      if (kind.test(stack) && carried(mainHand, offHand, pack, stack) >= 2) {
+        return stack;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * How many of this stack may leave the cleric: everything but the last
+   * potion of its brew. A stack that is not potion stock is entirely giveable.
+   */
+  public static int giveable(ItemStack mainHand, ItemStack offHand, Container pack, ItemStack stack) {
+    if (!isThrowable(stack)) {
+      return stack.getCount();
+    }
+    int total = carried(mainHand, offHand, pack, stack);
+    return Math.max(0, Math.min(stack.getCount(), total - 1));
+  }
+
+  /** The carried brew furthest below {@link #STOCK_TARGET}, or null when every brew is stocked. */
+  @Nullable
+  public static Stock lowestBelowTarget(ItemStack mainHand, ItemStack offHand, Container pack) {
+    Stock lowest = null;
+    for (Stock entry : stock(mainHand, offHand, pack)) {
+      if (entry.count() < STOCK_TARGET && (lowest == null || entry.count() < lowest.count())) {
+        lowest = entry;
+      }
+    }
+    return lowest;
+  }
+
+  /**
+   * The order a healer reaches for brews: instant healing when the patient is
+   * nearly dead, regeneration otherwise, then anything else beneficial they
+   * happen to carry.
+   */
+  public static List<Predicate<ItemStack>> healingPreference(LivingEntity patient) {
+    Predicate<ItemStack> healing = stack -> isBeneficial(stack) && has(stack, MobEffects.HEAL);
+    Predicate<ItemStack> regeneration = stack -> isBeneficial(stack) && has(stack, MobEffects.REGENERATION);
+    return patient.getHealth() <= NEARLY_DEAD
+        ? List.of(healing, regeneration, ClericPotions::isBeneficial)
+        : List.of(regeneration, healing, ClericPotions::isBeneficial);
+  }
+
+  // The villager's own three places, read live.
+
+  public static boolean isCleric(RealPerson person) {
+    return person.getOccupation() == Occupation.CLERIC;
+  }
+
+  public static List<Stock> stock(RealPerson person) {
+    return stock(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv);
+  }
+
+  @Nullable
+  public static ItemStack throwable(RealPerson person, Predicate<ItemStack> kind) {
+    return throwable(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv, kind);
+  }
+
+  /** The first brew in the preference order the cleric can spare one of, or null. */
+  @Nullable
+  public static ItemStack throwable(RealPerson person, List<Predicate<ItemStack>> preference) {
+    for (Predicate<ItemStack> kind : preference) {
+      ItemStack stack = throwable(person, kind);
+      if (stack != null) {
+        return stack;
+      }
+    }
+    return null;
+  }
+
+  public static boolean hasThrowable(RealPerson person, Predicate<ItemStack> kind) {
+    return throwable(person, kind) != null;
+  }
+
+  public static int giveable(RealPerson person, ItemStack stack) {
+    return giveable(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv, stack);
+  }
+
+  @Nullable
+  public static Stock lowestBelowTarget(RealPerson person) {
+    return lowestBelowTarget(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv);
+  }
+
+  /** Whether the target is one the cleric must never splash with harm. */
+  public static boolean isAlly(LivingEntity thrower, LivingEntity other) {
+    return other instanceof Person || other instanceof net.minecraft.world.entity.npc.AbstractVillager
+        || com.quzzar.kithkyn.village.VillageGolems.supports(other)
+        || (other instanceof Player player && !player.getAbilities().instabuild)
+        || thrower.isAlliedTo(other);
+  }
+
+  /**
+   * Whether a harmful splash burst at the target would catch an ally. A thrown
+   * potion reaches everyone within four blocks across and two up or down of
+   * where it breaks, so the check is that box around the target, less the
+   * target itself.
+   */
+  public static boolean harmfulSplashWouldCatchAlly(LivingEntity thrower, LivingEntity target) {
+    for (LivingEntity nearby : thrower.level().getEntitiesOfClass(LivingEntity.class,
+        target.getBoundingBox().inflate(4.0D, 2.0D, 4.0D))) {
+      if (nearby != target && nearby.isAlive() && isAlly(thrower, nearby)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Lob one potion of the stack at the target, the way a witch does: aimed at
+   * where the target is heading, lofted with distance. The stack loses the
+   * potion thrown; the thrown one is a copy of a single bottle, so a stack's
+   * other potions are never in the air.
+   */
+  public static void throwOne(LivingEntity thrower, LivingEntity target, ItemStack stack) {
+    Vec3 drift = target.getDeltaMovement();
+    double dx = target.getX() + drift.x - thrower.getX();
+    double dy = target.getEyeY() - 1.1F - thrower.getY();
+    double dz = target.getZ() + drift.z - thrower.getZ();
+    float flat = Mth.sqrt((float) (dx * dx + dz * dz));
+
+    ThrownPotion thrown = new ThrownPotion(thrower.level(), thrower);
+    thrown.setItem(stack.copyWithCount(1));
+    thrown.setXRot(-20.0F);
+    thrown.shoot(dx, dy + flat * 0.2F, dz, 0.75F, 8.0F);
+    thrower.level().playSound((Player) null, thrower.getX(), thrower.getY(), thrower.getZ(),
+        SoundEvents.SPLASH_POTION_THROW, thrower.getSoundSource(), 1.0F,
+        0.8F + thrower.getRandom().nextFloat() * 0.4F);
+    thrower.level().addFreshEntity(thrown);
+    stack.shrink(1);
+  }
+
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/ClericPotions.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ClericPotions.java
@@ -205,6 +205,24 @@ public final class ClericPotions {
     return Math.max(0, Math.min(stack.getCount(), total - 1));
   }
 
+  /**
+   * How many bottles of this brew in the pack are spare: the pack's count,
+   * capped at everything but the seed. What the chat briefing tells a cleric
+   * they have in their pockets, so a model that only ever offers what it was
+   * told about never offers the seed (Aaron, 2026-09-12: "you have this many
+   * minus one").
+   */
+  public static int sparePackCount(ItemStack mainHand, ItemStack offHand, Container pack, ItemStack brew) {
+    int inPack = 0;
+    for (int slot = 0; slot < pack.getContainerSize(); slot++) {
+      ItemStack stack = pack.getItem(slot);
+      if (sameBrew(stack, brew)) {
+        inPack += stack.getCount();
+      }
+    }
+    return Math.max(0, Math.min(inPack, carried(mainHand, offHand, pack, brew) - 1));
+  }
+
   /** The carried brew furthest below {@link #STOCK_TARGET}, or null when every brew is stocked. */
   @Nullable
   public static Stock lowestBelowTarget(ItemStack mainHand, ItemStack offHand, Container pack) {
@@ -263,6 +281,10 @@ public final class ClericPotions {
 
   public static int giveable(RealPerson person, ItemStack stack) {
     return giveable(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv, stack);
+  }
+
+  public static int sparePackCount(RealPerson person, ItemStack brew) {
+    return sparePackCount(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv, brew);
   }
 
   @Nullable

--- a/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
@@ -74,6 +74,7 @@ import com.quzzar.kithkyn.entities.ai.goals.work.MineStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.BuildStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.WallStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.MarketStep;
+import com.quzzar.kithkyn.entities.ai.goals.work.BrewStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.HealStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.HuntStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.FetchStep;
@@ -90,6 +91,8 @@ import com.quzzar.kithkyn.entities.ai.goals.work.PlantStep;
 import com.quzzar.kithkyn.entities.ai.goals.work.StashBonemealStep;
 import com.quzzar.kithkyn.entities.ai.goals.ArmorerRepairPersonArmorGoal;
 import com.quzzar.kithkyn.entities.ai.goals.CampfireRecoveryGoal;
+import com.quzzar.kithkyn.entities.ai.goals.SeekClericGoal;
+import com.quzzar.kithkyn.entities.ai.goals.ThrowPotionAttackGoal;
 import com.quzzar.kithkyn.entities.ai.goals.ReturnBackToVillageGoal;
 import com.quzzar.kithkyn.entities.ai.goals.RunAwayGoal;
 import com.quzzar.kithkyn.entities.ai.goals.PersonEatFoodGoal;
@@ -1515,7 +1518,15 @@ public class RealPerson extends Person {
     // loose item first: each rejected remainder is written back to the same pack
     // slot, so full shelves cannot destroy it after the entity despawns.
     final BlockPos preferredStorage = depositToLoc;
-    boolean storedAll = GuardWeapons.stowUnkept(this, this.keepingForHome,
+    // A cleric's potions are their working stock, not haul: they stay in the
+    // pack overnight like the guard's weapons (ClericPotions).
+    Set<Item> keeping = this.keepingForHome;
+    if (ClericPotions.isCleric(this)) {
+      Set<Item> kept = new java.util.HashSet<>(keeping);
+      kept.addAll(ClericPotions.STOCK_ITEMS);
+      keeping = kept;
+    }
+    boolean storedAll = GuardWeapons.stowUnkept(this, keeping,
         stack -> this.getVillage().storeAwayFrom(stack, List.of(), preferredStorage));
     if (!storedAll) {
       // Not a NoResourceBookkeepingEvent: that reports a shortage, while a
@@ -1557,6 +1568,9 @@ public class RealPerson extends Person {
       // after (PersonEatFoodGoal). Only then top up the rations.
       maybeEquipOrForgeShield(depositToLoc);
       restockRations(depositToLoc);
+    }
+    if (ClericPotions.isCleric(this)) {
+      restockClericSeeds();
     }
 
     // Take 1 sponge if builder or miner // TODO, change to if needed
@@ -1619,6 +1633,51 @@ public class RealPerson extends Person {
 
     }
 
+  }
+
+  /**
+   * A cleric's loadout is issued, not authored: any splash potion the village
+   * stores hold of a brew the cleric does not yet carry is lifted into the pack
+   * as a new seed, one bottle each, from the nearest chests that have any. A
+   * player who leaves a splash of harming in a village chest has armed the
+   * cleric; the brewing round grows it from there (ClericPotions, BrewStep).
+   * Nothing is conjured, and brews already carried are left on the shelf.
+   */
+  private void restockClericSeeds() {
+    Village village = getVillage();
+    if (village == null) {
+      return;
+    }
+    java.util.function.Predicate<ItemStack> newBrew = stack ->
+        ClericPotions.isThrowable(stack)
+            && ClericPotions.carried(getMainHandItem(), getOffhandItem(),
+                this.personMainInv, stack) == 0;
+    for (int visit = 0; visit < 3; visit++) {
+      BlockPos chestPos = com.quzzar.kithkyn.entities.ai.goals.work.PackLogistics.chestWhere(this, village, newBrew);
+      Container chest = chestPos == null ? null
+          : com.quzzar.kithkyn.entities.ai.goals.work.PackLogistics.containerAt(this, chestPos);
+      if (chest == null) {
+        return;
+      }
+      int taken = 0;
+      for (int slot = 0; slot < chest.getContainerSize(); slot++) {
+        ItemStack stack = chest.getItem(slot);
+        if (!newBrew.test(stack)) {
+          continue;
+        }
+        // Into the pack first, out of the chest only once it fit: a full pack
+        // moves nothing and ends the visit.
+        if (!this.personMainInv.addItem(stack.copyWithCount(1)).isEmpty()) {
+          break;
+        }
+        chest.removeItem(slot, 1);
+        taken++;
+      }
+      if (taken > 0) {
+        chest.setChanged();
+        Kithkyn.LOGGER.info("'{}' took {} new potion seed(s) from the village stores", getFullName(), taken);
+      }
+    }
   }
 
   /**
@@ -2659,6 +2718,12 @@ public class RealPerson extends Person {
 
     this.goalSelector.addGoal(0, new FloatGoal(this));
     this.goalSelector.addGoal(0, new PersonEatFoodGoal(this));
+    // A hurt villager with a cleric in reach goes to be tended first: the
+    // cleric's splash outlasts anything else on offer, and eating holds no
+    // movement flag, so a meal is taken on the way and while waiting. Same
+    // priority as fetching food and registered ahead of it, so the cleric wins
+    // when both are possible and food is fetched when no cleric is near.
+    this.goalSelector.addGoal(1, new SeekClericGoal(this));
     // A hurt villager with nothing to eat goes and gets some, from the stores
     // or their own chest, before any work; the eating goal takes over on arrival.
     this.goalSelector.addGoal(1, new com.quzzar.kithkyn.entities.ai.goals.FetchFoodWhenHurtGoal(this));
@@ -2757,7 +2822,19 @@ public class RealPerson extends Person {
     }
 
     if (getOccupation() == Occupation.CLERIC) {
+      // What a cleric does is what they carry (ClericPotions). Harm first at
+      // the same priority as healing, registered ahead of it, so a cleric with
+      // a target and a harmful splash to spare fights before tending; a cleric
+      // carrying only healing never acquires a target at all, since the threat
+      // goal below asks for the harmful stock. Brewing sits below both: more
+      // potions are made when nobody needs one thrown.
+      this.goalSelector.addGoal(2, new ThrowPotionAttackGoal(this));
       this.goalSelector.addGoal(2, new WorkLoopGoal<>(this, new HealStep(1, 7, 7.0F)));
+      this.goalSelector.addGoal(3, new WorkLoopGoal<>(this, new BrewStep()));
+      this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, Mob.class, 10, true, false,
+          (mob) -> mob instanceof Enemy && !(mob instanceof Creeper)
+              && ClericPotions.hasThrowable(this,
+                  ClericPotions::isHarmful)));
     }
     if (getOccupation() == Occupation.GUARD) {
       com.quzzar.kithkyn.village.GuardDuty guardDuty = com.quzzar.kithkyn.village.GuardDuty.of(this);
@@ -3112,7 +3189,6 @@ public class RealPerson extends Person {
     // long before, so which path runs cannot be settled here. (A wandering
     // merchant never reaches this line: it branched off above.)
     this.goalSelector.addGoal(6, new BedtimeWithoutBedGoal(this));
-    // this.goalSelector.addGoal(6, new RunToClericGoal(this)); Don't need it seems
     this.goalSelector.addGoal(6, new ArmorerRepairPersonArmorGoal(this));
 
     // Below the work goals, which sit at 4: a goal can only take movement from

--- a/src/main/java/com/quzzar/kithkyn/entities/SignatureGear.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/SignatureGear.java
@@ -17,7 +17,7 @@ import net.minecraft.world.item.alchemy.Potions;
  * The item a trade holds as the mark of its work, for the trades whose mark is
  * not a tool: the quartermaster's ledger (a writable book), the builder's
  * crafting table, the librarian's book, the blacksmith's iron ingot, the
- * cleric's healing and regeneration potions. This is the one place they are
+ * cleric's splash potions of healing and regeneration. This is the one place they are
  * named, so the starting kit that first hands them out
  * ({@link RealPerson#issueStartingKit}), the day-to-day check that keeps them in
  * hand ({@link RealPerson#tendSignatureGear}), and the rule that keeps a
@@ -75,12 +75,14 @@ public final class SignatureGear {
       // The quartermaster keeps the village's stores; a writable book reads as
       // the ledger they are forever taking count in.
       case QUARTERMASTER -> List.of(new Piece(EquipmentSlot.MAINHAND, () -> new ItemStack(Items.WRITABLE_BOOK)));
-      // A splash of regeneration to throw over the hurt, a healing potion kept
-      // in the off hand. HealStep makes each throw fresh, so these are the
-      // cleric's mark, not the flask it draws from.
+      // A splash of regeneration in hand and a splash of healing in the off
+      // hand: the two brews every cleric starts with. Unlike the other marks
+      // these are real stock (ClericPotions): a throw consumes one, and the
+      // last bottle of a brew is the seed the cleric brews more from, so it is
+      // never thrown or given away.
       case CLERIC -> List.of(
           new Piece(EquipmentSlot.MAINHAND, SignatureGear::regenSplash),
-          new Piece(EquipmentSlot.OFFHAND, SignatureGear::healing));
+          new Piece(EquipmentSlot.OFFHAND, SignatureGear::healingSplash));
       default -> List.of();
     };
   }
@@ -91,8 +93,8 @@ public final class SignatureGear {
     return stack;
   }
 
-  private static ItemStack healing() {
-    ItemStack stack = new ItemStack(Items.POTION);
+  private static ItemStack healingSplash() {
+    ItemStack stack = new ItemStack(Items.SPLASH_POTION);
     stack.set(DataComponents.POTION_CONTENTS, new PotionContents(Potions.HEALING));
     return stack;
   }

--- a/src/main/java/com/quzzar/kithkyn/entities/SignatureGear.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/SignatureGear.java
@@ -19,9 +19,8 @@ import net.minecraft.world.item.alchemy.Potions;
  * crafting table, the librarian's book, the blacksmith's iron ingot, the
  * cleric's splash potions of healing and regeneration. This is the one place they are
  * named, so the starting kit that first hands them out
- * ({@link RealPerson#issueStartingKit}), the day-to-day check that keeps them in
- * hand ({@link RealPerson#tendSignatureGear}), and the rule that keeps a
- * villager from giving their own away all read the same list.
+ * ({@link RealPerson#issueStartingKit}) and the day-to-day check that keeps them
+ * in hand ({@link RealPerson#tendSignatureGear}) read the same list.
  *
  * <p>Tiered tools (an axe, a pickaxe, a hoe, a bow) are not here: {@link JobTool}
  * maintains those, since a tool comes in tiers and is made again from real
@@ -43,7 +42,7 @@ public final class SignatureGear {
    */
   public record Piece(EquipmentSlot slot, Supplier<ItemStack> fresh) {
 
-    /** The kind of item the piece is, for naming and for the give-away guard. */
+    /** The kind of item the piece is, for naming. */
     public Item item() {
       return this.fresh.get().getItem();
     }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/HealthRecoveryPolicy.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/HealthRecoveryPolicy.java
@@ -12,12 +12,39 @@ public final class HealthRecoveryPolicy {
   /** Only residents already this close consider the campfire a recovery option. */
   public static final double CAMPFIRE_SEARCH_RANGE = 30.0D;
 
+  /**
+   * How far a hurt villager will walk to be tended by the village cleric. Wider
+   * than the campfire's because a cleric is the better cure: a splash of
+   * regeneration outlasts the fire's ten seconds several times over, and the
+   * cleric brings it to whoever stands close.
+   */
+  public static final double CLERIC_SEARCH_RANGE = 48.0D;
+
+  /**
+   * How close a patient stands to the cleric to be tended: inside the ten
+   * blocks the cleric scans and the seven they can throw, with room for the
+   * cleric to step in and steady the throw.
+   */
+  public static final double CLERIC_TENDING_REACH = 5.0D;
+
+  /** How long a patient waits beside a cleric who has not tended them before going about their day. */
+  public static final int CLERIC_WAIT_TICKS = 20 * 60;
+
   private HealthRecoveryPolicy() {
   }
 
   /** Eating, retreating, and campfire recovery begin below one-third health. */
   public static boolean isBadlyHurt(float health, float maximumHealth) {
     return maximumHealth > 0.0F && health < maximumHealth / 3.0F;
+  }
+
+  /**
+   * Where a recovery stops: a little above the line it started at, so a
+   * villager hovering on the threshold does not start and stop every second.
+   * The eating goal's rule, shared by seeking the cleric.
+   */
+  public static boolean isBackOverTheLine(float health, float maximumHealth) {
+    return health >= maximumHealth / 3.0F + 2.0F;
   }
 
   /** Whether the persisted campfire cooldown has elapsed. */
@@ -31,6 +58,17 @@ public final class HealthRecoveryPolicy {
     return isBadlyHurt(health, maximumHealth)
         && !hasMeal
         && isCampfireReady(gameTime, availableAt);
+  }
+
+  /**
+   * The person needs help and a cleric could give it: badly hurt, not already
+   * regenerating, and by day, since the cleric's round stops at dark like every
+   * other job. Food is no bar: a hurt villager eats on the way and while they
+   * wait (Aaron, 2026-09-12: "run to cleric, eat some food").
+   */
+  public static boolean shouldSeekCleric(float health, float maximumHealth, boolean regenerating,
+      boolean night) {
+    return isBadlyHurt(health, maximumHealth) && !regenerating && !night;
   }
 
   /** The first game tick at which another campfire recovery may begin. */

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/SeekClericGoal.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/SeekClericGoal.java
@@ -1,0 +1,167 @@
+package com.quzzar.kithkyn.entities.ai.goals;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+import com.quzzar.kithkyn.Kithkyn;
+import com.quzzar.kithkyn.entities.RealPerson;
+import com.quzzar.kithkyn.entities.ai.HealthRecoveryPolicy;
+import com.quzzar.kithkyn.village.JobAssignment;
+import com.quzzar.kithkyn.village.Occupation;
+import com.quzzar.kithkyn.village.Village;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.ai.goal.Goal;
+
+/**
+ * A badly hurt villager goes to the cleric to be tended (Aaron, 2026-09-12: if
+ * there is a cleric nearby, they are a better source of healing than the fire).
+ *
+ * <p>A personal need like eating, not a job: anyone hurt may do it. The patient
+ * walks to within throwing reach of the nearest awake cleric of their village
+ * and stands there; the cleric's own round ({@code HealStep}) sees a hurt
+ * neighbour within ten blocks and lobs the potion. Eating is not displaced: it
+ * holds no movement flag, so a villager carrying food eats on the walk and
+ * while they wait. The visit ends when the patient is back over the line or
+ * regenerating, when the cleric sleeps, leaves the village or dies, at night,
+ * or after a minute of standing beside a cleric who has not thrown, so a
+ * cleric out of potions cannot pin a patient for the day.
+ */
+public final class SeekClericGoal extends Goal {
+
+  private static final double SPEED = 0.6D;
+  private static final int SELECT_INTERVAL_TICKS = 20;
+  private static final int NAVIGATION_REFRESH_TICKS = 10;
+
+  private final RealPerson person;
+  private final ApproachWatch approach;
+
+  @Nullable
+  private RealPerson cleric;
+  private int nextSelectTick;
+  private int nextNavigationTick;
+  private int ticksWaiting;
+  private boolean complete;
+
+  public SeekClericGoal(RealPerson person) {
+    this.person = person;
+    this.approach = new ApproachWatch(person, "the cleric to be tended");
+    this.setFlags(EnumSet.of(Flag.MOVE, Flag.LOOK));
+  }
+
+  @Override
+  public boolean canUse() {
+    if (!maySeek() || this.approach.standingDown() || this.person.tickCount < this.nextSelectTick) {
+      return false;
+    }
+    this.nextSelectTick = this.person.tickCount + SELECT_INTERVAL_TICKS;
+    Village village = this.person.getVillage();
+    if (village == null || !village.hasResident(this.person.getUUID())
+        || !(this.person.level() instanceof ServerLevel level)) {
+      return false;
+    }
+    this.cleric = nearestCleric(village, level);
+    return this.cleric != null;
+  }
+
+  @Override
+  public boolean canContinueToUse() {
+    return !this.complete && this.cleric != null && maySeek() && isAvailable(this.cleric)
+        && !HealthRecoveryPolicy.isBackOverTheLine(this.person.getHealth(), this.person.getMaxHealth())
+        && this.ticksWaiting < HealthRecoveryPolicy.CLERIC_WAIT_TICKS;
+  }
+
+  @Override
+  public boolean requiresUpdateEveryTick() {
+    return true;
+  }
+
+  @Override
+  public void start() {
+    this.complete = false;
+    this.ticksWaiting = 0;
+    this.nextNavigationTick = this.person.tickCount;
+    this.approach.begin();
+    if (this.cleric != null) {
+      Kithkyn.LOGGER.debug("{} is hurt and going to {} the cleric to be tended",
+          this.person.getFullName(), this.cleric.getFullName());
+    }
+  }
+
+  @Override
+  public void stop() {
+    this.person.getNavigation().stop();
+    this.cleric = null;
+    this.complete = false;
+    this.ticksWaiting = 0;
+  }
+
+  @Override
+  public void tick() {
+    if (this.cleric == null) {
+      this.complete = true;
+      return;
+    }
+    double reach = HealthRecoveryPolicy.CLERIC_TENDING_REACH;
+    if (this.person.distanceToSqr(this.cleric) <= reach * reach) {
+      this.approach.arrived();
+      this.person.getNavigation().stop();
+      this.person.getLookControl().setLookAt(this.cleric, 30.0F, 30.0F);
+      this.ticksWaiting++;
+      return;
+    }
+    if (this.approach.giveUp(this.cleric.blockPosition())) {
+      this.complete = true;
+      return;
+    }
+    if (this.person.tickCount >= this.nextNavigationTick) {
+      this.nextNavigationTick = this.person.tickCount + NAVIGATION_REFRESH_TICKS;
+      this.person.getNavigation().moveTo(this.cleric, SPEED);
+    }
+  }
+
+  /** Personal state that permits starting or carrying on with the visit. */
+  private boolean maySeek() {
+    return HealthRecoveryPolicy.shouldSeekCleric(this.person.getHealth(), this.person.getMaxHealth(),
+            this.person.hasEffect(MobEffects.REGENERATION), this.person.level().isNight())
+        && this.person.getTravelTarget() == null
+        && this.person.getTarget() == null
+        && !this.person.isAggressive()
+        && !this.person.isSleeping()
+        && !this.person.isImmobile()
+        && !this.person.isInterrupted();
+  }
+
+  /** A cleric who could tend anyone right now: alive, awake, loaded, and not this villager. */
+  private boolean isAvailable(RealPerson candidate) {
+    return candidate != this.person && candidate.isAlive() && !candidate.isSleeping()
+        && !candidate.isRemoved() && candidate.getOccupation() == Occupation.CLERIC;
+  }
+
+  @Nullable
+  private RealPerson nearestCleric(Village village, ServerLevel level) {
+    double range = HealthRecoveryPolicy.CLERIC_SEARCH_RANGE;
+    RealPerson nearest = null;
+    double nearestSqr = range * range;
+    for (Map.Entry<UUID, JobAssignment> entry : village.getJobAssignmentsView().entrySet()) {
+      if (entry.getValue().getOccupation() != Occupation.CLERIC) {
+        continue;
+      }
+      RealPerson candidate = village.getPerson(level, entry.getKey());
+      if (candidate == null || !isAvailable(candidate)) {
+        continue;
+      }
+      double distanceSqr = this.person.distanceToSqr(candidate);
+      if (distanceSqr <= nearestSqr) {
+        nearest = candidate;
+        nearestSqr = distanceSqr;
+      }
+    }
+    return nearest;
+  }
+
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/ThrowPotionAttackGoal.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/ThrowPotionAttackGoal.java
@@ -1,0 +1,115 @@
+package com.quzzar.kithkyn.entities.ai.goals;
+
+import java.util.EnumSet;
+
+import com.quzzar.kithkyn.entities.ClericPotions;
+import com.quzzar.kithkyn.entities.RealPerson;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * A cleric with harm to throw throws it at the village's enemies (Aaron,
+ * 2026-09-12: the swamp's witches are clerics, and a cleric's loadout decides
+ * whether they heal, hex, or both).
+ *
+ * <p>Only a cleric carrying a harmful splash potion with one to spare ever has
+ * a target here (the threat goal in {@code RealPerson.registerGoals} checks the
+ * same stock), and each throw consumes one bottle. The two safety rules are
+ * absolute: a harmful potion is never thrown while an ally stands inside the
+ * burst around the target, and never through a friend in the way. When either
+ * holds, the cleric closes in and waits for a clear throw rather than throwing
+ * badly. Out of harm, the goal ends and the target is dropped; the cleric's
+ * healing round takes over if anyone is hurt.
+ */
+public final class ThrowPotionAttackGoal extends Goal {
+
+  private static final double SPEED = 0.6D;
+  private static final float THROW_RANGE = 7.0F;
+  private static final int THROW_INTERVAL_TICKS = 40;
+  private static final int CHARGE_TICKS = 20;
+
+  private final RealPerson person;
+  private int cooldown;
+  private int charge;
+
+  public ThrowPotionAttackGoal(RealPerson person) {
+    this.person = person;
+    this.setFlags(EnumSet.of(Flag.MOVE, Flag.LOOK));
+  }
+
+  @Override
+  public boolean canUse() {
+    LivingEntity target = this.person.getTarget();
+    return target != null && target.isAlive() && ClericPotions.isCleric(this.person)
+        && !this.person.isSleeping() && !this.person.isEating()
+        && ClericPotions.hasThrowable(this.person, ClericPotions::isHarmful);
+  }
+
+  @Override
+  public boolean canContinueToUse() {
+    return canUse();
+  }
+
+  @Override
+  public boolean requiresUpdateEveryTick() {
+    return true;
+  }
+
+  @Override
+  public void start() {
+    this.cooldown = 0;
+    this.charge = 0;
+  }
+
+  @Override
+  public void stop() {
+    this.person.getNavigation().stop();
+    this.person.setPose(Pose.STANDING);
+    if (!ClericPotions.hasThrowable(this.person, ClericPotions::isHarmful)) {
+      this.person.setTarget(null); // nothing left to fight with
+    }
+  }
+
+  @Override
+  public void tick() {
+    LivingEntity target = this.person.getTarget();
+    if (target == null) {
+      return;
+    }
+    this.person.getLookControl().setLookAt(target, 30.0F, 30.0F);
+    double reach = THROW_RANGE * 0.75D;
+    boolean inReach = this.person.distanceToSqr(target) <= reach * reach;
+    boolean clear = this.person.getSensing().hasLineOfSight(target)
+        && !RangedShotSafety.blockedByFriendly(this.person, target)
+        && !ClericPotions.harmfulSplashWouldCatchAlly(this.person, target);
+    if (!inReach || !clear) {
+      this.charge = 0;
+      this.person.setPose(Pose.STANDING);
+      this.person.getNavigation().moveTo(target, SPEED);
+      return;
+    }
+    this.person.getNavigation().stop();
+    if (this.cooldown > 0) {
+      this.cooldown--;
+      return;
+    }
+    // Crouch to steady the throw, as the healing round does.
+    this.person.setPose(Pose.CROUCHING);
+    if (++this.charge < CHARGE_TICKS) {
+      return;
+    }
+    ItemStack harm = ClericPotions.throwable(this.person, ClericPotions::isHarmful);
+    if (harm != null) {
+      this.person.swing(InteractionHand.MAIN_HAND);
+      ClericPotions.throwOne(this.person, target, harm);
+    }
+    this.person.setPose(Pose.STANDING);
+    this.charge = 0;
+    this.cooldown = THROW_INTERVAL_TICKS;
+  }
+
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/BrewStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/BrewStep.java
@@ -1,0 +1,93 @@
+package com.quzzar.kithkyn.entities.ai.goals.work;
+
+import javax.annotation.Nullable;
+
+import com.quzzar.kithkyn.Kithkyn;
+import com.quzzar.kithkyn.entities.ClericPotions;
+import com.quzzar.kithkyn.entities.RealPerson;
+import com.quzzar.kithkyn.village.LocationManager;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * The cleric's other round: brewing more of what they carry.
+ *
+ * <p>A CONVERT act at the cleric's own station (Aaron, 2026-09-12). The stand
+ * needs nothing put in it: one potion the cleric already carries stands for the
+ * recipe, and a session as long as a brewing stand's yields three more of that
+ * brew into the pack. What the cleric can make is therefore exactly what they
+ * were handed: a healer given a splash of harming starts brewing harm. The
+ * brew furthest below {@link ClericPotions#STOCK_TARGET} is made first, and a
+ * pack with no room for a bottle waits.
+ */
+public final class BrewStep implements BlockWorkStep {
+
+  private int ticksBrewing;
+
+  @Override
+  @Nullable
+  public BlockPos select(RealPerson person) {
+    if (!ClericPotions.isCleric(person) || person.isSleeping() || person.getVillage() == null) {
+      return null;
+    }
+    BlockPos station = LocationManager.getJobLocation(person);
+    if (station.equals(BlockPos.ZERO) || ClericPotions.lowestBelowTarget(person) == null
+        || emptySlots(person) == 0) {
+      return null;
+    }
+    return station;
+  }
+
+  @Override
+  public void acquired(RealPerson person, BlockPos target) {
+    this.ticksBrewing = 0;
+  }
+
+  @Override
+  public boolean act(RealPerson person, BlockPos target) {
+    ClericPotions.Stock brew = ClericPotions.lowestBelowTarget(person);
+    if (brew == null) {
+      return false; // stocked meanwhile, or the seed was handed away
+    }
+    this.ticksBrewing += actEveryTicks();
+    if (this.ticksBrewing < ClericPotions.BREW_TICKS) {
+      return true;
+    }
+    int made = Math.min(ClericPotions.BREW_YIELD, emptySlots(person));
+    for (int index = 0; index < made; index++) {
+      person.personMainInv.addItem(brew.sample().copyWithCount(1));
+    }
+    Kithkyn.LOGGER.info("'{}' brewed {} more {} at their station", person.getFullName(), made,
+        brew.sample().getHoverName().getString().toLowerCase(java.util.Locale.ROOT));
+    this.ticksBrewing = 0;
+    return false;
+  }
+
+  @Override
+  public void released(RealPerson person, BlockPos target) {
+    this.ticksBrewing = 0;
+  }
+
+  @Override
+  public String describe() {
+    return "the brewing station";
+  }
+
+  @Override
+  public String activity() {
+    return "brewing potions";
+  }
+
+  /** Potions do not stack, so each bottle brewed needs a slot of its own. */
+  private static int emptySlots(RealPerson person) {
+    int empty = 0;
+    for (int slot = 0; slot < person.personMainInv.getContainerSize(); slot++) {
+      if (person.personMainInv.getItem(slot).isEmpty()) {
+        empty++;
+      }
+    }
+    return empty;
+  }
+
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/HealStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/HealStep.java
@@ -4,25 +4,17 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import com.quzzar.kithkyn.entities.ClericPotions;
 import com.quzzar.kithkyn.entities.Person;
 import com.quzzar.kithkyn.entities.RealPerson;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
-import net.minecraft.core.component.DataComponents;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.entity.projectile.ThrownPotion;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
-import net.minecraft.world.item.alchemy.Potion;
-import net.minecraft.world.item.alchemy.PotionContents;
-import net.minecraft.world.item.alchemy.Potions;
-import net.minecraft.world.phys.Vec3;
 
 /**
  * The cleric's round: an APPLY step whose target is a person rather than a
@@ -35,7 +27,10 @@ import net.minecraft.world.phys.Vec3;
  * Reach here is throwing distance, not arm's length: the cleric closes to
  * within three quarters of their range, crouches to steady the throw, waits out
  * a charge that is longer the further away the patient is, and lobs a splash
- * potion - healing if the patient is nearly dead, regeneration otherwise.
+ * potion from their own stock ({@link ClericPotions}): healing if the patient
+ * is nearly dead, regeneration otherwise, whichever they carry. Each throw
+ * consumes a bottle, and the last of a brew is never thrown, so a cleric with
+ * only their seed potions left has nobody to tend until they brew more.
  */
 public final class HealStep implements WorkStep<LivingEntity> {
 
@@ -63,7 +58,8 @@ public final class HealStep implements WorkStep<LivingEntity> {
     List<LivingEntity> nearby = person.level().getEntitiesOfClass(LivingEntity.class,
         person.getBoundingBox().inflate(SEARCH_RANGE, 3.0D, SEARCH_RANGE));
     for (LivingEntity candidate : nearby) {
-      if (candidate != null && !candidate.hasEffect(MobEffects.REGENERATION) && needsTending(person, candidate)) {
+      if (candidate != null && !candidate.hasEffect(MobEffects.REGENERATION) && needsTending(person, candidate)
+          && brewFor(person, candidate) != null) {
         return candidate;
       }
     }
@@ -79,6 +75,10 @@ public final class HealStep implements WorkStep<LivingEntity> {
   public boolean act(RealPerson person, LivingEntity target) {
     if (!needsTending(person, target)) {
       return false; // mended, or dead, or somebody else got there
+    }
+    ItemStack brew = brewFor(person, target);
+    if (brew == null) {
+      return false; // the stock ran out while walking over
     }
     // A potion thrown at a wall helps nobody. Hold the charge and close up.
     if (!person.getSensing().hasLineOfSight(target)) {
@@ -97,7 +97,7 @@ public final class HealStep implements WorkStep<LivingEntity> {
     if (this.chargeLeft-- > 0) {
       return true;
     }
-    throwPotion(person, target);
+    ClericPotions.throwOne(person, target, brew);
     this.charging = false;
     person.setPose(Pose.STANDING);
     return false;
@@ -144,25 +144,10 @@ public final class HealStep implements WorkStep<LivingEntity> {
     return candidate instanceof Player player && !player.getAbilities().instabuild;
   }
 
-  private void throwPotion(RealPerson healer, LivingEntity target) {
-    Vec3 drift = target.getDeltaMovement();
-    double dx = target.getX() + drift.x - healer.getX();
-    double dy = target.getEyeY() - 1.1F - healer.getY();
-    double dz = target.getZ() + drift.z - healer.getZ();
-    float flat = Mth.sqrt((float) (dx * dx + dz * dz));
-
-    Holder<Potion> potion = target.getHealth() <= 4.0F ? Potions.HEALING : Potions.REGENERATION;
-    ItemStack bottle = new ItemStack(Items.SPLASH_POTION);
-    bottle.set(DataComponents.POTION_CONTENTS, new PotionContents(potion));
-
-    ThrownPotion thrown = new ThrownPotion(healer.level(), healer);
-    thrown.setItem(bottle);
-    thrown.setXRot(-20.0F);
-    thrown.shoot(dx, dy + flat * 0.2F, dz, 0.75F, 8.0F);
-    healer.level().playSound((Player) null, healer.getX(), healer.getY(), healer.getZ(),
-        SoundEvents.SPLASH_POTION_THROW, healer.getSoundSource(), 1.0F,
-        0.8F + healer.getRandom().nextFloat() * 0.4F);
-    healer.level().addFreshEntity(thrown);
+  /** The bottle this cleric would throw over this patient, or null when they can spare none that helps. */
+  @Nullable
+  private static ItemStack brewFor(RealPerson person, LivingEntity patient) {
+    return ClericPotions.throwable(person, ClericPotions.healingPreference(patient));
   }
 
 }

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/BuildingDefinitionLoader.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/BuildingDefinitionLoader.java
@@ -60,6 +60,12 @@ public class BuildingDefinitionLoader extends SimpleJsonResourceReloadListener {
                         Kithkyn.LOGGER.error("Rejected building definition {} ({})", id, problem);
                         return;
                     }
+                    // A warning, not a rejection: the building still stands and
+                    // staffs its post, but the planner cannot see what the post
+                    // gives, so the author is told (StationGrants).
+                    for (String missing : StationGrants.missing(info)) {
+                        Kithkyn.LOGGER.warn("Building definition {}: {}", id, missing);
+                    }
                     ResourceLocation recipeId = BuildingRecipe.idFor(info);
                     BuildingRecipe recipe;
                     if (json.getAsJsonObject().has("cost")) {

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/StationGrants.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/StationGrants.java
@@ -1,0 +1,67 @@
+package com.quzzar.kithkyn.village.buildings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.quzzar.kithkyn.village.Occupation;
+
+/**
+ * The capability a work station stands for, so a definition cannot add the
+ * post without telling the planner what the post gives (Aaron, 2026-09-12: a
+ * building with a cleric station obviously grants HEALING; a building with a
+ * blacksmith and a cleric grants both).
+ *
+ * <p>Only the trades with one unmistakable grant are listed. A guard post is
+ * not: the watchtower's guards grant PROTECTION while the center's captain and
+ * a castle's sentries do not, and that is a planning decision the definitions
+ * make on purpose. The builder and the leader grant nothing.
+ */
+public final class StationGrants {
+
+  private static final Map<Occupation, String> CANONICAL = Map.ofEntries(
+      Map.entry(Occupation.CLERIC, "HEALING"),
+      Map.entry(Occupation.BLACKSMITH, "REPAIR"),
+      Map.entry(Occupation.FARMER, "GRAIN"),
+      Map.entry(Occupation.BAKER, "BREAD"),
+      Map.entry(Occupation.BUTCHER, "MEAT"),
+      Map.entry(Occupation.HERDER, "MEAT"),
+      Map.entry(Occupation.HUNTER, "MEAT"),
+      Map.entry(Occupation.FISHER, "MEAT"),
+      Map.entry(Occupation.LUMBERJACK, "LOGS"),
+      Map.entry(Occupation.MASON, "CUT_STONE"),
+      Map.entry(Occupation.MERCHANT, "TRADE"),
+      Map.entry(Occupation.MINER, "ORES"),
+      Map.entry(Occupation.QUARTERMASTER, "STORAGE"),
+      Map.entry(Occupation.INNKEEPER, "WANDERERS"));
+
+  private StationGrants() {
+  }
+
+  /** The grant a station of this trade must come with, or null for a trade that grants nothing by itself. */
+  public static String canonical(Occupation occupation) {
+    return CANONICAL.get(occupation);
+  }
+
+  /**
+   * Every station whose canonical grant the definition lacks, as
+   * "OCCUPATION needs GRANT" lines. Conditional grants count: an inn whose
+   * WANDERERS waits on ale has still declared it.
+   */
+  public static List<String> missing(BuildingInfo info) {
+    List<String> problems = new ArrayList<>();
+    for (Occupation occupation : info.getWorkLocations().values().stream().distinct().toList()) {
+      String grant = canonical(occupation);
+      if (grant == null) {
+        continue;
+      }
+      boolean declared = info.getGrants().contains(grant)
+          || info.getConditionalGrants().stream().anyMatch(conditional -> conditional.capability().equals(grant));
+      if (!declared) {
+        problems.add(occupation + " station needs the " + grant + " grant");
+      }
+    }
+    return problems;
+  }
+
+}

--- a/src/test/java/com/quzzar/kithkyn/entities/ClericPotionsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ClericPotionsTest.java
@@ -100,6 +100,24 @@ class ClericPotionsTest {
   }
 
   @Test
+  void theBriefingCountsSpareBottlesInThePackAndNeverTheSeed() {
+    SimpleContainer pack = new SimpleContainer(9);
+    ItemStack hand = splash(Potions.REGENERATION);
+    pack.setItem(0, splash(Potions.HARMING));
+
+    // The only harm is the seed: nothing to tell. The hand's regeneration is not in the pack.
+    assertEquals(0, ClericPotions.sparePackCount(hand, ItemStack.EMPTY, pack, splash(Potions.HARMING)));
+    assertEquals(0, ClericPotions.sparePackCount(hand, ItemStack.EMPTY, pack, splash(Potions.REGENERATION)));
+
+    // Two more harm: two spare. One regeneration in the pack beside the hand's: one spare.
+    pack.setItem(1, splash(Potions.HARMING));
+    pack.setItem(2, splash(Potions.HARMING));
+    pack.setItem(3, splash(Potions.REGENERATION));
+    assertEquals(2, ClericPotions.sparePackCount(hand, ItemStack.EMPTY, pack, splash(Potions.HARMING)));
+    assertEquals(1, ClericPotions.sparePackCount(hand, ItemStack.EMPTY, pack, splash(Potions.REGENERATION)));
+  }
+
+  @Test
   void brewingRestocksTheEmptiestBrewFirstAndStopsAtTheTarget() {
     SimpleContainer pack = new SimpleContainer(9);
     ItemStack hand = splash(Potions.REGENERATION);

--- a/src/test/java/com/quzzar/kithkyn/entities/ClericPotionsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ClericPotionsTest.java
@@ -1,0 +1,122 @@
+package com.quzzar.kithkyn.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.Potion;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.item.alchemy.Potions;
+
+class ClericPotionsTest {
+
+  private static ItemStack splash(Holder<Potion> potion) {
+    ItemStack stack = new ItemStack(Items.SPLASH_POTION);
+    stack.set(DataComponents.POTION_CONTENTS, new PotionContents(potion));
+    return stack;
+  }
+
+  @Test
+  void onlySplashAndLingeringPotionsWithEffectsAreThrowable() {
+    assertTrue(ClericPotions.isThrowable(splash(Potions.HEALING)));
+    ItemStack lingering = new ItemStack(Items.LINGERING_POTION);
+    lingering.set(DataComponents.POTION_CONTENTS, new PotionContents(Potions.REGENERATION));
+    assertTrue(ClericPotions.isThrowable(lingering));
+    ItemStack drinkable = new ItemStack(Items.POTION);
+    drinkable.set(DataComponents.POTION_CONTENTS, new PotionContents(Potions.HEALING));
+    assertFalse(ClericPotions.isThrowable(drinkable));
+    assertFalse(ClericPotions.isThrowable(splash(Potions.WATER)));
+    assertFalse(ClericPotions.isThrowable(new ItemStack(Items.SPLASH_POTION)));
+    assertFalse(ClericPotions.isThrowable(ItemStack.EMPTY));
+  }
+
+  @Test
+  void harmIsNeverBeneficialAndHealingIsNeverHarmful() {
+    assertTrue(ClericPotions.isHarmful(splash(Potions.HARMING)));
+    assertFalse(ClericPotions.isBeneficial(splash(Potions.HARMING)));
+    assertTrue(ClericPotions.isBeneficial(splash(Potions.HEALING)));
+    assertFalse(ClericPotions.isHarmful(splash(Potions.HEALING)));
+    assertTrue(ClericPotions.isHarmful(splash(Potions.POISON)));
+    assertTrue(ClericPotions.isBeneficial(splash(Potions.REGENERATION)));
+  }
+
+  @Test
+  void brewsAreTalliedByPotionNotByItem() {
+    SimpleContainer pack = new SimpleContainer(9);
+    pack.setItem(0, splash(Potions.HEALING));
+    pack.setItem(3, splash(Potions.HARMING));
+    pack.setItem(5, splash(Potions.HEALING));
+    List<ClericPotions.Stock> stock = ClericPotions.stock(splash(Potions.REGENERATION), ItemStack.EMPTY, pack);
+
+    assertEquals(3, stock.size());
+    assertEquals(2, ClericPotions.carried(splash(Potions.REGENERATION), ItemStack.EMPTY, pack, splash(Potions.HEALING)));
+    assertEquals(1, ClericPotions.carried(splash(Potions.REGENERATION), ItemStack.EMPTY, pack, splash(Potions.HARMING)));
+    assertEquals(0, ClericPotions.carried(splash(Potions.REGENERATION), ItemStack.EMPTY, pack, splash(Potions.POISON)));
+  }
+
+  @Test
+  void theLastPotionOfABrewIsNeverThrown() {
+    SimpleContainer pack = new SimpleContainer(9);
+    ItemStack hand = splash(Potions.REGENERATION);
+    pack.setItem(0, splash(Potions.HARMING));
+
+    // One of each: nothing to spare, of either kind.
+    assertNull(ClericPotions.throwable(hand, ItemStack.EMPTY, pack, ClericPotions::isBeneficial));
+    assertNull(ClericPotions.throwable(hand, ItemStack.EMPTY, pack, ClericPotions::isHarmful));
+
+    // A second regeneration makes the hand's bottle throwable; harm still is not.
+    pack.setItem(1, splash(Potions.REGENERATION));
+    assertSame(hand, ClericPotions.throwable(hand, ItemStack.EMPTY, pack, ClericPotions::isBeneficial));
+    assertNull(ClericPotions.throwable(hand, ItemStack.EMPTY, pack, ClericPotions::isHarmful));
+  }
+
+  @Test
+  void aClericMayGiveEverythingButTheSeed() {
+    SimpleContainer pack = new SimpleContainer(9);
+    ItemStack hand = splash(Potions.REGENERATION);
+    ItemStack spare = splash(Potions.REGENERATION);
+    pack.setItem(0, spare);
+    ItemStack bread = new ItemStack(Items.BREAD, 5);
+    pack.setItem(1, bread);
+
+    assertEquals(1, ClericPotions.giveable(hand, ItemStack.EMPTY, pack, spare));
+    assertEquals(1, ClericPotions.giveable(hand, ItemStack.EMPTY, pack, hand));
+    assertEquals(5, ClericPotions.giveable(hand, ItemStack.EMPTY, pack, bread));
+
+    pack.setItem(0, ItemStack.EMPTY);
+    assertEquals(0, ClericPotions.giveable(hand, ItemStack.EMPTY, pack, hand));
+  }
+
+  @Test
+  void brewingRestocksTheEmptiestBrewFirstAndStopsAtTheTarget() {
+    SimpleContainer pack = new SimpleContainer(9);
+    ItemStack hand = splash(Potions.REGENERATION);
+    pack.setItem(0, splash(Potions.HEALING));
+    pack.setItem(1, splash(Potions.REGENERATION));
+
+    ClericPotions.Stock lowest = ClericPotions.lowestBelowTarget(hand, ItemStack.EMPTY, pack);
+    assertNotNull(lowest);
+    assertTrue(ClericPotions.sameBrew(lowest.sample(), splash(Potions.HEALING)));
+    assertEquals(1, lowest.count());
+
+    for (int slot = 2; slot < 2 + ClericPotions.STOCK_TARGET; slot++) {
+      pack.setItem(slot, splash(Potions.HEALING));
+    }
+    for (int slot = 6; slot < 6 + ClericPotions.STOCK_TARGET - 2; slot++) {
+      pack.setItem(slot, splash(Potions.REGENERATION));
+    }
+    assertNull(ClericPotions.lowestBelowTarget(hand, ItemStack.EMPTY, pack));
+  }
+}

--- a/src/test/java/com/quzzar/kithkyn/entities/ai/HealthRecoveryPolicyTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ai/HealthRecoveryPolicyTest.java
@@ -28,6 +28,21 @@ class HealthRecoveryPolicyTest {
   }
 
   @Test
+  void theClericIsSoughtByDayWhileHurtAndNotYetRegenerating() {
+    assertTrue(HealthRecoveryPolicy.shouldSeekCleric(5.0F, 18.0F, false, false));
+    assertFalse(HealthRecoveryPolicy.shouldSeekCleric(5.0F, 18.0F, true, false));
+    assertFalse(HealthRecoveryPolicy.shouldSeekCleric(5.0F, 18.0F, false, true));
+    assertFalse(HealthRecoveryPolicy.shouldSeekCleric(7.0F, 18.0F, false, false));
+    assertEquals(48.0D, HealthRecoveryPolicy.CLERIC_SEARCH_RANGE);
+  }
+
+  @Test
+  void aRecoveryEndsALittleAboveTheLineItStartedAt() {
+    assertFalse(HealthRecoveryPolicy.isBackOverTheLine(7.9F, 18.0F));
+    assertTrue(HealthRecoveryPolicy.isBackOverTheLine(8.0F, 18.0F));
+  }
+
+  @Test
   void foodAlwaysWinsOverCampfireRecovery() {
     assertFalse(HealthRecoveryPolicy.shouldSeekCampfire(5.0F, 18.0F, true, 1_200L, 1_200L));
     assertTrue(HealthRecoveryPolicy.shouldSeekCampfire(5.0F, 18.0F, false, 1_200L, 1_200L));

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/StationGrantsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/StationGrantsTest.java
@@ -1,0 +1,82 @@
+package com.quzzar.kithkyn.village.buildings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.mojang.serialization.JsonOps;
+
+import net.minecraft.resources.ResourceLocation;
+
+class StationGrantsTest {
+
+  private static BuildingInfo parse(String json) {
+    return BuildingInfo.CODEC.parse(JsonOps.INSTANCE, JsonParser.parseString(json)).getOrThrow();
+  }
+
+  @Test
+  void aClericStationWithoutHealingIsReported() {
+    BuildingInfo info = parse("{\"structure\":\"shrine\",\"work_stations\":[{\"pos\":[1,1,1],\"occupation\":\"CLERIC\"}]}");
+    assertEquals(List.of("CLERIC station needs the HEALING grant"), StationGrants.missing(info));
+  }
+
+  @Test
+  void everyStationInAMixedBuildingNeedsItsOwnGrant() {
+    BuildingInfo both = parse("{\"structure\":\"chapel_forge\",\"work_stations\":["
+        + "{\"pos\":[1,1,1],\"occupation\":\"CLERIC\"},{\"pos\":[2,1,1],\"occupation\":\"BLACKSMITH\"}],"
+        + "\"grants\":[\"HEALING\"]}");
+    assertEquals(List.of("BLACKSMITH station needs the REPAIR grant"), StationGrants.missing(both));
+    BuildingInfo complete = parse("{\"structure\":\"chapel_forge\",\"work_stations\":["
+        + "{\"pos\":[1,1,1],\"occupation\":\"CLERIC\"},{\"pos\":[2,1,1],\"occupation\":\"BLACKSMITH\"}],"
+        + "\"grants\":[\"HEALING\",\"REPAIR\"]}");
+    assertTrue(StationGrants.missing(complete).isEmpty());
+  }
+
+  @Test
+  void aConditionalGrantCountsAndTradesWithoutACanonicalGrantAreLeftAlone() {
+    BuildingInfo inn = parse("{\"structure\":\"inn\",\"work_stations\":[{\"pos\":[1,1,1],\"occupation\":\"INNKEEPER\"}],"
+        + "\"grants_if\":[{\"capability\":\"WANDERERS\",\"requires_supply\":[\"minecraft:bread\"]}]}");
+    assertTrue(StationGrants.missing(inn).isEmpty());
+    BuildingInfo center = parse("{\"structure\":\"camp\",\"work_stations\":["
+        + "{\"pos\":[1,1,1],\"occupation\":\"BUILDER\"},{\"pos\":[2,1,1],\"occupation\":\"GUARD\"}]}");
+    assertTrue(StationGrants.missing(center).isEmpty());
+  }
+
+  @Test
+  void everyBundledDefinitionGrantsWhatItsStationsStandFor() throws Exception {
+    Map<String, BuildingInfo> loaded = BuildingDefinitionLoader.resolve(
+        resources("kithkyn/buildings"), resources(BuildingRecipe.DIRECTORY));
+    assertFalse(loaded.isEmpty());
+    Map<String, List<String>> problems = new HashMap<>();
+    for (BuildingInfo info : loaded.values()) {
+      List<String> missing = StationGrants.missing(info);
+      if (!missing.isEmpty()) {
+        problems.put(info.getName(), missing);
+      }
+    }
+    assertTrue(problems.isEmpty(), problems.toString());
+  }
+
+  private static Map<ResourceLocation, JsonElement> resources(String directory) throws Exception {
+    Path root = Path.of(Objects.requireNonNull(StationGrantsTest.class.getResource("/data/kithkyn/" + directory)).toURI());
+    Map<ResourceLocation, JsonElement> out = new HashMap<>();
+    try (var files = Files.list(root)) {
+      for (Path file : files.filter(path -> path.toString().endsWith(".json")).toList()) {
+        out.put(ResourceLocation.fromNamespaceAndPath("kithkyn", file.getFileName().toString().replace(".json", "")),
+            JsonParser.parseString(Files.readString(file)));
+      }
+    }
+    return out;
+  }
+}


### PR DESCRIPTION
Closes #136.

## What changes

**Potions are stock.** `ClericPotions` tallies the splash and lingering potions a cleric carries by brew (item plus potion contents). Every throw consumes one bottle; nothing is conjured any more. The last bottle of a brew is the seed and is never thrown or given away in conversation (`PersonChatDispatcher.takeFromSlots` gets its one exception).

**Healing draws from stock.** `HealStep` picks a splash of healing when the patient is nearly dead, regeneration otherwise, whichever the cleric can spare, and finds nobody to tend when it can spare neither.

**Harm is a loadout.** `ThrowPotionAttackGoal` plus a threat goal on the cleric: a cleric carrying a harmful splash with one to spare acquires hostile mobs and throws at them, never while an ally is inside the four-block burst or in the shot corridor. A cleric carrying only healing never acquires a target. Harm is registered ahead of healing at the same priority.

**Brewing at the station.** `BrewStep` turns one carried bottle into three more of the same brew in a twenty-second session at the cleric's station, brew furthest below four first. Nothing goes into the stand.

**Loadouts are issued.** The starting kit is a splash of regeneration and a splash of healing (`SignatureGear`, the off-hand potion changes from drinkable to splash). At bedtime potions are kept in the pack, and one bottle of any new splash brew found in the village stores is lifted as a seed.

**Hurt villagers seek the cleric.** `SeekClericGoal` at priority 1, registered ahead of fetching food: a badly hurt villager with an awake cleric within 48 blocks walks to within 5 and waits, eating on the way. Ends when back over the line, regenerating, at night, when the cleric sleeps or leaves, or after a minute of waiting.

**A station declares its grant.** `StationGrants` maps trades to their canonical grant; the loader warns on a missing one (private datapacks stay loadable) and `StationGrantsTest` holds the bundled catalog to zero.

## Verification

- `./gradlew test`: 118 suites, 540 tests, 0 failures. New: `ClericPotionsTest` (6), `StationGrantsTest` (4), two cases in `HealthRecoveryPolicyTest`.
- Not verified in a live world. No church exists in the dev world and no cleric has ever been hired there; a `dev/ClericVerification` harness is listed as the first follow-up in #136.

## Docs

`docs/worker-loops.md` gains "Seeking the cleric" and "The cleric's potions are stock"; `docs/building-spec.md` gains the station-declares-its-grant rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)