### PR TITLE
Path: one shared time budget for long retries, so a burst of them cannot hold up a tick

### DIFF
--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -964,7 +964,7 @@ the lodge reaches up to ninety blocks, while one path search never goes further 
 forty-eight. Every tree past that was asked about anyway, up to four searches a tree, and each
 failed search spends its whole node budget first. On the live server one lumberjack ran 2,325 such
 searches in six minutes and reached 19 trees; the scans held the server at five ticks a second,
-and one held a tick past the sixty-second watchdog and took the server down. A pass now considers
+and the watchdog took the server down (below four ticks a second it does, see below). A pass now considers
 only trees within one search's reach of where the worker stands, asks about them nearest first,
 spends at most six searches in total, and leaves a tree it found no way to out of that worker's
 scans for two minutes. The nearest reachable tree is taken rather than a random one. Trimming a
@@ -980,6 +980,31 @@ retry is now not repeated for the same target for five seconds unless the person
 blocks since (`LongRetryMemo`), and one that reaches its target clears it. The last sixteen failures
 are kept, not one: a villager stuck beside a chest asks for each of the nine cells round it in
 turn, and a single remembered failure was forgotten before its cell came round again.
+
+**Long retries share a time budget, 2026-09-12 (#138).** The memo stops a person asking again
+for a target that just failed, not the first asking, and first askings come in bursts: a villager
+trying the twelve cells round a chest ran twelve long searches in one tick, a miner's shaft hop
+is an exact target too, and in the live server's busiest seconds long retries expanded 25,000 to
+80,000 nodes. The retries of every person now draw on one budget of server-thread time
+(`LongRetryBudget`): five milliseconds a tick, of which ten at most can be saved up. A retry
+starts while any time is left and is charged what it took, so over any stretch of ticks long
+retries cost at most the refill, plus ten milliseconds, plus one search. A retry the budget cannot
+pay for does not run: the caller keeps the ordinary search's answer, nothing is remembered as
+failed, and the next re-plan asks again, so a watch platform or ramp waypoint that only a long
+retry finds is found a few re-plans later rather than at once. Time is counted rather than nodes
+because the cost of a node is what moves: three microseconds on the warm server, over twenty in
+the first minutes after a start, which is when a restarted server is most at risk.
+`dev/LongRetryVerification` replays the burst: 96 exact requests in one tick from lanes that run
+past the 48-block horizon onto open ground, and a corridor target only a long retry can reach.
+
+**The watchdog kills a slow server, not only a stuck one.** Its "a single server tick took 60
+seconds" measures how far the server has fallen behind its tick schedule, and the server only
+jumps the schedule forward (the "Can't keep up" warning) once every 300 ticks. Below four ticks a
+second those 300 ticks take more than 75 seconds, so the lag passes sixty before the jump comes.
+The 12:28 kill on 2026-09-12 came two minutes after a restart: the server thread was still logging
+path searches when the watchdog reported, and its own "Can't keep up, 62,578 ms behind" followed
+four seconds later. A crash report's stack is where the thread happened to be at that moment,
+which is wherever it spends most of its time; sample the thread before blaming one call.
 
 **Attached bee nests (2026-09-08).** Shared tree felling also removes unowned bee nests
 and beehives touching a log actually removed, once each. It releases occupants normally;

--- a/src/main/java/com/quzzar/kithkyn/dev/LongRetryVerification.java
+++ b/src/main/java/com/quzzar/kithkyn/dev/LongRetryVerification.java
@@ -1,0 +1,215 @@
+package com.quzzar.kithkyn.dev;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.quzzar.kithkyn.Kithkyn;
+import com.quzzar.kithkyn.PersonEntityType;
+import com.quzzar.kithkyn.entities.RealPerson;
+import com.quzzar.kithkyn.entities.ai.PersonPathNavigation;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.pathfinder.Path;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+
+/**
+ * Opt-in regression for what the long path retry costs a tick. Use
+ * -Dkithkyn.longRetry.verify=true in a disposable flat world.
+ *
+ * <p>Eight people stand at the closed end of eight walled lanes that run 56
+ * blocks, past the ordinary search's 48-block horizon, onto open ground. In one
+ * tick each asks for twelve sealed cells beside their lane, the way a villager
+ * tries the cells round a chest. Every ordinary search stops cheaply at the
+ * horizon and every long retry floods the open ground to its node limit, so
+ * without a budget that one tick pays for 96 long searches: the per-tick cost
+ * behind the watchdog kills of 2026-09-12. The same requests at accuracy 1,
+ * which never retry, give the tick's cost without them.
+ *
+ * <p>A ninth person's exact target is four blocks away through a wall, and the
+ * only way to it is a U-shaped corridor whose far end lies 56 blocks out, like a
+ * watch platform whose way in is a long detour: only a long retry finds it. It
+ * must be found with the budget full, including at the start of the burst tick;
+ * it must not be found once the burst has spent that tick's budget, which is
+ * what shows the budget bounds the tick; and it must be found again within a
+ * few re-plans, which shows the budget does not starve a long route.
+ */
+@EventBusSubscriber(modid = Kithkyn.MODID)
+public final class LongRetryVerification {
+  private static final String TAG = "[long-retry-verify]";
+  private static final int LANES = 8;
+  private static final int CELLS = 12;
+  private static final int LANE_LENGTH = 56;
+  /** West end of the lanes, which run east onto open ground. */
+  private static final int BURST_X = 64;
+  private static final int BURST_Z = 64;
+  /** West end of the U-shaped corridor, closed on every side. */
+  private static final int DETOUR_X = 64;
+  private static final int DETOUR_Z = -64;
+  /** Ticks after the fixture is built at which the burst comes, with the budget long refilled. */
+  private static final int BURST_AT = 30;
+  /** How soon after the burst the corridor target must be found again: ten seconds. */
+  private static final int REFOUND_WITHIN_TICKS = 200;
+  /** A work loop's re-plan cadence. */
+  private static final int REPLAN_TICKS = 10;
+
+  private static final List<RealPerson> askers = new ArrayList<>();
+  private static final List<List<BlockPos>> sealedCells = new ArrayList<>();
+  private static RealPerson detourWalker;
+  private static BlockPos detourTarget;
+  private static int surfaceY;
+  private static int ticks;
+  private static int builtTick;
+  private static int burstTick;
+  private static long baselineNanos;
+
+  private LongRetryVerification() { }
+
+  @SubscribeEvent
+  public static void tick(ServerTickEvent.Post event) {
+    if (!Boolean.getBoolean("kithkyn.longRetry.verify")) return;
+    ticks++;
+    ServerLevel level = event.getServer().overworld();
+    try {
+      if (ticks == 1) {
+        forEachFixtureChunk((x, z) -> level.setChunkForced(x, z, true));
+        return;
+      }
+      if (builtTick == 0) {
+        if (ticks >= 60 && fixtureLoaded(level)) {
+          build(level);
+          builtTick = ticks;
+        } else if (ticks > 1200) {
+          throw new AssertionError("fixture chunks never loaded");
+        }
+        return;
+      }
+      int since = ticks - builtTick;
+      if (since == 10) {
+        check(foundDetour(), "the corridor target was not found with the budget full");
+        Kithkyn.LOGGER.info("{} corridor target, {} blocks of walking away, found at the first ask",
+            TAG, 2 * LANE_LENGTH + 4);
+      } else if (since == 11) {
+        ask(1); // warms the search code, so the baseline and the burst compare like with like
+      } else if (since == 12) {
+        baselineNanos = ask(1);
+        Kithkyn.LOGGER.info("{} baseline: {} requests at accuracy 1, which never retry, took {} ms",
+            TAG, LANES * CELLS, baselineNanos / 1_000_000L);
+      } else if (since == BURST_AT) {
+        check(foundDetour(), "the first long retry of a tick did not run with the budget full");
+        Kithkyn.LOGGER.info("{} burst begins", TAG);
+        long burstNanos = ask(0);
+        Kithkyn.LOGGER.info("{} burst ends", TAG);
+        Kithkyn.LOGGER.info("{} burst: {} exact requests in one tick took {} ms, {} ms more than the baseline",
+            TAG, LANES * CELLS, burstNanos / 1_000_000L, (burstNanos - baselineNanos) / 1_000_000L);
+        check(!foundDetour(), "a long retry still ran after the burst, in the same tick: nothing bounds them");
+        burstTick = ticks;
+      } else if (burstTick > 0 && (ticks - burstTick) % REPLAN_TICKS == 0) {
+        if (foundDetour()) {
+          Kithkyn.LOGGER.info("{} RESULT PASS: the burst's long retries stopped once the tick's budget was spent; "
+              + "the corridor target was found with the budget full, deferred once it was spent, and found again "
+              + "{} ticks later", TAG, ticks - burstTick);
+          event.getServer().halt(false);
+        } else if (ticks - burstTick >= REFOUND_WITHIN_TICKS) {
+          throw new AssertionError("the corridor target was not found again within "
+              + REFOUND_WITHIN_TICKS + " ticks of the burst");
+        }
+      }
+    } catch (Exception | AssertionError failure) {
+      Kithkyn.LOGGER.error("{} RESULT FAIL", TAG, failure);
+      event.getServer().halt(false);
+    }
+  }
+
+  /** Every asker asks for each of their sealed cells; returns how long that took. */
+  private static long ask(int accuracy) {
+    long started = System.nanoTime();
+    for (int lane = 0; lane < LANES; lane++) {
+      RealPerson asker = askers.get(lane);
+      for (BlockPos cell : sealedCells.get(lane)) {
+        Path path = asker.getNavigation().createPath(cell, accuracy);
+        check(path == null || !path.canReach(), "a sealed cell was reached: " + cell);
+      }
+    }
+    return System.nanoTime() - started;
+  }
+
+  private static boolean foundDetour() {
+    Path path = detourWalker.getNavigation().createPath(detourTarget, 0);
+    return path != null && path.canReach() && path.getEndNode() != null
+        && path.getEndNode().asBlockPos().equals(detourTarget);
+  }
+
+  private static void build(ServerLevel level) {
+    surfaceY = level.getHeight(Heightmap.Types.MOTION_BLOCKING, BURST_X, BURST_Z);
+    check(level.getHeight(Heightmap.Types.MOTION_BLOCKING, DETOUR_X, DETOUR_Z) == surfaceY, "the world is not flat");
+    // Lanes along every fourth row of a two-high stone block, open at the east
+    // end, with a row of sealed single cells between each lane and the next.
+    fill(level, BURST_X - 1, BURST_Z - 1, BURST_X + LANE_LENGTH - 1, BURST_Z + 4 * LANES - 1, true);
+    for (int lane = 0; lane < LANES; lane++) {
+      int z = BURST_Z + 4 * lane;
+      fill(level, BURST_X, z, BURST_X + LANE_LENGTH - 1, z, false);
+      List<BlockPos> cells = new ArrayList<>();
+      for (int cell = 0; cell < CELLS; cell++) {
+        BlockPos sealed = new BlockPos(BURST_X + 1 + 2 * cell, surfaceY, z + 2);
+        level.setBlock(sealed, Blocks.AIR.defaultBlockState(), 2);
+        cells.add(sealed);
+      }
+      sealedCells.add(cells);
+      askers.add(person(level, new BlockPos(BURST_X, surfaceY, z)));
+    }
+    // The corridor: east from the walker, north at the far end, and back west
+    // to a target four blocks from where the walker stands.
+    fill(level, DETOUR_X - 1, DETOUR_Z - 1, DETOUR_X + LANE_LENGTH + 1, DETOUR_Z + 5, true);
+    fill(level, DETOUR_X, DETOUR_Z, DETOUR_X + LANE_LENGTH, DETOUR_Z, false);
+    fill(level, DETOUR_X + LANE_LENGTH, DETOUR_Z, DETOUR_X + LANE_LENGTH, DETOUR_Z + 4, false);
+    fill(level, DETOUR_X, DETOUR_Z + 4, DETOUR_X + LANE_LENGTH, DETOUR_Z + 4, false);
+    detourTarget = new BlockPos(DETOUR_X, surfaceY, DETOUR_Z + 4);
+    detourWalker = person(level, new BlockPos(DETOUR_X, surfaceY, DETOUR_Z));
+    check(PersonPathNavigation.searchRange(detourWalker) < LANE_LENGTH,
+        "the corridor's far end is within one ordinary search");
+  }
+
+  /** Stone or air two blocks high over a rectangle of ground. */
+  private static void fill(ServerLevel level, int minX, int minZ, int maxX, int maxZ, boolean stone) {
+    BlockState state = stone ? Blocks.STONE.defaultBlockState() : Blocks.AIR.defaultBlockState();
+    for (BlockPos pos : BlockPos.betweenClosed(minX, surfaceY, minZ, maxX, surfaceY + 1, maxZ)) {
+      level.setBlock(pos, state, 2);
+    }
+  }
+
+  /** A person standing at {@code feet}, never added to the level, so no goal of theirs moves them. */
+  private static RealPerson person(ServerLevel level, BlockPos feet) {
+    RealPerson person = PersonEntityType.PERSON.get().create(level);
+    check(person != null, "no person entity");
+    person.moveTo(feet.getX() + 0.5D, feet.getY(), feet.getZ() + 0.5D, 0.0F, 0.0F);
+    person.setOnGround(true);
+    return person;
+  }
+
+  private static boolean fixtureLoaded(ServerLevel level) {
+    boolean[] loaded = {true};
+    forEachFixtureChunk((x, z) -> loaded[0] &= level.getChunkSource().hasChunk(x, z));
+    return loaded[0];
+  }
+
+  /** The chunks under the lanes, the ground a long retry floods past them, and the corridor. */
+  private static void forEachFixtureChunk(ChunkVisitor visitor) {
+    for (int x = 3; x <= 11; x++) for (int z = 0; z <= 9; z++) visitor.visit(x, z);
+    for (int x = 3; x <= 8; x++) for (int z = -5; z <= -4; z++) visitor.visit(x, z);
+  }
+
+  @FunctionalInterface
+  private interface ChunkVisitor {
+    void visit(int x, int z);
+  }
+
+  private static void check(boolean condition, String message) {
+    if (!condition) throw new AssertionError(message);
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/LongRetryBudget.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/LongRetryBudget.java
@@ -1,0 +1,67 @@
+package com.quzzar.kithkyn.entities.ai;
+
+/**
+ * How much server-thread time the long path retries of every person may take
+ * between them, so a burst of them cannot hold up a tick.
+ *
+ * <p>{@link PersonPathNavigation} retries an exact destination that the
+ * ordinary 48-block search cannot reach with a 128-block horizon and double the
+ * node budget, for posts such as a watch platform whose way in is a long
+ * detour. One such search costs a few milliseconds on a warm server and up to
+ * ten times that in the first minutes after a start or on a busy machine, and
+ * most of them fail. {@link LongRetryMemo} stops a person asking again for a
+ * target that just failed, but not the first asking: a villager trying the
+ * twelve cells round a chest ran twelve long searches in one tick, a miner's
+ * shaft hop is an exact target too, and workers re-planning together ran theirs
+ * in the same tick. On 2026-09-12 the live server, two minutes after a restart,
+ * spent about half its time in path searches and was killed by the watchdog.
+ *
+ * <p>The budget is a bucket of time. It refills {@link #REFILL_NANOS_PER_TICK}
+ * a tick, up to {@link #CAPACITY_NANOS}. A long retry may start while anything
+ * is left and is charged what it actually took, so the one that empties the
+ * bucket can overdraw it, and the refill pays that back before the next one may
+ * start. Over any stretch of ticks, long retries take at most the capacity, plus
+ * the refill for each tick, plus one search. Time rather than nodes is counted
+ * because the cost of a node is what varies: the same search took 3 microseconds
+ * a node on the warm server and over 20 two minutes after a restart.
+ *
+ * <p>A retry the bucket cannot pay for does not run. The caller keeps the
+ * ordinary search's answer, exactly as if the retry had failed, and nothing is
+ * remembered as failed, so the person asks again at their next re-plan.
+ */
+public final class LongRetryBudget {
+
+  /** Time added each tick: five milliseconds, a tenth of a tick. */
+  public static final long REFILL_NANOS_PER_TICK = 5_000_000L;
+
+  /** Most time the bucket holds: ten milliseconds, a fifth of a tick. */
+  public static final long CAPACITY_NANOS = 10_000_000L;
+
+  private long balance = CAPACITY_NANOS;
+  private long refilledAt;
+
+  /** Whether a long retry may start at this game time: while any time is left. */
+  public boolean admits(long gameTime) {
+    refill(gameTime);
+    return this.balance > 0L;
+  }
+
+  /** A long retry at this game time took {@code nanos} of server-thread time. */
+  public void charge(long gameTime, long nanos) {
+    refill(gameTime);
+    this.balance -= Math.max(0L, nanos);
+  }
+
+  private void refill(long gameTime) {
+    if (gameTime < this.refilledAt) {
+      // Game time only runs backwards when another world is loaded: it starts full.
+      this.balance = CAPACITY_NANOS;
+    } else {
+      long elapsed = gameTime - this.refilledAt;
+      long ticksToFull = Math.ceilDiv(CAPACITY_NANOS - this.balance, REFILL_NANOS_PER_TICK);
+      this.balance = elapsed >= ticksToFull
+          ? CAPACITY_NANOS : this.balance + elapsed * REFILL_NANOS_PER_TICK;
+    }
+    this.refilledAt = gameTime;
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
@@ -101,6 +101,13 @@ public final class PersonPathNavigation extends GroundPathNavigation {
   /** Squared distance of one diagonal stair step in the mine. */
   private static final double ADJACENT_MINE_STEP_SQR = 3.0D;
 
+  /**
+   * The server-thread time long retries may take, shared by every person in
+   * every dimension: one thread runs all their path searches, and it is that
+   * thread's ticks the budget keeps.
+   */
+  private static final LongRetryBudget LONG_RETRY_BUDGET = new LongRetryBudget();
+
   @Nullable
   private String lastMinePathFailure;
 
@@ -143,11 +150,22 @@ public final class PersonPathNavigation extends GroundPathNavigation {
     // Reaching a watch platform can take more than 48 blocks of walking even
     // when it is nearby in a straight line. Retry exact work destinations with
     // a longer horizon and bounded extra search work, retaining loaded chunks.
-    // A retry that just failed from here is not asked again (LongRetryMemo).
+    // A retry that just failed from here is not asked again (LongRetryMemo), and
+    // one the shared budget cannot pay for now waits for a later re-plan
+    // (LongRetryBudget). A mine shaft hop is an exact target, so it comes here too.
     long now = this.level.getGameTime();
     if (accuracy == 0 && range < EXACT_SEARCH_RANGE && (route == null || !route.canReach())
         && this.longRetry.worthRetrying(targets, this.mob.blockPosition(), now)) {
+      if (!LONG_RETRY_BUDGET.admits(now)) {
+        if (Kithkyn.LOGGER.isDebugEnabled()) {
+          Kithkyn.LOGGER.debug("[path-budget] {} at {} to {}: long retry deferred",
+              this.mob.getName().getString(), this.mob.blockPosition(), targets);
+        }
+        return route;
+      }
+      long started = System.nanoTime();
       Path longer = super.createPath(targets, regionOffset, offsetUpward, accuracy, EXACT_SEARCH_RANGE);
+      LONG_RETRY_BUDGET.charge(now, System.nanoTime() - started);
       if (longer != null && longer.canReach()) {
         this.longRetry.reached(targets);
       } else {

--- a/src/test/java/com/quzzar/kithkyn/entities/ai/LongRetryBudgetTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ai/LongRetryBudgetTest.java
@@ -1,0 +1,85 @@
+package com.quzzar.kithkyn.entities.ai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class LongRetryBudgetTest {
+
+  private static final long MILLISECOND = 1_000_000L;
+
+  @Test
+  void aFreshBudgetAdmitsARetry() {
+    assertTrue(new LongRetryBudget().admits(1_000L));
+  }
+
+  @Test
+  void theRetryThatEmptiesTheBucketHoldsBackTheRestOfTheTick() {
+    LongRetryBudget budget = new LongRetryBudget();
+    assertTrue(budget.admits(1_000L));
+    budget.charge(1_000L, 50 * MILLISECOND); // one long search two minutes after a restart
+    assertFalse(budget.admits(1_000L));
+  }
+
+  @Test
+  void aBurstOfExactRequestsInOneTickRunsOnlyWhatTheBucketHolds() {
+    // Twelve cells round a chest, all asked in the same tick, each long search taking 4 ms.
+    long search = 4 * MILLISECOND;
+    LongRetryBudget budget = new LongRetryBudget();
+    int ran = 0;
+    for (int cell = 0; cell < 12; cell++) {
+      if (budget.admits(1_000L)) {
+        budget.charge(1_000L, search);
+        ran++;
+      }
+    }
+    assertEquals(Math.ceilDiv(LongRetryBudget.CAPACITY_NANOS, search), ran);
+  }
+
+  @Test
+  void anOverdraftIsPaidBackAtTheRefillRateBeforeTheNextRetry() {
+    LongRetryBudget budget = new LongRetryBudget();
+    budget.charge(1_000L, LongRetryBudget.CAPACITY_NANOS + 3 * LongRetryBudget.REFILL_NANOS_PER_TICK);
+    assertFalse(budget.admits(1_003L)); // three ticks of refill only clear the debt
+    assertTrue(budget.admits(1_004L));
+  }
+
+  @Test
+  void idleTicksNeverSaveMoreThanTheCapacity() {
+    LongRetryBudget budget = new LongRetryBudget();
+    budget.charge(1_000L, LongRetryBudget.CAPACITY_NANOS);
+    assertTrue(budget.admits(100_000L));
+    budget.charge(100_000L, LongRetryBudget.CAPACITY_NANOS);
+    assertFalse(budget.admits(100_000L));
+  }
+
+  @Test
+  void overAnyStretchOfTicksLongRetriesTakeTheRefillAndNeverMore() {
+    // Five people wanting a 12 ms long retry every tick, for twenty seconds.
+    long search = 12 * MILLISECOND;
+    int ticks = 400;
+    LongRetryBudget budget = new LongRetryBudget();
+    long spent = 0L;
+    for (long tick = 1_000L; tick < 1_000L + ticks; tick++) {
+      for (int asker = 0; asker < 5; asker++) {
+        if (budget.admits(tick)) {
+          budget.charge(tick, search);
+          spent += search;
+        }
+      }
+    }
+    long refill = ticks * LongRetryBudget.REFILL_NANOS_PER_TICK;
+    assertTrue(spent <= LongRetryBudget.CAPACITY_NANOS + refill + search, "over budget: " + spent);
+    assertTrue(spent >= refill - search, "the refill went unused: " + spent);
+  }
+
+  @Test
+  void anotherWorldStartsWithAFullBucket() {
+    LongRetryBudget budget = new LongRetryBudget();
+    budget.charge(50_000L, 10 * LongRetryBudget.CAPACITY_NANOS);
+    assertFalse(budget.admits(50_001L));
+    assertTrue(budget.admits(20L)); // game time ran backwards: a different world was loaded
+  }
+}


### PR DESCRIPTION
Refs #138. The third path hotspot behind the 2026-09-12 watchdog kills, after the woodland pass (#139) and repeated long retries (#141).

## What the 12:28 kill was

`crash-2026-09-12_12.28.15` was not one 60-second tick. The watchdog measures how far the server has fallen behind its tick schedule, and the server only jumps that schedule forward (the "Can't keep up" warning) once every 300 ticks. Below 4 TPS, those 300 ticks take more than 75 s and the lag passes 60 s first. From the release log:

- 12:26:42 the server is up again after the 12:23 kill; at 12:26:56, "Can't keep up … 13,201 ms behind"
- 12:28:10 the watchdog reports "A single server tick took 60.01 seconds"
- 12:28:11 to 12:28:14 the server thread goes on logging path searches
- 12:28:14 the server's own warning: "Can't keep up … 62,578 ms behind"

That works out to about 3.9 TPS for 78 s. Path search took about 455 ms of every second, a third of it long retries, on a cold JIT: 21 µs a node, against 3 to 4 µs once warm. Also in that window were the pre-#139 woodland pass (one lumberjack at 45 capped searches a second) and an 11-second `save-all` from a gallery placement at 12:27:25. The crash report's stack only shows where the thread happened to be.

The leads, checked:

- **Several exact retries in one tick: confirmed.** A villager's candidate scan (`ContainerAccess` 12, `ConstructionAccess` and `WallStep` 8, `RepairStep` 8) runs one long retry per candidate in the same tick. The #141 memo keys on the target, so every first asking runs, and the cooldowns then expire together. On the live server since 13:51, Tobias Henderson's eight cells round one chest were retried all in the same second 210 times. The busiest seconds reach 25,000 to 80,000 long-retry nodes. A mine hop is an exact target (`MINE_WAYPOINT_ACCURACY = 0`), so every failed hop paid for the 128-block retry as well.
- **Block reads outside the navigation region: no chunk loading.** `WorkerFooting.standingPosition` reads the live level, but guards with `hasChunkAt`, and `noCollision` never loads chunks. The per-node cost follows the JIT and the machine's load: 10.9, then 6.4, then 3.4 µs a node over the first three minutes of the 13:51 server.
- **Skipping retries that provably cannot help: measured and dropped.** In 72% of long retries the ordinary search had emptied its open set inside the horizon, but together they come to 0.1% of long-retry nodes: 1- to 4-node searches by villagers stuck in pockets. The cost sits in retries the horizon cut short (54% of nodes, and 29% of those reach their target, so they are real detours) and in retries whose ordinary search hit the node limit (46%, 4% reach).

## Fix

`LongRetryBudget` is one bucket of server-thread time shared by every person, since one thread runs all their searches. It refills 5 ms a tick and holds 10 ms at most. A retry starts while anything is left and is charged what it took, so over any T ticks long retries cost at most 10 ms + 5 ms × T + one search. A retry the bucket cannot pay for is deferred. The caller keeps the ordinary search's answer, exactly as if the retry had failed, the memo is left alone, and the next re-plan asks again (every 10 ticks for a work loop, every 40 for a guard's post).

The bucket counts time rather than nodes because a node's cost moves 10× with JIT warmth and machine load, and a cold start is when a restarted server is most at risk. Warm demand on the live server averages about 2 ms of long retries a tick, so steady play rarely defers anything; bursts and cold starts get spread out. Deferrals log at debug as `[path-budget]`.

## Verification

- `./gradlew build`: 559 tests (8 skipped), 0 failures, and the template audit passes; the new tests are `LongRetryBudgetTest` (7 cases: burst admission, overdraft payback, the capacity cap, a 400-tick bound, a world switch).
- `dev/LongRetryVerification` (new, `-Dkithkyn.longRetry.verify=true`) runs in a flat world. Eight people each ask, in one tick, for 12 sealed cells, from lanes that run past the 48-block horizon onto open ground. A U-shaped corridor target that only a long retry reaches is asked for first with the budget full, and again after the burst in the same tick. The same harness ran on both trees:

| | origin/main (8388277) | this branch |
| --- | --- | --- |
| Long searches run in the burst tick | 96 | 1 |
| Long-search time in that tick | 6,874 ms | 47 ms |
| Retries deferred | 0 | 95 |
| Burst tick, vs the same requests without retries | 7,425 ms vs 1,175 ms | 222 ms vs 265 ms |
| Result | FAIL: a long retry still ran after the burst, in the same tick | PASS: corridor target found at the first ask, deferred once the tick's budget was spent, found again 10 ticks later |

  Both ran at background QoS on the efficiency cores of a shared machine, so the absolute times run high. The counts are what matter.
- Long routes still work, on this branch: `BirchVillageVerification` in mine-entry mode passes (excavated mine exit and re-entry in all four rotations, eight real walks through the shaft hops), and `GateAccessVerification` passes (eight guards up and down ladders to wall posts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
