### PR TITLE
Station grants: exempt the quartermaster post

### DIFF
--- a/docs/building-spec.md
+++ b/docs/building-spec.md
@@ -553,8 +553,10 @@ station whose grant is missing rather than rejecting the building, so a private 
 loads and its author sees the gap in the log; a test holds the bundled catalog to zero
 warnings. Guard, builder and leader stations are exempt: the watchtower's guards grant
 `PROTECTION` while the centre's captain does not, and that is a planning choice. So is a
-station with a `worksite_category`: the centre's quartermaster and miner posts work at the
-storehouse and the mine, and those definitions carry `STORAGE` and `ORES`.
+station with a `worksite_category`: the centre's miner post works at the mine, and the mine
+carries `ORES`. The quartermaster is exempt outright: `STORAGE` means shelves, the storehouse
+that holds them grants it, and the desert and floodplain centres keep their quartermaster at a
+centre with no chest by design.
 
 Capability resolution is a fixed point: grant everything unconditional, then re-evaluate
 `grants_if` until nothing new appears. Two buildings that each require the other's capability

--- a/src/main/java/com/quzzar/kithkyn/village/buildings/StationGrants.java
+++ b/src/main/java/com/quzzar/kithkyn/village/buildings/StationGrants.java
@@ -15,7 +15,12 @@ import com.quzzar.kithkyn.village.Occupation;
  * <p>Only the trades with one unmistakable grant are listed. A guard post is
  * not: the watchtower's guards grant PROTECTION while the center's captain and
  * a castle's sentries do not, and that is a planning decision the definitions
- * make on purpose. The builder and the leader grant nothing. A station that
+ * make on purpose. The builder and the leader grant nothing. Nor does the
+ * quartermaster: the post keeps the village's shelves in order, but STORAGE
+ * means shelves, and those belong to the storehouse, which grants it. The
+ * desert and floodplain centres keep their quartermaster at the centre by
+ * design, with no chest there, and STORAGE on them would send allays and the
+ * planner to shelves that do not exist. A station that
  * routes its worker to a separate physical worksite (the centre's quartermaster
  * post whose shelves are the storehouse, its miner post whose pit is the mine)
  * is exempt too: the grant belongs to the worksite's own definition, which
@@ -36,7 +41,6 @@ public final class StationGrants {
       Map.entry(Occupation.MASON, "CUT_STONE"),
       Map.entry(Occupation.MERCHANT, "TRADE"),
       Map.entry(Occupation.MINER, "ORES"),
-      Map.entry(Occupation.QUARTERMASTER, "STORAGE"),
       Map.entry(Occupation.INNKEEPER, "WANDERERS"));
 
   private StationGrants() {

--- a/src/test/java/com/quzzar/kithkyn/village/buildings/StationGrantsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/village/buildings/StationGrantsTest.java
@@ -49,9 +49,16 @@ class StationGrantsTest {
         + "{\"pos\":[1,1,1],\"occupation\":\"QUARTERMASTER\",\"worksite_category\":\"storehouse\"},"
         + "{\"pos\":[2,1,1],\"occupation\":\"MINER\",\"worksite_category\":\"mine\"}]}");
     assertTrue(StationGrants.missing(center).isEmpty());
-    BuildingInfo storehouse = parse("{\"structure\":\"storehouse\",\"work_stations\":["
-        + "{\"pos\":[1,1,1],\"occupation\":\"QUARTERMASTER\"}]}");
-    assertEquals(List.of("QUARTERMASTER station needs the STORAGE grant"), StationGrants.missing(storehouse));
+    BuildingInfo mine = parse("{\"structure\":\"mine\",\"work_stations\":["
+        + "{\"pos\":[1,1,1],\"occupation\":\"MINER\"}]}");
+    assertEquals(List.of("MINER station needs the ORES grant"), StationGrants.missing(mine));
+  }
+
+  @Test
+  void aQuartermasterPostAtACentreWithNoShelvesNeedsNoStorageGrant() {
+    BuildingInfo desertCentre = parse("{\"structure\":\"camp\",\"work_stations\":["
+        + "{\"pos\":[8,1,3],\"occupation\":\"QUARTERMASTER\"},{\"pos\":[2,1,1],\"occupation\":\"BUILDER\"}]}");
+    assertTrue(StationGrants.missing(desertCentre).isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #139. After the woodland-fix deploy the station-grant check left two warnings on the live server:

```
kithkyn:village_center_desert_1: QUARTERMASTER station needs the STORAGE grant
kithkyn:village_center_floodplain_1: QUARTERMASTER station needs the STORAGE grant
```

Both are the check being wrong, not the data. The desert and floodplain docs say the quartermaster keeps the centre post by design; those centres have no chest, and their storehouses already grant `STORAGE` and have no quartermaster worksite to route to (so tagging the post `worksite_category: storehouse` would have left the quartermaster without a job location). `STORAGE` means shelves, and granting it to a chestless centre would point allays and the planner at shelves that do not exist. The quartermaster leaves the canonical table; the storehouse keeps `STORAGE`.

- `./gradlew test`: all pass, including a new desert-centre case.
- Log-only change: no redeploy needed; it ships with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)