### PR TITLE
Stop the woodland pass crashing the server; guard overlapping foundings; grant-check fixes

### DIFF
--- a/docs/building-spec.md
+++ b/docs/building-spec.md
@@ -552,7 +552,9 @@ buildings will do what"). The table lives in `StationGrants`. The loader warns a
 station whose grant is missing rather than rejecting the building, so a private datapack still
 loads and its author sees the gap in the log; a test holds the bundled catalog to zero
 warnings. Guard, builder and leader stations are exempt: the watchtower's guards grant
-`PROTECTION` while the centre's captain does not, and that is a planning choice.
+`PROTECTION` while the centre's captain does not, and that is a planning choice. So is a
+station with a `worksite_category`: the centre's quartermaster and miner posts work at the
+storehouse and the mine, and those definitions carry `STORAGE` and `ORES`.
 
 Capability resolution is a fixed point: grant everything unconditional, then re-evaluate
 `grants_if` until nothing new appears. Two buildings that each require the other's capability

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -958,6 +958,18 @@ seconds; the guard's roll was one in twenty until 2026-09-01, which left a fresh
 quarter of an hour per tree for the lodge it could not yet afford); combat goals outrank the
 guard's chopping.
 
+**Bounded, 2026-09-12: a woodland pass asks the navigator about a handful of trees, not all of
+them (#138).** The lumberjack's village-wide pass covers the whole claim plus a margin, which from
+the lodge reaches up to ninety blocks, while one path search never goes further than about
+forty-eight. Every tree past that was asked about anyway, up to four searches a tree, and each
+failed search spends its whole node budget first. On the live server one lumberjack ran 2,325 such
+searches in six minutes and reached 19 trees; the scans held the server at five ticks a second,
+and one held a tick past the sixty-second watchdog and took the server down. A pass now considers
+only trees within one search's reach of where the worker stands, asks about them nearest first,
+spends at most six searches in total, and leaves a tree it found no way to out of that worker's
+scans for two minutes. The nearest reachable tree is taken rather than a random one. Trimming a
+way into a hemmed-in stand shares the same six-search budget.
+
 **Attached bee nests (2026-09-08).** Shared tree felling also removes unowned bee nests
 and beehives touching a log actually removed, once each. It releases occupants normally;
 Silk Touch preserves bees in the native hive drop instead. Player/village-owned hives,

--- a/src/main/java/com/quzzar/kithkyn/dev/FoundingProbe.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/FoundingProbe.java
@@ -1,0 +1,136 @@
+package com.quzzar.kithkyn.dev;
+
+import com.quzzar.kithkyn.Kithkyn;
+import com.quzzar.kithkyn.entities.Kind;
+import com.quzzar.kithkyn.village.Village;
+import com.quzzar.kithkyn.village.VillageManager;
+import com.quzzar.kithkyn.village.buildings.VillageStyle;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+
+/**
+ * Founds one village at a given spot on whatever world the server was started
+ * with, and samples the server thread every two seconds until it stands
+ * (#138: a manual founding near Sorevia held one tick for over a minute).
+ *
+ * <p>{@code -Dkithkyn.foundingProbe=x,y,z,style[;x,y,z,style...]}: each site is
+ * founded once the one before it stands, which is how the live hang was made
+ * (a second founding nine blocks from a fresh one). Every server tick longer
+ * than a second is logged with its length. Runs on a copy of the live world,
+ * never the live server: it halts the server when the last village stands or
+ * after ten minutes, and logs {@code [founding-probe] RESULT}.
+ */
+@EventBusSubscriber(modid = Kithkyn.MODID)
+public final class FoundingProbe {
+
+  private static final String PREFIX = "[founding-probe]";
+  private static final int SETTLE_TICKS = 100;
+  private static final long GIVE_UP_NANOS = 10L * 60L * 1_000_000_000L;
+
+  private static int ticks;
+  private static boolean started;
+  private static boolean done;
+  private static long startedAt;
+  private static long tickStartedAt;
+  private static java.util.List<String> sites;
+  private static int next;
+  private static BlockPos site;
+  private static Thread sampler;
+
+  private FoundingProbe() { }
+
+  @SubscribeEvent
+  public static void tickStart(ServerTickEvent.Pre event) {
+    tickStartedAt = System.nanoTime();
+  }
+
+  @SubscribeEvent
+  public static void tick(ServerTickEvent.Post event) {
+    String spec = System.getProperty("kithkyn.foundingProbe");
+    if (spec == null || done) return;
+    long tickMillis = (System.nanoTime() - tickStartedAt) / 1_000_000L;
+    if (started && tickMillis > 1_000L) {
+      Kithkyn.LOGGER.info("{} LONG TICK: {} ms", PREFIX, tickMillis);
+    }
+    if (++ticks < SETTLE_TICKS) return;
+    ServerLevel level = event.getServer().overworld();
+    if (!started) {
+      started = true;
+      sites = java.util.List.of(spec.split(";"));
+      Thread server = Thread.currentThread();
+      sampler = new Thread(() -> sample(server), "founding-probe-sampler");
+      sampler.setDaemon(true);
+      sampler.start();
+      request(event, level);
+      return;
+    }
+    long elapsed = System.nanoTime() - startedAt;
+    int standing = 0;
+    for (Village village : VillageManager.get(level).getVillages().values()) {
+      if (village.getTownCenter() != null && village.getCenterPosition().closerThan(site, 64.0D)
+          && village.getBuildings().size() >= 7) {
+        standing++;
+      }
+    }
+    // Every earlier site in this run sits within 64 blocks too, so count them.
+    if (standing >= next) {
+      Kithkyn.LOGGER.info("{} site {} of {} stands, {} s after its request", PREFIX, next, sites.size(),
+          String.format("%.1f", elapsed / 1e9));
+      if (next >= sites.size()) {
+        finish(event, "RESULT PASS: every site founded");
+        return;
+      }
+      request(event, level);
+      return;
+    }
+    if (elapsed > GIVE_UP_NANOS) finish(event, "RESULT FAIL: site " + (next) + " not founded within ten minutes");
+  }
+
+  private static void request(ServerTickEvent.Post event, ServerLevel level) {
+    String[] parts = sites.get(next).split(",");
+    next++;
+    site = new BlockPos(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]));
+    VillageStyle style = parts.length > 3 ? VillageStyle.parse(parts[3]) : null;
+    startedAt = System.nanoTime();
+    Kithkyn.LOGGER.info("{} requesting founding {} at {} in the {} style", PREFIX, next, site.toShortString(),
+        style == null ? "biome" : style.id());
+    boolean accepted = VillageManager.get(level).registerVillage(level, site, style, Kind.LIVING, false);
+    Kithkyn.LOGGER.info("{} request {}", PREFIX, accepted ? "accepted; waiting for the name" : "REFUSED");
+    if (!accepted) finish(event, "RESULT FAIL: founding " + next + " refused");
+  }
+
+  private static void finish(ServerTickEvent.Post event, String result) {
+    done = true;
+    Kithkyn.LOGGER.info("{} {}", PREFIX, result);
+    event.getServer().halt(false);
+  }
+
+  /** Every two seconds, the server thread's innermost frames, so a long tick shows where it is. */
+  private static void sample(Thread server) {
+    long lastTickSeen = -1;
+    while (!done) {
+      try {
+        Thread.sleep(2_000L);
+      } catch (InterruptedException interrupted) {
+        return;
+      }
+      StackTraceElement[] stack = server.getStackTrace();
+      StringBuilder out = new StringBuilder();
+      int shown = 0;
+      for (StackTraceElement frame : stack) {
+        if (shown >= 14) break;
+        String cls = frame.getClassName();
+        if (!cls.startsWith("com.quzzar") && !cls.startsWith("net.minecraft") && shown > 0) continue;
+        out.append("\n    ").append(cls.substring(cls.lastIndexOf('.') + 1)).append('.')
+            .append(frame.getMethodName()).append(':').append(frame.getLineNumber());
+        shown++;
+      }
+      Kithkyn.LOGGER.info("{} sample{}", PREFIX, out);
+    }
+  }
+
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
@@ -1716,7 +1716,10 @@ public class RealPerson extends Person {
     }
     int taken = 0;
     for (int slot = 0; slot < container.getContainerSize() && taken < want.getCount(); slot++) {
-      if (container.getItem(slot).is(want.getItem())) {
+      // The same match the stores make (Utils.removeItem): a cleric asking for
+      // a splash of regeneration must not be handed the splash of harming
+      // beside it in their own chest.
+      if (ItemStack.isSameItemSameComponents(container.getItem(slot), want)) {
         taken += container.removeItem(slot, want.getCount() - taken).getCount();
       }
     }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
@@ -108,6 +108,17 @@ public final class PersonPathNavigation extends GroundPathNavigation {
     super(mob, level);
   }
 
+  /**
+   * How far from where a person stands one ordinary path search can take them.
+   * The search never expands a node further than this from its start, so a
+   * target beyond it is only ever answered with a partial path, and asking costs
+   * the whole node budget first. Callers choosing among many targets use this to
+   * leave out the ones no single search can reach (#138).
+   */
+  public static float searchRange(Mob mob) {
+    return Math.max(MINIMUM_SEARCH_RANGE, (float)mob.getAttributeValue(Attributes.FOLLOW_RANGE));
+  }
+
   @Override
   protected PathFinder createPathFinder(int maxVisitedNodes) {
     PersonNodeEvaluator evaluator = new PersonNodeEvaluator();
@@ -124,8 +135,7 @@ public final class PersonPathNavigation extends GroundPathNavigation {
   @Override
   @Nullable
   protected Path createPath(Set<BlockPos> targets, int regionOffset, boolean offsetUpward, int accuracy) {
-    float perceptionRange = (float)this.mob.getAttributeValue(Attributes.FOLLOW_RANGE);
-    float range = Math.max(MINIMUM_SEARCH_RANGE, perceptionRange);
+    float range = searchRange(this.mob);
     Path route = super.createPath(targets, regionOffset, offsetUpward, accuracy, range);
     // Reaching a watch platform can take more than 48 blocks of walking even
     // when it is nearby in a straight line. Retry exact work destinations with

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/ChopStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/ChopStep.java
@@ -10,13 +10,14 @@ import com.quzzar.kithkyn.Kithkyn;
 import com.quzzar.kithkyn.entities.RealPerson;
 import com.quzzar.kithkyn.entities.GuardWeapons;
 import com.quzzar.kithkyn.entities.JobTool;
+import com.quzzar.kithkyn.entities.ai.PersonPathNavigation;
 import com.quzzar.kithkyn.entities.ai.goals.ShortageWatch;
 import com.quzzar.kithkyn.village.LocationManager;
 import com.quzzar.kithkyn.village.TreeFelling;
 import com.quzzar.kithkyn.village.Village;
 
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.BlockTags;
@@ -101,6 +102,29 @@ public final class ChopStep implements WorkStep<ChopStep.Cut> {
   /** Paths the navigator is asked for per tree before it is called unreachable. */
   private static final int PATHS_PER_TREE = 4;
 
+  /**
+   * Paths one pass may ask the navigator for, across every tree or leaf it
+   * considers. A search that fails spends its whole node budget first, tens of
+   * milliseconds to over a second each, and the woodland pass once asked for up
+   * to four per tree across sixty-odd trees: on 2026-09-12 one scan held the
+   * live server's tick past the sixty-second watchdog, and scans like it kept
+   * the server at five ticks a second (#138).
+   */
+  private static final int PATHS_PER_PASS = 6;
+
+  /**
+   * How long a tree the worker could not walk to stays out of their woodland
+   * scans. Without it the same unreachable trunks were asked about on every
+   * scan, every few seconds, for as long as they stood.
+   */
+  private static final int UNREACHABLE_TREE_TICKS = 20 * 60 * 2;
+
+  /**
+   * Slack taken off the navigator's search range: a route winds, so a trunk
+   * this close to the edge of the range is out of reach in practice too.
+   */
+  private static final int PATH_RANGE_SLACK = 4;
+
   /** How far out and up from a hemmed-in trunk to look for a leaf blocking the way in. */
   private static final int LEAF_CLEAR_RADIUS = 3;
 
@@ -122,6 +146,9 @@ public final class ChopStep implements WorkStep<ChopStep.Cut> {
   private final boolean villageWide;
 
   private final ShortageWatch dry = new ShortageWatch();
+
+  /** Tree bases this worker found no way to, and the game time each is tried again. */
+  private final Long2LongOpenHashMap unreachableUntil = new Long2LongOpenHashMap();
 
   private BlockPos chopping;
   private int chopTime;
@@ -382,57 +409,125 @@ public final class ChopStep implements WorkStep<ChopStep.Cut> {
   }
 
   /**
-   * Reservoir-samples a fellable tree with a natural canopy that the worker
-   * can walk up to, and returns its base and the spot to cut it from. Each
-   * tree is flood-filled once per scan and every log on it mapped to the base,
-   * and each base is asked for its standing spot once, because every log of a
-   * tree in the box asks.
+   * The nearest fellable tree with a natural canopy that the worker can walk
+   * up to, and the spot to cut it from; null when none is found this pass.
+   *
+   * <p>Only trees one path search can reach from where the worker stands are
+   * considered ({@link PersonPathNavigation#searchRange}): the village-wide
+   * box reaches up to ninety blocks from a lumberjack at the lodge, and every
+   * search to a trunk past the range was answered with a partial path after
+   * spending its whole node budget. The far corners are reached as the worker
+   * works their way out, which is how they were reached before, since no search
+   * could ever have picked them. The rest are asked about nearest first, at most
+   * {@link #PATHS_PER_PASS} searches a pass, and a tree with no way to it is left
+   * out of this worker's scans for {@link #UNREACHABLE_TREE_TICKS} (#138).
    */
   @Nullable
   private Cut findWoodlandTree(RealPerson person, ServerLevel level, BlockPos around, int radius) {
+    long now = level.getGameTime();
+    this.unreachableUntil.long2LongEntrySet().removeIf(entry -> entry.getLongValue() <= now);
+    BlockPos worker = person.blockPosition();
+    int reach = Math.max(0, (int) PersonPathNavigation.searchRange(person) - PATH_RANGE_SLACK);
+    ScanBounds bounds = ScanBounds.within(around, radius, worker, reach);
+    if (bounds == null) {
+      return null;
+    }
     BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
-    Long2LongOpenHashMap baseOf = new Long2LongOpenHashMap();
-    Long2ObjectOpenHashMap<BlockPos> standOf = new Long2ObjectOpenHashMap<>();
-    Cut found = null;
-    int seen = 0;
-    for (int x = -radius; x <= radius; ++x) {
+    LongOpenHashSet mapped = new LongOpenHashSet();
+    LongOpenHashSet counted = new LongOpenHashSet();
+    List<BlockPos> candidates = new ArrayList<>();
+    int remembered = 0;
+    for (int x = bounds.minX(); x <= bounds.maxX(); ++x) {
       for (int y = -WOODLAND_VERTICAL_RADIUS; y <= WOODLAND_VERTICAL_RADIUS; ++y) {
-        for (int z = -radius; z <= radius; ++z) {
-          cursor.setWithOffset(around, x, y, z);
-          if (!TreeFelling.isFellableWood(level, cursor)) {
+        for (int z = bounds.minZ(); z <= bounds.maxZ(); ++z) {
+          cursor.set(x, around.getY() + y, z);
+          if (mapped.contains(cursor.asLong()) || !TreeFelling.isFellableWood(level, cursor)) {
             continue;
           }
-          long key = cursor.asLong();
-          if (!baseOf.containsKey(key)) {
-            List<BlockPos> logs = TreeFelling.treeWood(level, cursor.immutable());
-            long base = lowestOf(logs).asLong();
-            for (BlockPos log : logs) {
-              baseOf.put(log.asLong(), base);
-            }
+          // Each tree is flood-filled once a scan and every log on it mapped,
+          // because every log of a tree in the box would otherwise ask again.
+          List<BlockPos> logs = TreeFelling.treeWood(level, cursor.immutable());
+          for (BlockPos log : logs) {
+            mapped.add(log.asLong());
           }
-          long baseKey = baseOf.get(key);
-          if (!standOf.containsKey(baseKey)) {
-            standOf.put(baseKey, standBeside(person, level, BlockPos.of(baseKey)));
-          }
-          BlockPos stand = standOf.get(baseKey);
-          if (stand == null) {
+          BlockPos base = lowestOf(logs);
+          if (!counted.add(base.asLong()) || !ScanBounds.withinReach(base, worker, reach)) {
             continue;
           }
-          if (person.getRandom().nextInt(++seen) == 0) {
-            found = new Cut(BlockPos.of(baseKey), stand);
+          if (this.unreachableUntil.containsKey(base.asLong())) {
+            remembered++;
+            continue;
           }
+          candidates.add(base);
         }
+      }
+    }
+    candidates.sort(Comparator.comparingLong(base -> ScanBounds.horizontalDistSqr(base, worker)));
+    Cut found = null;
+    int budget = PATHS_PER_PASS;
+    int asked = 0;
+    for (BlockPos base : candidates) {
+      if (budget <= 0) {
+        break;
+      }
+      StandSearch search = standBeside(person, level, base, budget);
+      budget -= search.pathsAsked();
+      asked++;
+      if (search.stand() != null) {
+        found = new Cut(base, search.stand());
+        break;
+      }
+      if (search.decided()) {
+        this.unreachableUntil.put(base.asLong(), now + UNREACHABLE_TREE_TICKS);
       }
     }
     // Once per scan that rolled to fell: what the box held. A guard that picks
     // nothing for an hour is either surrounded by nothing fellable or by trunks
     // nobody can stand beside, and only this line tells the two apart.
-    int trees = new java.util.HashSet<>(baseOf.values()).size();
-    int cuttable = (int) standOf.values().stream().filter(java.util.Objects::nonNull).count();
-    Kithkyn.LOGGER.debug("[chop] {} ({}) scanned the woodland round {}: {} tree(s), {} with ground to cut from{}",
-        person.getName().getString(), person.getOccupation(), around.toShortString(), trees, cuttable,
+    Kithkyn.LOGGER.debug("[chop] {} ({}) scanned the woodland round {}: {} tree(s) in reach, {} asked about "
+            + "with {} path(s), {} left alone as unreachable{}",
+        person.getName().getString(), person.getOccupation(), around.toShortString(), counted.size(), asked,
+        PATHS_PER_PASS - budget, remembered,
         found == null ? "" : ", chose the one at " + found.log().toShortString());
     return found;
+  }
+
+  /**
+   * The columns a woodland scan reads: the requested box, cut down to the
+   * square a single path search can cover from where the worker stands.
+   * Package-visible for tests.
+   */
+  record ScanBounds(int minX, int maxX, int minZ, int maxZ) {
+
+    /** The overlap of the scan box and the worker's reach, or null when they do not meet. */
+    @Nullable
+    static ScanBounds within(BlockPos around, int radius, BlockPos worker, int reach) {
+      int minX = Math.max(around.getX() - radius, worker.getX() - reach);
+      int maxX = Math.min(around.getX() + radius, worker.getX() + reach);
+      int minZ = Math.max(around.getZ() - radius, worker.getZ() - reach);
+      int maxZ = Math.min(around.getZ() + radius, worker.getZ() + reach);
+      return minX > maxX || minZ > maxZ ? null : new ScanBounds(minX, maxX, minZ, maxZ);
+    }
+
+    /** Across the ground only: a trunk up a hillside is no further to walk to than its footprint. */
+    static long horizontalDistSqr(BlockPos a, BlockPos b) {
+      long dx = a.getX() - b.getX();
+      long dz = a.getZ() - b.getZ();
+      return dx * dx + dz * dz;
+    }
+
+    static boolean withinReach(BlockPos pos, BlockPos worker, int reach) {
+      return horizontalDistSqr(pos, worker) <= (long) reach * reach;
+    }
+  }
+
+  /**
+   * What asking the navigator about one trunk found and cost. {@code decided}
+   * is false only when the pass's budget ran out before the tree had its full
+   * {@link #PATHS_PER_TREE}, so an unanswered tree is not mistaken for an
+   * unreachable one.
+   */
+  private record StandSearch(@Nullable BlockPos stand, int pathsAsked, boolean decided) {
   }
 
   /** The base of a tree: the lowest of its logs. */
@@ -456,6 +551,11 @@ public final class ChopStep implements WorkStep<ChopStep.Cut> {
    */
   @Nullable
   private static BlockPos standBeside(RealPerson person, ServerLevel level, BlockPos base) {
+    return standBeside(person, level, base, PATHS_PER_TREE).stand();
+  }
+
+  /** The same, asking the navigator at most {@code maxPaths} times, and saying what that cost. */
+  private static StandSearch standBeside(RealPerson person, ServerLevel level, BlockPos base, int maxPaths) {
     List<BlockPos> spots = new ArrayList<>();
     BlockPos.MutableBlockPos feet = new BlockPos.MutableBlockPos();
     for (int dx = -2; dx <= 2; dx++) {
@@ -476,11 +576,14 @@ public final class ChopStep implements WorkStep<ChopStep.Cut> {
       }
     }
     spots.sort(Comparator.comparingInt(spot -> spot.distManhattan(base)));
+    int limit = Math.min(maxPaths, PATHS_PER_TREE);
     int asked = 0;
     for (BlockPos spot : spots) {
-      if (asked++ >= PATHS_PER_TREE) {
-        break;
+      if (asked >= limit) {
+        // Out of this tree's allowance, or out of the pass's budget first.
+        return new StandSearch(null, asked, asked >= PATHS_PER_TREE);
       }
+      asked++;
       Path path = person.getNavigation().createPath(spot, 1);
       if (path == null || !path.canReach()) {
         continue;
@@ -492,10 +595,10 @@ public final class ChopStep implements WorkStep<ChopStep.Cut> {
       // Where the path actually ends is where the worker will stand.
       BlockPos there = end.asBlockPos();
       if (axeReachesFrom(there, eyesAt(there, person), base)) {
-        return there;
+        return new StandSearch(there, asked, true);
       }
     }
-    return null;
+    return new StandSearch(null, asked, true);
   }
 
   /**
@@ -522,13 +625,15 @@ public final class ChopStep implements WorkStep<ChopStep.Cut> {
     }
     leaves.sort(Comparator.comparingDouble(leaf -> leaf.distSqr(person.blockPosition())));
     int asked = 0;
+    int budget = PATHS_PER_PASS;
     for (BlockPos leaf : leaves) {
-      if (asked++ >= LEAVES_PER_PASS) {
+      if (asked++ >= LEAVES_PER_PASS || budget <= 0) {
         break;
       }
-      BlockPos stand = standBeside(person, level, leaf);
-      if (stand != null) {
-        return new Cut(leaf, stand);
+      StandSearch search = standBeside(person, level, leaf, budget);
+      budget -= search.pathsAsked();
+      if (search.stand() != null) {
+        return new Cut(leaf, search.stand());
       }
     }
     return null;

--- a/src/main/java/com/quzzar/kithkyn/events/KithkynCommands.java
+++ b/src/main/java/com/quzzar/kithkyn/events/KithkynCommands.java
@@ -102,7 +102,12 @@ public class KithkynCommands {
     private static int createVillage(CommandSourceStack source, BlockPos pos, @javax.annotation.Nullable VillageStyle style,
             com.quzzar.kithkyn.entities.Kind kind) {
         ServerLevel level = source.getLevel();
-        VillageManager.get(level).registerVillage(level, pos, style, kind);
+        if (!VillageManager.get(level).registerVillage(level, pos, style, kind)) {
+            source.sendFailure(Component.literal("No village founded at " + pos.toShortString() + ": within "
+                    + com.quzzar.kithkyn.village.VillageGeneration.MIN_SEPARATION_BLOCKS
+                    + " blocks of another village or a founding still being named"));
+            return 0;
+        }
         source.sendSuccess(() -> Component.literal("Village founding requested at " + pos.toShortString()
                 + (style == null ? "" : " in the " + style.id() + " style")
                 + (kind == com.quzzar.kithkyn.entities.Kind.LIVING ? "" : ", " + kind.id())), true);

--- a/src/main/java/com/quzzar/kithkyn/savedata/VillageManagerSaveData.java
+++ b/src/main/java/com/quzzar/kithkyn/savedata/VillageManagerSaveData.java
@@ -173,27 +173,40 @@ public class VillageManagerSaveData extends SavedData {
         }
     }
 
-    public void registerVillage(ServerLevelAccessor levelAccess, BlockPos location) {
-        registerVillage(levelAccess, location, null);
+    public boolean registerVillage(ServerLevelAccessor levelAccess, BlockPos location) {
+        return registerVillage(levelAccess, location, null);
     }
 
     /**
      * Founds a village at the site in the given style, or, with none given, in
      * the style the biome there calls for ({@link com.quzzar.kithkyn.village.buildings.VillageStyle#fromBiome}).
      */
-    public void registerVillage(ServerLevelAccessor levelAccess, BlockPos location,
+    public boolean registerVillage(ServerLevelAccessor levelAccess, BlockPos location,
             @javax.annotation.Nullable com.quzzar.kithkyn.village.buildings.VillageStyle style) {
-        registerVillage(levelAccess, location, style, com.quzzar.kithkyn.entities.Kind.LIVING);
+        return registerVillage(levelAccess, location, style, com.quzzar.kithkyn.entities.Kind.LIVING);
     }
 
     /**
      * Founds a village of the given kind: a manual founding is living unless
      * the command says undead, because a placed village is a deliberate act
      * and a surprise kind would be a bug report (docs/undead.md).
+     *
+     * <p>A manual founding keeps the same separation from other villages that a
+     * natural one does. On 2026-09-12 three foundings landed within a few blocks
+     * of each other near Sorevia: the second began while the first was still
+     * being cleared (#138), and the third logged a POI conflict on the first's
+     * blocks. Returns false, founding nothing, when the site is within
+     * {@code VillageGeneration.MIN_SEPARATION_BLOCKS} of a standing village
+     * centre or a founding still being named.
      */
-    public void registerVillage(ServerLevelAccessor levelAccess, BlockPos location,
+    public boolean registerVillage(ServerLevelAccessor levelAccess, BlockPos location,
             @javax.annotation.Nullable com.quzzar.kithkyn.village.buildings.VillageStyle style,
             com.quzzar.kithkyn.entities.Kind kind) {
+        if (!naturalSiteAvailable(location)) {
+            Kithkyn.LOGGER.info("Refused to found a village at {}: within {} blocks of another village or a pending founding",
+                    location.toShortString(), com.quzzar.kithkyn.village.VillageGeneration.MIN_SEPARATION_BLOCKS);
+            return false;
+        }
         // One name for life (#60): the LLM name is requested BEFORE the camp is
         // placed, and founding runs when it lands moments later, so the village
         // never carries a provisional name. The wait opens a short window in
@@ -202,7 +215,7 @@ public class VillageManagerSaveData extends SavedData {
         // skipped.
         long site = location.asLong();
         if (!pendingFoundings.add(site)) {
-            return;
+            return false;
         }
         ServerLevel serverLevel = level != null ? level : levelAccess.getLevel();
         var selectedStyle = style != null ? style
@@ -223,6 +236,7 @@ public class VillageManagerSaveData extends SavedData {
                 pendingFoundings.remove(site);
             }
         });
+        return true;
     }
 
     /** Runs every second, driven by the overworld tick handler. */

--- a/src/main/java/com/quzzar/kithkyn/savedata/VillageManagerSaveData.java
+++ b/src/main/java/com/quzzar/kithkyn/savedata/VillageManagerSaveData.java
@@ -202,7 +202,18 @@ public class VillageManagerSaveData extends SavedData {
     public boolean registerVillage(ServerLevelAccessor levelAccess, BlockPos location,
             @javax.annotation.Nullable com.quzzar.kithkyn.village.buildings.VillageStyle style,
             com.quzzar.kithkyn.entities.Kind kind) {
-        if (!naturalSiteAvailable(location)) {
+        return registerVillage(levelAccess, location, style, kind, true);
+    }
+
+    /**
+     * The founding itself, with the separation check optional. Only the dev
+     * founding probe passes false: it reproduces a founding at exactly the site
+     * a player used, whether or not another village has since grown up beside it.
+     */
+    public boolean registerVillage(ServerLevelAccessor levelAccess, BlockPos location,
+            @javax.annotation.Nullable com.quzzar.kithkyn.village.buildings.VillageStyle style,
+            com.quzzar.kithkyn.entities.Kind kind, boolean requireSeparation) {
+        if (requireSeparation && !naturalSiteAvailable(location)) {
             Kithkyn.LOGGER.info("Refused to found a village at {}: within {} blocks of another village or a pending founding",
                     location.toShortString(), com.quzzar.kithkyn.village.VillageGeneration.MIN_SEPARATION_BLOCKS);
             return false;

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/BuildingInfo.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/BuildingInfo.java
@@ -720,7 +720,8 @@ public class BuildingInfo {
     return bedLocs.stream().map(BlockPos::of).toList();
   }
 
-  private List<WorkStation> workStations() {
+  /** The authored posts, in station order; package-visible so StationGrants can read each post's worksite routing. */
+  List<WorkStation> workStations() {
     return workLocs.entrySet().stream()
         .map(entry -> new WorkStation(BlockPos.of(entry.getKey()), entry.getValue(),
             java.util.Optional.ofNullable(guardRoles.get(entry.getKey())),

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/StationGrants.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/StationGrants.java
@@ -15,7 +15,11 @@ import com.quzzar.kithkyn.village.Occupation;
  * <p>Only the trades with one unmistakable grant are listed. A guard post is
  * not: the watchtower's guards grant PROTECTION while the center's captain and
  * a castle's sentries do not, and that is a planning decision the definitions
- * make on purpose. The builder and the leader grant nothing.
+ * make on purpose. The builder and the leader grant nothing. A station that
+ * routes its worker to a separate physical worksite (the centre's quartermaster
+ * post whose shelves are the storehouse, its miner post whose pit is the mine)
+ * is exempt too: the grant belongs to the worksite's own definition, which
+ * already carries it, and the vacancy stays with the civic building.
  */
 public final class StationGrants {
 
@@ -50,11 +54,14 @@ public final class StationGrants {
    */
   public static List<String> missing(BuildingInfo info) {
     List<String> problems = new ArrayList<>();
-    for (Occupation occupation : info.getWorkLocations().values().stream().distinct().toList()) {
+    List<Occupation> seen = new ArrayList<>();
+    for (BuildingInfo.WorkStation station : info.workStations()) {
+      Occupation occupation = station.occupation();
       String grant = canonical(occupation);
-      if (grant == null) {
+      if (grant == null || station.worksiteCategory().isPresent() || seen.contains(occupation)) {
         continue;
       }
+      seen.add(occupation);
       boolean declared = info.getGrants().contains(grant)
           || info.getConditionalGrants().stream().anyMatch(conditional -> conditional.capability().equals(grant));
       if (!declared) {

--- a/src/test/java/com/quzzar/kithkyn/entities/ai/goals/work/ChopScanBoundsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ai/goals/work/ChopScanBoundsTest.java
@@ -1,0 +1,39 @@
+package com.quzzar.kithkyn.entities.ai.goals.work;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.core.BlockPos;
+
+class ChopScanBoundsTest {
+
+  @Test
+  void aVillageWideBoxIsCutDownToWhatOnePathSearchCanReach() {
+    // Claim centre at the origin, 64 each way; a lumberjack at the lodge 70 blocks east.
+    ChopStep.ScanBounds bounds = ChopStep.ScanBounds.within(new BlockPos(0, 64, 0), 64,
+        new BlockPos(70, 64, 5), 44);
+    assertNotNull(bounds);
+    assertEquals(26, bounds.minX());
+    assertEquals(64, bounds.maxX());
+    assertEquals(-39, bounds.minZ());
+    assertEquals(49, bounds.maxZ());
+  }
+
+  @Test
+  void aWorkerOutOfReachOfTheWholeBoxScansNothing() {
+    assertNull(ChopStep.ScanBounds.within(new BlockPos(0, 64, 0), 16, new BlockPos(200, 64, 0), 44));
+  }
+
+  @Test
+  void reachIsMeasuredAcrossTheGroundNotUpTheHill() {
+    BlockPos worker = new BlockPos(0, 64, 0);
+    assertTrue(ChopStep.ScanBounds.withinReach(new BlockPos(30, 90, 30), worker, 44));
+    assertFalse(ChopStep.ScanBounds.withinReach(new BlockPos(32, 64, 32), worker, 44));
+    assertEquals(25L, ChopStep.ScanBounds.horizontalDistSqr(new BlockPos(3, 0, 4), new BlockPos(0, 99, 0)));
+  }
+}

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/StationGrantsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/StationGrantsTest.java
@@ -44,6 +44,17 @@ class StationGrantsTest {
   }
 
   @Test
+  void aStationRoutedToASeparateWorksiteLeavesTheGrantToThatWorksite() {
+    BuildingInfo center = parse("{\"structure\":\"camp\",\"work_stations\":["
+        + "{\"pos\":[1,1,1],\"occupation\":\"QUARTERMASTER\",\"worksite_category\":\"storehouse\"},"
+        + "{\"pos\":[2,1,1],\"occupation\":\"MINER\",\"worksite_category\":\"mine\"}]}");
+    assertTrue(StationGrants.missing(center).isEmpty());
+    BuildingInfo storehouse = parse("{\"structure\":\"storehouse\",\"work_stations\":["
+        + "{\"pos\":[1,1,1],\"occupation\":\"QUARTERMASTER\"}]}");
+    assertEquals(List.of("QUARTERMASTER station needs the STORAGE grant"), StationGrants.missing(storehouse));
+  }
+
+  @Test
   void aConditionalGrantCountsAndTradesWithoutACanonicalGrantAreLeftAlone() {
     BuildingInfo inn = parse("{\"structure\":\"inn\",\"work_stations\":[{\"pos\":[1,1,1],\"occupation\":\"INNKEEPER\"}],"
         + "\"grants_if\":[{\"capability\":\"WANDERERS\",\"requires_supply\":[\"minecraft:bread\"]}]}");


### PR DESCRIPTION
Fixes #138.

## The crash

Two watchdog kills on the live server today (11:38 during a founding, 12:23 with no founding at all) were each a single tick spent in `ChopStep.findWoodlandTree`. The lumberjack's village-wide woodland pass asked the navigator about every tree in the claim plus a margin, up to four path searches per tree. From the lodge that box reaches ~90 blocks, but one path search never expands past ~48, so almost every search came back partial after spending its whole node budget, and the same trees were re-asked every scan.

Measured on a copy of the live world (pre-founding backup, `dev/FoundingProbe`), six minutes:

| Lumberjack | Stand searches | Reached | Beyond path range | Server time |
| --- | --- | --- | --- | --- |
| Elric Corona | 2,325 | 19 | 2,233 | 55 s |
| Dass Hanna | 1,038 | 5 | 1,032 | 38 s |
| Winston Villa | 618 | 15 | 509 | 24 s |

The live server was at 5.2 TPS (193 ms/tick) from this.

**Fix:** a woodland pass now only considers trees within one search's reach of the worker (`PersonPathNavigation.searchRange`), asks nearest first, spends at most six searches per pass, and remembers a tree it found no way to for two minutes. Trimming into a hemmed-in stand shares the budget. Far trees were never reachable by a search anyway, so nothing that could be felled before is lost.

## Also in this PR

- **Overlapping foundings refused.** `create-village` keeps the natural-founding separation from other villages and pending foundings, and reports the refusal. Three villages were founded within a few blocks of each other today, and the third logged a POI conflict.
- **Station-grant check:** stations routed to a separate worksite (`worksite_category`) are exempt; the centre's quartermaster and miner posts were eight false warnings. The real gaps (castle smiths, merchants, bakers; a badlands stoneworks granting `STONE`) are fixed in the private datapacks, outside git.
- **Home chest matches by brew**, like the stores, so a cleric drawing regeneration is never handed harming.
- **`dev/FoundingProbe`**: founds villages at given sites on a copy of a world, logs every tick over one second with server-thread stack samples.

## Verification

- `./gradlew test`: 545 tests, 0 failures (new: `ChopScanBoundsTest`, a worksite case in `StationGrantsTest`).
- After-fix probe on the same world copy: see the comment below once it completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)