### PR TITLE
Path: remember a failed long retry instead of paying for it twice a second

### DIFF
--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -977,7 +977,9 @@ so one who was stuck, or whose post was walled off, paid for that retry twice a 
 live server long retries were 38% of all path-search time and reached their target 1.2% of the
 time, the costliest being one guard asking 200 times for a post six blocks away. A failed long
 retry is now not repeated for the same target for five seconds unless the person has moved four
-blocks since (`LongRetryMemo`), and one that reaches its target clears the memory.
+blocks since (`LongRetryMemo`), and one that reaches its target clears it. The last sixteen failures
+are kept, not one: a villager stuck beside a chest asks for each of the nine cells round it in
+turn, and a single remembered failure was forgotten before its cell came round again.
 
 **Attached bee nests (2026-09-08).** Shared tree felling also removes unowned bee nests
 and beehives touching a log actually removed, once each. It releases occupants normally;

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -970,6 +970,15 @@ spends at most six searches in total, and leaves a tree it found no way to out o
 scans for two minutes. The nearest reachable tree is taken rather than a random one. Trimming a
 way into a hemmed-in stand shares the same six-search budget.
 
+**The long retry is remembered, 2026-09-12 (#138).** An exact destination that the ordinary
+48-block search cannot reach is retried with a 128-block horizon and double the node budget, for
+posts such as a watch platform whose way in is a long detour. A worker re-plans every ten ticks,
+so one who was stuck, or whose post was walled off, paid for that retry twice a second: on the
+live server long retries were 38% of all path-search time and reached their target 1.2% of the
+time, the costliest being one guard asking 200 times for a post six blocks away. A failed long
+retry is now not repeated for the same target for five seconds unless the person has moved four
+blocks since (`LongRetryMemo`), and one that reaches its target clears the memory.
+
 **Attached bee nests (2026-09-08).** Shared tree felling also removes unowned bee nests
 and beehives touching a log actually removed, once each. It releases occupants normally;
 Silk Touch preserves bees in the native hive drop instead. Player/village-owned hives,

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/LongRetryMemo.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/LongRetryMemo.java
@@ -1,0 +1,61 @@
+package com.quzzar.kithkyn.entities.ai;
+
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.core.BlockPos;
+
+/**
+ * Remembers the last long path retry that failed, so a person who cannot reach
+ * a place does not pay for the same failure twice a second.
+ *
+ * <p>{@link PersonPathNavigation} retries an exact destination with a 128-block
+ * horizon and double the node budget when the ordinary search fails, for posts
+ * such as a watch platform whose way in is a long detour. A worker re-plans
+ * every ten ticks, so one who is stuck, or whose target is walled off, ran
+ * that retry on every re-plan: on 2026-09-12 long retries were 38% of all path
+ * search time on the live server and reached their target 1.2% of the time,
+ * and one sat under a watchdog kill (#138). A failed retry is now not repeated
+ * for the same targets for {@link #COOLDOWN_TICKS}, unless the person has
+ * moved {@link #MOVED_BLOCKS} since, which gives the search a new start.
+ * A retry that reaches its target clears the memory.
+ */
+public final class LongRetryMemo {
+
+  /** How long a failed long retry to the same targets is not asked again: five seconds. */
+  public static final int COOLDOWN_TICKS = 100;
+
+  /** Moving this far since the failure earns a fresh retry: the search starts somewhere new. */
+  public static final int MOVED_BLOCKS = 4;
+
+  @Nullable
+  private Set<BlockPos> targets;
+  @Nullable
+  private BlockPos from;
+  private long failedAt;
+
+  /** Whether the long retry is worth asking for: false only for a recent failure to these targets from about here. */
+  public boolean worthRetrying(Set<BlockPos> wanted, BlockPos standing, long gameTime) {
+    if (this.targets == null || this.from == null || !this.targets.equals(wanted)) {
+      return true;
+    }
+    if (gameTime - this.failedAt >= COOLDOWN_TICKS) {
+      return true;
+    }
+    return this.from.distSqr(standing) >= (long) MOVED_BLOCKS * MOVED_BLOCKS;
+  }
+
+  /** The long retry to these targets from here came back without reaching them. */
+  public void failed(Set<BlockPos> wanted, BlockPos standing, long gameTime) {
+    this.targets = Set.copyOf(wanted);
+    this.from = standing.immutable();
+    this.failedAt = gameTime;
+  }
+
+  /** A long retry reached its target: nothing to hold back. */
+  public void reached() {
+    this.targets = null;
+    this.from = null;
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/LongRetryMemo.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/LongRetryMemo.java
@@ -1,14 +1,14 @@
 package com.quzzar.kithkyn.entities.ai;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
-
-import javax.annotation.Nullable;
 
 import net.minecraft.core.BlockPos;
 
 /**
- * Remembers the last long path retry that failed, so a person who cannot reach
- * a place does not pay for the same failure twice a second.
+ * Remembers the long path retries that failed lately, so a person who cannot
+ * reach a place does not pay for the same failure twice a second.
  *
  * <p>{@link PersonPathNavigation} retries an exact destination with a 128-block
  * horizon and double the node budget when the ordinary search fails, for posts
@@ -18,8 +18,13 @@ import net.minecraft.core.BlockPos;
  * search time on the live server and reached their target 1.2% of the time,
  * and one sat under a watchdog kill (#138). A failed retry is now not repeated
  * for the same targets for {@link #COOLDOWN_TICKS}, unless the person has
- * moved {@link #MOVED_BLOCKS} since, which gives the search a new start.
- * A retry that reaches its target clears the memory.
+ * moved {@link #MOVED_BLOCKS} since, which gives the search a new start. A
+ * retry that reaches its target forgets that target.
+ *
+ * <p>Several failures are kept, not one: a villager stuck beside a chest asks
+ * for each of the nine cells round it in turn, and a single remembered failure
+ * was forgotten before its cell came round again (the A/B run on 2026-09-12
+ * that led to {@link #CAPACITY}).
  */
 public final class LongRetryMemo {
 
@@ -29,33 +34,36 @@ public final class LongRetryMemo {
   /** Moving this far since the failure earns a fresh retry: the search starts somewhere new. */
   public static final int MOVED_BLOCKS = 4;
 
-  @Nullable
-  private Set<BlockPos> targets;
-  @Nullable
-  private BlockPos from;
-  private long failedAt;
+  /** Failed retries remembered at once: a ring of approach cells round a chest, with room to spare. */
+  public static final int CAPACITY = 16;
+
+  /** Where a long retry failed from, and when. */
+  private record Failure(BlockPos from, long at) {
+  }
+
+  private final Map<Set<BlockPos>, Failure> failures = new LinkedHashMap<>(CAPACITY, 0.75F, true) {
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<Set<BlockPos>, Failure> eldest) {
+      return size() > CAPACITY;
+    }
+  };
 
   /** Whether the long retry is worth asking for: false only for a recent failure to these targets from about here. */
   public boolean worthRetrying(Set<BlockPos> wanted, BlockPos standing, long gameTime) {
-    if (this.targets == null || this.from == null || !this.targets.equals(wanted)) {
+    Failure failure = this.failures.get(wanted);
+    if (failure == null || gameTime - failure.at() >= COOLDOWN_TICKS) {
       return true;
     }
-    if (gameTime - this.failedAt >= COOLDOWN_TICKS) {
-      return true;
-    }
-    return this.from.distSqr(standing) >= (long) MOVED_BLOCKS * MOVED_BLOCKS;
+    return failure.from().distSqr(standing) >= (long) MOVED_BLOCKS * MOVED_BLOCKS;
   }
 
   /** The long retry to these targets from here came back without reaching them. */
   public void failed(Set<BlockPos> wanted, BlockPos standing, long gameTime) {
-    this.targets = Set.copyOf(wanted);
-    this.from = standing.immutable();
-    this.failedAt = gameTime;
+    this.failures.put(Set.copyOf(wanted), new Failure(standing.immutable(), gameTime));
   }
 
-  /** A long retry reached its target: nothing to hold back. */
-  public void reached() {
-    this.targets = null;
-    this.from = null;
+  /** A long retry reached these targets: nothing to hold back for them. */
+  public void reached(Set<BlockPos> wanted) {
+    this.failures.remove(wanted);
   }
 }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
@@ -104,7 +104,7 @@ public final class PersonPathNavigation extends GroundPathNavigation {
   @Nullable
   private String lastMinePathFailure;
 
-  /** The last long retry that failed, so a stuck walker is not charged for it on every re-plan. */
+  /** The long retries that failed lately, so a stuck walker is not charged for them on every re-plan. */
   private final LongRetryMemo longRetry = new LongRetryMemo();
 
   public PersonPathNavigation(Mob mob, Level level) {
@@ -149,7 +149,7 @@ public final class PersonPathNavigation extends GroundPathNavigation {
         && this.longRetry.worthRetrying(targets, this.mob.blockPosition(), now)) {
       Path longer = super.createPath(targets, regionOffset, offsetUpward, accuracy, EXACT_SEARCH_RANGE);
       if (longer != null && longer.canReach()) {
-        this.longRetry.reached();
+        this.longRetry.reached(targets);
       } else {
         this.longRetry.failed(targets, this.mob.blockPosition(), now);
       }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
@@ -104,6 +104,9 @@ public final class PersonPathNavigation extends GroundPathNavigation {
   @Nullable
   private String lastMinePathFailure;
 
+  /** The last long retry that failed, so a stuck walker is not charged for it on every re-plan. */
+  private final LongRetryMemo longRetry = new LongRetryMemo();
+
   public PersonPathNavigation(Mob mob, Level level) {
     super(mob, level);
   }
@@ -140,8 +143,16 @@ public final class PersonPathNavigation extends GroundPathNavigation {
     // Reaching a watch platform can take more than 48 blocks of walking even
     // when it is nearby in a straight line. Retry exact work destinations with
     // a longer horizon and bounded extra search work, retaining loaded chunks.
-    if (accuracy == 0 && range < EXACT_SEARCH_RANGE && (route == null || !route.canReach())) {
+    // A retry that just failed from here is not asked again (LongRetryMemo).
+    long now = this.level.getGameTime();
+    if (accuracy == 0 && range < EXACT_SEARCH_RANGE && (route == null || !route.canReach())
+        && this.longRetry.worthRetrying(targets, this.mob.blockPosition(), now)) {
       Path longer = super.createPath(targets, regionOffset, offsetUpward, accuracy, EXACT_SEARCH_RANGE);
+      if (longer != null && longer.canReach()) {
+        this.longRetry.reached();
+      } else {
+        this.longRetry.failed(targets, this.mob.blockPosition(), now);
+      }
       if (longer != null && (route == null || longer.canReach()
           || longer.getDistToTarget() < route.getDistToTarget())) route = longer;
     }

--- a/src/test/java/com/quzzar/kithkyn/entities/ai/LongRetryMemoTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ai/LongRetryMemoTest.java
@@ -1,0 +1,46 @@
+package com.quzzar.kithkyn.entities.ai;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.core.BlockPos;
+
+class LongRetryMemoTest {
+
+  private static final Set<BlockPos> POST = Set.of(new BlockPos(10, 70, 10));
+  private static final BlockPos STUCK = new BlockPos(0, 64, 0);
+
+  @Test
+  void aFreshMemoAlwaysRetries() {
+    assertTrue(new LongRetryMemo().worthRetrying(POST, STUCK, 0L));
+  }
+
+  @Test
+  void aFailureFromTheSameSpotIsNotRepeatedWithinTheCooldown() {
+    LongRetryMemo memo = new LongRetryMemo();
+    memo.failed(POST, STUCK, 1_000L);
+    assertFalse(memo.worthRetrying(POST, STUCK, 1_010L));
+    assertFalse(memo.worthRetrying(POST, STUCK.offset(1, 0, 1), 1_099L));
+    assertTrue(memo.worthRetrying(POST, STUCK, 1_000L + LongRetryMemo.COOLDOWN_TICKS));
+  }
+
+  @Test
+  void movingOrWantingSomewhereElseEarnsAFreshRetry() {
+    LongRetryMemo memo = new LongRetryMemo();
+    memo.failed(POST, STUCK, 1_000L);
+    assertTrue(memo.worthRetrying(POST, STUCK.offset(LongRetryMemo.MOVED_BLOCKS, 0, 0), 1_010L));
+    assertTrue(memo.worthRetrying(Set.of(new BlockPos(40, 70, 40)), STUCK, 1_010L));
+  }
+
+  @Test
+  void reachingTheTargetClearsTheMemory() {
+    LongRetryMemo memo = new LongRetryMemo();
+    memo.failed(POST, STUCK, 1_000L);
+    memo.reached();
+    assertTrue(memo.worthRetrying(POST, STUCK, 1_001L));
+  }
+}

--- a/src/test/java/com/quzzar/kithkyn/entities/ai/LongRetryMemoTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ai/LongRetryMemoTest.java
@@ -3,6 +3,8 @@ package com.quzzar.kithkyn.entities.ai;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -40,7 +42,37 @@ class LongRetryMemoTest {
   void reachingTheTargetClearsTheMemory() {
     LongRetryMemo memo = new LongRetryMemo();
     memo.failed(POST, STUCK, 1_000L);
-    memo.reached();
+    memo.reached(POST);
     assertTrue(memo.worthRetrying(POST, STUCK, 1_001L));
+  }
+
+  @Test
+  void aVillagerCyclingRoundTheCellsBesideAChestIsHeldBackOnEveryCell() {
+    LongRetryMemo memo = new LongRetryMemo();
+    List<Set<BlockPos>> ring = new ArrayList<>();
+    for (int dx = -1; dx <= 1; dx++) {
+      for (int dz = -1; dz <= 1; dz++) {
+        ring.add(Set.of(new BlockPos(6601 + dx, 64, 2414 + dz)));
+      }
+    }
+    long now = 1_000L;
+    for (Set<BlockPos> cell : ring) {
+      assertTrue(memo.worthRetrying(cell, STUCK, now));
+      memo.failed(cell, STUCK, now++);
+    }
+    // The second time round, within the cooldown, every cell is held back.
+    for (Set<BlockPos> cell : ring) {
+      assertFalse(memo.worthRetrying(cell, STUCK, now++));
+    }
+  }
+
+  @Test
+  void theOldestFailureMakesWayWhenMoreThanCapacityAreRemembered() {
+    LongRetryMemo memo = new LongRetryMemo();
+    for (int i = 0; i <= LongRetryMemo.CAPACITY; i++) {
+      memo.failed(Set.of(new BlockPos(i, 64, 0)), STUCK, 1_000L);
+    }
+    assertTrue(memo.worthRetrying(Set.of(new BlockPos(0, 64, 0)), STUCK, 1_001L));
+    assertFalse(memo.worthRetrying(Set.of(new BlockPos(LongRetryMemo.CAPACITY, 64, 0)), STUCK, 1_001L));
   }
 }


### PR DESCRIPTION
Refs #138. Second hotspot found after the woodland-pass fix (#139) was deployed.

## What

An exact destination the ordinary 48-block search cannot reach is retried with a 128-block horizon and double the node budget (for posts like a watch platform whose way in is a long detour). Workers re-plan every ten ticks, so a stuck worker, or one whose post is walled off, ran that retry on every re-plan.

Live server, first five minutes after the #139 deploy:

| | |
| --- | --- |
| Path searches | 59,902 (108 s of server time) |
| Long retries | 16,578 searches, 41.6 s: 38% of path time |
| Long retries that reached their target | 195 (1.2%) |
| Costliest | Casimir Hardy, 200 retries to a post 11 blocks away, 6.4 s, every one at the node limit; Wilfred Hardin, 10.5 s across posts 5 to 6 blocks away |
| Share of long-retry time on targets retried 3+ times | 77% |

A long retry also sat under the 12:28 watchdog kill (a miner's shaft waypoint, `MINE_WAYPOINT_ACCURACY = 0`).

## Fix

`LongRetryMemo` keeps the last failed long retry per navigator: the same targets are not retried for five seconds unless the person has moved four blocks since; a retry that reaches its target clears it. The first long search for any target still runs, so watch-platform detours keep working.

## Verification

- `./gradlew test`: 549 tests, 0 failures (new `LongRetryMemoTest`).
- A/B on two copies of the 12:42 world, current live jar against this branch, same three minutes: numbers in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)