### PR TITLE
Cleric works from the off hand, drinks potions, and judges throws by who they reach

### DIFF
--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -317,8 +317,8 @@ two health every ten seconds everyone gets. Below a third of their health, with 
 fight, a villager takes a bite a second until they are back over the line
 (`PersonEatFoodGoal`). A bite heals by Aaron's rule: the food's nutrition as hearts plus a
 quarter of its saturation as hearts, so an apple heals about four and a half hearts and cooked
-beef more than a full bar (`Person.eatFood`). A meal is anything edible in the off hand or the
-pack: only guards are issued rations (topped up to six bites at the bedtime restock from the
+beef more than a full bar (`Person.eatFood`). A meal is food in the off hand or the
+pack (a potion is not: it is drunk when it would help, see the cleric's potions below): only guards are issued rations (topped up to six bites at the bedtime restock from the
 village's own food, best first by what a bite heals, never conjured: a village with no food
 logs the shortage and the guard goes without), but a fisher
 carries cod and a farmer carrots, and food from the pack is brought to the off hand for the
@@ -358,25 +358,38 @@ has not thrown, so a cleric out of potions cannot pin a patient for the day.
 ## The cleric's potions are stock
 
 Decided 2026-09-12. A cleric's potions are real items, not a spell (`ClericPotions`). Every
-throw consumes one splash potion from the cleric's hands or pack, and what the cleric carries
-decides what they can do:
+potion used is a real bottle from the cleric's hands or pack, and what the cleric carries
+decides what they can do. How a bottle is used follows from what it is (Aaron, 2026-09-12): an
+ordinary potion is drunk, a splash or lingering potion is thrown. Whether a throw goes to a
+friend or a foe follows from what the brew would do to the body it lands on, so a splash of
+healing burns the undead, a splash of harming heals them, and poison and regeneration do not
+take on them at all:
 
 - **Healing** (`HealStep`): a hurt villager or player within ten blocks gets a splash of
-  healing when nearly dead and regeneration otherwise, whichever the cleric carries, and
-  nothing when they carry neither to spare.
-- **Harm** (`ThrowPotionAttackGoal`): a cleric carrying a harmful splash potion (harming,
-  poison, weakness, slowness: every effect of it hurts) acquires hostile mobs as targets and
-  throws it at them. A cleric carrying only healing never acquires a target. Two rules are
+  healing when nearly dead and regeneration otherwise, then anything else that mends
+  (absorption, health boost), whichever the cleric carries, and nothing when they carry none to
+  spare. The brew must help that patient as a whole, and it is never thrown while an enemy
+  stands inside the burst or in the way (Aaron, 2026-09-12): the cleric holds the throw until
+  the enemy is clear.
+- **Harm** (`ThrowPotionAttackGoal`): a cleric carrying a harmful splash or lingering potion
+  (harming, poison, weakness, slowness: every effect of it hurts) acquires hostile mobs it would
+  hurt as targets and throws it at them, so a splash of harming is never thrown at a zombie. A
+  cleric carrying only healing never acquires a target. Two rules are
   absolute: harm is never thrown while an ally stands inside the burst around the target, and
   never through a friend in the way; the cleric closes in and waits for a clear throw instead.
   Harm sits ahead of healing at the same priority, so a cleric with both fights first and tends
   after.
+- **Drinking** (`DrinkPotionGoal`, any villager): an ordinary potion is drunk when it answers
+  what is wrong right now: water breathing when out of air under water, fire resistance when
+  burning, and below two thirds of health healing, regeneration, absorption or health boost.
+  Only a potion that helps the drinker as a whole is drunk, so nobody drinks harm, and a cleric
+  never drinks the seed. Potions are not meals: the eating path could never finish a drink.
 - **Brewing** (`BrewStep`): at their station, a cleric turns one carried potion of a brew into
   three more of it, in a session as long as a brewing stand's. The stand needs nothing put in
   it: the carried bottle is the recipe. The brew furthest below four carried is made first.
   Potions do not stack, so each bottle needs a pack slot, and a full pack waits.
 
-The last bottle of a brew is the **seed**. It is never thrown and never given away in
+The last bottle of a brew is the **seed**. It is never thrown or drunk, and never given away in
 conversation, because a cleric who parts with it has lost the brew for good and would have to
 be handed another before making more. The clean half of that rule is in the chat briefing: a
 cleric is told the bottles they can spare of each brew, "you have this many minus one", so a
@@ -385,9 +398,14 @@ the brews held in reserve and why, so the cleric also knows what they can brew. 
 (`PersonChatDispatcher.takeFromSlots`) caps at the spare as a backstop, the one exception to
 "anything goes". Above the seed, potions are theirs to give like anything else.
 
-The loadout is issued, not authored. Every cleric starts with a splash of regeneration and a
-splash of healing (`SignatureGear`). At bedtime, before the pack is shelved (their potions are
-kept, like a guard's weapons), a cleric lifts one bottle of every splash brew the village stores
+The loadout is issued, not authored. Every cleric starts with a splash of regeneration in the
+off hand, and a splash of healing and a potion of regeneration in the pack (`SignatureGear`).
+Each is the seed of its brew, so a new cleric brews at their station before it throws or drinks
+any. The off hand is the cleric's one working slot (Aaron, 2026-09-12): it rests on the splash
+of regeneration, a bottle to throw or drink is swapped into it for the use, and the resting
+bottle comes back after (`OffHandUse`). The main hand stays empty; a bottle left there by the
+old two-handed kit goes into the pack. At bedtime, before the pack is shelved (their potions are
+kept, like a guard's weapons), a cleric lifts one bottle of every brew the village stores
 hold that they do not yet carry. So a player who leaves a splash of harming in a village chest
 has armed the cleric, and the swamp's witch circle is a cleric someone handed harm. The
 authored-per-station alternative, marking a church's station healer or battle-cleric, was

--- a/docs/worker-loops.md
+++ b/docs/worker-loops.md
@@ -404,7 +404,8 @@ Each is the seed of its brew, so a new cleric brews at their station before it t
 any. The off hand is the cleric's one working slot (Aaron, 2026-09-12): it rests on the splash
 of regeneration, a bottle to throw or drink is swapped into it for the use, and the resting
 bottle comes back after (`OffHandUse`). The main hand stays empty; a bottle left there by the
-old two-handed kit goes into the pack. At bedtime, before the pack is shelved (their potions are
+old two-handed kit goes into the pack, and a different bottle left in the off hand at rest is
+swapped for a splash of regeneration from the pack at the next daily tending. At bedtime, before the pack is shelved (their potions are
 kept, like a guard's weapons), a cleric lifts one bottle of every brew the village stores
 hold that they do not yet carry. So a player who leaves a splash of harming in a village chest
 has armed the cleric, and the swamp's witch circle is a cleric someone handed harm. The

--- a/src/main/java/com/quzzar/kithkyn/chat/PersonChatContext.java
+++ b/src/main/java/com/quzzar/kithkyn/chat/PersonChatContext.java
@@ -568,7 +568,7 @@ public final class PersonChatContext {
       if (stack.isEmpty()) {
         continue;
       }
-      if (cleric && ClericPotions.isThrowable(stack)) {
+      if (cleric && ClericPotions.isStock(stack)) {
         // Counted once per brew, as the spare, however many slots it fills.
         counts.putIfAbsent(itemName(stack), ClericPotions.sparePackCount(person, stack));
         continue;
@@ -599,7 +599,9 @@ public final class PersonChatContext {
       return "You carry no potions at all, so there is nothing you can brew more of until someone hands you a bottle.";
     }
     return "In reserve, not counted above and not for giving: one " + String.join(", one ", brews)
-        + ". Each is the recipe you brew three more of at your station; give the last one away and that brew is lost to you.";
+        + ". Each is the recipe you brew three more of at your station; give the last one away and that brew is lost to you."
+        + " You drink ordinary potions yourself when one would help you, and throw splash and lingering potions:"
+        + " helpful ones at friends when no enemy stands in the splash, harmful ones at enemies when no friend does.";
   }
 
   /**

--- a/src/main/java/com/quzzar/kithkyn/entities/ClericPotions.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ClericPotions.java
@@ -7,16 +7,21 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
+import com.quzzar.kithkyn.entities.ai.HealthRecoveryPolicy;
 import com.quzzar.kithkyn.village.Occupation;
 
+import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.Mth;
 import net.minecraft.world.Container;
+import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.monster.Enemy;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.ThrownPotion;
 import net.minecraft.world.item.Item;
@@ -28,21 +33,29 @@ import net.minecraft.world.phys.Vec3;
 /**
  * A cleric's potions are stock, not a spell (Aaron, 2026-09-12).
  *
- * <p>Every throw consumes one real splash potion from the cleric's hands or
- * pack, and what the cleric carries decides what they can do: a splash of
- * regeneration makes a healer, a splash of harming makes a hexer, and a cleric
- * carrying both chooses by target. Nothing is conjured. Stock is grown the one
- * way a cleric has, at their station ({@code BrewStep}): one carried potion of
- * a brew stands for the recipe, and a brewing session yields {@link #BREW_YIELD}
- * more of it. That seed is why the last potion of a brew is never thrown and
- * never given away ({@link #giveable}): a cleric who parts with it has lost the
+ * <p>Every potion a cleric uses is a real bottle from their hands or pack, and
+ * what they carry decides what they can do. How a bottle is used follows from
+ * what it is (Aaron, 2026-09-12): an ordinary potion is drunk by the cleric
+ * themselves ({@code DrinkPotionGoal}), and a splash or lingering potion is
+ * thrown. Whether a throw goes to a friend or a foe follows from what the brew
+ * would do to the body it lands on ({@link #outcomeOn}): a brew that helps goes
+ * to an ally, and only while no enemy stands in the splash; a brew that hurts
+ * goes to an enemy, and only while no ally does. What a brew does depends on the
+ * body, so a splash of healing burns the undead, a splash of harming heals them,
+ * and poison and regeneration do not take on them at all.
+ *
+ * <p>Nothing is conjured. Stock is grown the one way a cleric has, at their
+ * station ({@code BrewStep}): one carried potion of a brew stands for the
+ * recipe, and a brewing session yields {@link #BREW_YIELD} more of it. That seed
+ * is why the last potion of a brew is never thrown, drunk or given away
+ * ({@link #spare}, {@link #giveable}): a cleric who parts with it has lost the
  * brew for good, and would have to be handed another before making more.
  *
- * <p>A brew is the item plus its {@link PotionContents}: a splash of healing
- * and a splash of harming are both splash potions and are never confused. The
- * static helpers take the three places a villager keeps things so the rules
- * can be tested on plain containers; the {@link RealPerson} overloads read the
- * villager's own.
+ * <p>A brew is the item plus its {@link PotionContents}: a potion of
+ * regeneration and a splash of regeneration are different brews, as are a
+ * splash of healing and a splash of harming. The static helpers take the three
+ * places a villager keeps things so the rules can be tested on plain
+ * containers; the {@link RealPerson} overloads read the villager's own.
  */
 public final class ClericPotions {
 
@@ -56,10 +69,14 @@ public final class ClericPotions {
   public static final int BREW_TICKS = 400;
 
   /** The items a cleric's stock is kept in overnight rather than shelved with the rest of the pack. */
-  public static final Set<Item> STOCK_ITEMS = Set.of(Items.SPLASH_POTION, Items.LINGERING_POTION);
+  public static final Set<Item> STOCK_ITEMS = Set.of(Items.POTION, Items.SPLASH_POTION, Items.LINGERING_POTION);
 
   /** Below this the cleric reaches for instant healing over regeneration. */
   private static final float NEARLY_DEAD = 4.0F;
+
+  /** The effects that mend a hurt body: what a healer throws, and what a hurt villager drinks. */
+  private static final List<Holder<MobEffect>> MENDING = List.of(MobEffects.HEAL, MobEffects.REGENERATION,
+      MobEffects.ABSORPTION, MobEffects.HEALTH_BOOST);
 
   private ClericPotions() {
   }
@@ -68,8 +85,18 @@ public final class ClericPotions {
   public record Stock(ItemStack sample, int count) {
   }
 
-  /** A potion that can be thrown at all: a splash or lingering potion that does something. */
-  public static boolean isThrowable(ItemStack stack) {
+  /** What a brew would do to one body it reaches. */
+  public enum Outcome {
+    HELPS, HURTS, MIXED, NOTHING
+  }
+
+  /** What is wrong with a body right now that a potion could answer, most urgent first. */
+  public enum Need {
+    DROWNING, BURNING, HURT
+  }
+
+  /** A potion with an effect in it, of any kind: stock a cleric keeps, brews and uses. Water is not. */
+  public static boolean isStock(ItemStack stack) {
     if (stack.isEmpty() || !STOCK_ITEMS.contains(stack.getItem())) {
       return false;
     }
@@ -77,39 +104,81 @@ public final class ClericPotions {
     return contents != null && contents.getAllEffects().iterator().hasNext();
   }
 
-  /** A throwable brew whose every effect hurts: what a cleric throws at an enemy and never at a friend. */
-  public static boolean isHarmful(ItemStack stack) {
-    if (!isThrowable(stack)) {
-      return false;
-    }
-    for (MobEffectInstance effect : stack.get(DataComponents.POTION_CONTENTS).getAllEffects()) {
-      if (effect.getEffect().value().getCategory() != MobEffectCategory.HARMFUL) {
-        return false;
-      }
-    }
-    return true;
+  /** A splash or lingering potion that does something: thrown, never drunk. */
+  public static boolean isThrowable(ItemStack stack) {
+    return isStock(stack) && stack.getItem() != Items.POTION;
   }
 
-  /** A throwable brew with nothing harmful in it: what a cleric throws over the hurt. */
-  public static boolean isBeneficial(ItemStack stack) {
-    if (!isThrowable(stack)) {
-      return false;
+  /** An ordinary potion that does something: drunk, never thrown. */
+  public static boolean isDrinkable(ItemStack stack) {
+    return isStock(stack) && stack.getItem() == Items.POTION;
+  }
+
+  /**
+   * What the brew does to a body, given whether healing and harm trade places
+   * for it (the undead) and which of the brew's effects take on it at all.
+   * Neutral effects count for nothing either way.
+   */
+  public static Outcome outcome(ItemStack stack, boolean invertedHealAndHarm, Predicate<MobEffectInstance> takes) {
+    if (!isStock(stack)) {
+      return Outcome.NOTHING;
     }
+    boolean helps = false;
+    boolean hurts = false;
     for (MobEffectInstance effect : stack.get(DataComponents.POTION_CONTENTS).getAllEffects()) {
-      if (effect.getEffect().value().getCategory() == MobEffectCategory.HARMFUL) {
-        return false;
+      if (!takes.test(effect)) {
+        continue;
+      }
+      MobEffectCategory category = effect.getEffect().value().getCategory();
+      if (invertedHealAndHarm && effect.getEffect().equals(MobEffects.HEAL)) {
+        category = MobEffectCategory.HARMFUL;
+      } else if (invertedHealAndHarm && effect.getEffect().equals(MobEffects.HARM)) {
+        category = MobEffectCategory.BENEFICIAL;
+      }
+      if (category == MobEffectCategory.BENEFICIAL) {
+        helps = true;
+      } else if (category == MobEffectCategory.HARMFUL) {
+        hurts = true;
       }
     }
-    return true;
+    if (helps && hurts) {
+      return Outcome.MIXED;
+    }
+    return helps ? Outcome.HELPS : hurts ? Outcome.HURTS : Outcome.NOTHING;
+  }
+
+  /** What the brew does to this body, read from the body itself. */
+  public static Outcome outcomeOn(ItemStack stack, LivingEntity body) {
+    return outcome(stack, body.isInvertedHealAndHarm(), body::canBeAffected);
+  }
+
+  /** A brew whose every effect helps an ordinary living body. */
+  public static boolean isBeneficial(ItemStack stack) {
+    return outcome(stack, false, effect -> true) == Outcome.HELPS;
+  }
+
+  /** A brew whose every effect hurts an ordinary living body: what a cleric may fight with. */
+  public static boolean isHarmful(ItemStack stack) {
+    return outcome(stack, false, effect -> true) == Outcome.HURTS;
   }
 
   /** Whether the brew carries this effect, whatever else it does. */
-  public static boolean has(ItemStack stack, net.minecraft.core.Holder<net.minecraft.world.effect.MobEffect> effect) {
-    if (!isThrowable(stack)) {
+  public static boolean has(ItemStack stack, Holder<MobEffect> effect) {
+    if (!isStock(stack)) {
       return false;
     }
     for (MobEffectInstance instance : stack.get(DataComponents.POTION_CONTENTS).getAllEffects()) {
       if (instance.getEffect().equals(effect)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Whether the brew carries an effect that mends a hurt body. */
+  public static boolean mends(ItemStack stack) {
+    for (Holder<MobEffect> effect : MENDING) {
+      if (has(stack, effect)) {
         return true;
       }
     }
@@ -126,18 +195,18 @@ public final class ClericPotions {
     return ca != null && ca.equals(cb);
   }
 
-  /** Every throwable stack across the hands and the pack, live, in that order. */
+  /** Every stock stack across the hands and the pack, live, in that order. */
   static List<ItemStack> stacks(ItemStack mainHand, ItemStack offHand, Container pack) {
     List<ItemStack> out = new ArrayList<>();
-    if (isThrowable(mainHand)) {
+    if (isStock(mainHand)) {
       out.add(mainHand);
     }
-    if (isThrowable(offHand)) {
+    if (isStock(offHand)) {
       out.add(offHand);
     }
     for (int slot = 0; slot < pack.getContainerSize(); slot++) {
       ItemStack stack = pack.getItem(slot);
-      if (isThrowable(stack)) {
+      if (isStock(stack)) {
         out.add(stack);
       }
     }
@@ -176,17 +245,33 @@ public final class ClericPotions {
   }
 
   /**
-   * The stack to throw one of, for the first brew that passes the test and has
-   * a potion to spare, or null when none does. The seed is protected here: a
-   * brew with a single potion left is never offered, so throwing can never end
-   * a brew. Hands are preferred over the pack, which is where the mark of the
-   * trade already sits.
+   * The stack to use one of, for the first brew that passes the test and has a
+   * potion to spare, or null when none does. The seed is protected here: a brew
+   * with a single potion left is never offered, so no throw or drink can end a
+   * brew. Hands come before the pack: the off hand is where the cleric works.
    */
+  @Nullable
+  public static ItemStack spare(ItemStack mainHand, ItemStack offHand, Container pack, Predicate<ItemStack> kind) {
+    for (ItemStack stack : stacks(mainHand, offHand, pack)) {
+      if (kind.test(stack) && carried(mainHand, offHand, pack, stack) >= 2) {
+        return stack;
+      }
+    }
+    return null;
+  }
+
+  /** A splash or lingering potion to spare that passes the test, or null. */
   @Nullable
   public static ItemStack throwable(ItemStack mainHand, ItemStack offHand, Container pack,
       Predicate<ItemStack> kind) {
+    return spare(mainHand, offHand, pack, stack -> isThrowable(stack) && kind.test(stack));
+  }
+
+  /** The first carried stack that passes the test, seed or not, or null: for villagers who do not brew. */
+  @Nullable
+  static ItemStack first(ItemStack mainHand, ItemStack offHand, Container pack, Predicate<ItemStack> kind) {
     for (ItemStack stack : stacks(mainHand, offHand, pack)) {
-      if (kind.test(stack) && carried(mainHand, offHand, pack, stack) >= 2) {
+      if (kind.test(stack)) {
         return stack;
       }
     }
@@ -198,7 +283,7 @@ public final class ClericPotions {
    * potion of its brew. A stack that is not potion stock is entirely giveable.
    */
   public static int giveable(ItemStack mainHand, ItemStack offHand, Container pack, ItemStack stack) {
-    if (!isThrowable(stack)) {
+    if (!isStock(stack)) {
       return stack.getCount();
     }
     int total = carried(mainHand, offHand, pack, stack);
@@ -236,16 +321,52 @@ public final class ClericPotions {
   }
 
   /**
-   * The order a healer reaches for brews: instant healing when the patient is
-   * nearly dead, regeneration otherwise, then anything else beneficial they
-   * happen to carry.
+   * The order a healer reaches for brews for a hurt patient: instant healing
+   * when the patient is nearly dead, regeneration otherwise, then anything else
+   * that mends. Every choice must help this patient as a whole, so a splash of
+   * healing is never the answer for a body it would burn.
    */
   public static List<Predicate<ItemStack>> healingPreference(LivingEntity patient) {
-    Predicate<ItemStack> healing = stack -> isBeneficial(stack) && has(stack, MobEffects.HEAL);
-    Predicate<ItemStack> regeneration = stack -> isBeneficial(stack) && has(stack, MobEffects.REGENERATION);
+    Predicate<ItemStack> helps = stack -> outcomeOn(stack, patient) == Outcome.HELPS;
+    Predicate<ItemStack> healing = stack -> helps.test(stack) && has(stack, MobEffects.HEAL);
+    Predicate<ItemStack> regeneration = stack -> helps.test(stack) && has(stack, MobEffects.REGENERATION);
+    Predicate<ItemStack> mending = stack -> helps.test(stack) && mends(stack);
     return patient.getHealth() <= NEARLY_DEAD
-        ? List.of(healing, regeneration, ClericPotions::isBeneficial)
-        : List.of(regeneration, healing, ClericPotions::isBeneficial);
+        ? List.of(healing, regeneration, mending)
+        : List.of(regeneration, healing, mending);
+  }
+
+  /**
+   * What is wrong with a body right now that a potion could answer, or null:
+   * out of air under water, then burning, then hurt below the drinking line
+   * ({@link HealthRecoveryPolicy#shouldDrinkForHealth}) and not already
+   * regenerating, unless nearly dead, when instant healing still helps.
+   */
+  @Nullable
+  public static Need need(LivingEntity body) {
+    if (body.isUnderWater() && body.getAirSupply() < body.getMaxAirSupply() / 3
+        && !body.hasEffect(MobEffects.WATER_BREATHING)) {
+      return Need.DROWNING;
+    }
+    if (body.isOnFire() && !body.fireImmune() && !body.hasEffect(MobEffects.FIRE_RESISTANCE)) {
+      return Need.BURNING;
+    }
+    boolean nearlyDead = body.getHealth() <= NEARLY_DEAD;
+    if (HealthRecoveryPolicy.shouldDrinkForHealth(body.getHealth(), body.getMaxHealth())
+        && (nearlyDead || !body.hasEffect(MobEffects.REGENERATION))) {
+      return Need.HURT;
+    }
+    return null;
+  }
+
+  /** The order a body reaches for brews that answer its need, each helping that body as a whole. */
+  public static List<Predicate<ItemStack>> preferenceFor(Need need, LivingEntity body) {
+    Predicate<ItemStack> helps = stack -> outcomeOn(stack, body) == Outcome.HELPS;
+    return switch (need) {
+      case DROWNING -> List.of(stack -> helps.test(stack) && has(stack, MobEffects.WATER_BREATHING));
+      case BURNING -> List.of(stack -> helps.test(stack) && has(stack, MobEffects.FIRE_RESISTANCE));
+      case HURT -> healingPreference(body);
+    };
   }
 
   // The villager's own three places, read live.
@@ -256,6 +377,11 @@ public final class ClericPotions {
 
   public static List<Stock> stock(RealPerson person) {
     return stock(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv);
+  }
+
+  @Nullable
+  public static ItemStack spare(RealPerson person, Predicate<ItemStack> kind) {
+    return spare(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv, kind);
   }
 
   @Nullable
@@ -279,6 +405,31 @@ public final class ClericPotions {
     return throwable(person, kind) != null;
   }
 
+  /**
+   * The potion this villager would drink now, or null: an ordinary potion that
+   * answers what is wrong with them and helps them as a whole. A cleric keeps
+   * the seed of every brew; a villager who does not brew drinks what they were
+   * given.
+   */
+  @Nullable
+  public static ItemStack drinkFor(RealPerson person) {
+    Need need = need(person);
+    if (need == null) {
+      return null;
+    }
+    boolean cleric = isCleric(person);
+    for (Predicate<ItemStack> kind : preferenceFor(need, person)) {
+      Predicate<ItemStack> drink = stack -> isDrinkable(stack) && kind.test(stack);
+      ItemStack stack = cleric
+          ? spare(person, drink)
+          : first(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv, drink);
+      if (stack != null) {
+        return stack;
+      }
+    }
+    return null;
+  }
+
   public static int giveable(RealPerson person, ItemStack stack) {
     return giveable(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv, stack);
   }
@@ -292,7 +443,7 @@ public final class ClericPotions {
     return lowestBelowTarget(person.getMainHandItem(), person.getOffhandItem(), person.personMainInv);
   }
 
-  /** Whether the target is one the cleric must never splash with harm. */
+  /** Whether the body is one the cleric must never splash with harm. */
   public static boolean isAlly(LivingEntity thrower, LivingEntity other) {
     return other instanceof Person || other instanceof net.minecraft.world.entity.npc.AbstractVillager
         || com.quzzar.kithkyn.village.VillageGolems.supports(other)
@@ -301,19 +452,45 @@ public final class ClericPotions {
   }
 
   /**
-   * Whether a harmful splash burst at the target would catch an ally. A thrown
-   * potion reaches everyone within four blocks across and two up or down of
-   * where it breaks, so the check is that box around the target, less the
-   * target itself.
+   * Whether the body is on the other side: a hostile mob, the cleric's own
+   * target, or a mob with its sights on the cleric or one of their allies. An
+   * ally is never an enemy.
    */
-  public static boolean harmfulSplashWouldCatchAlly(LivingEntity thrower, LivingEntity target) {
+  public static boolean isEnemy(LivingEntity thrower, LivingEntity other) {
+    if (isAlly(thrower, other)) {
+      return false;
+    }
+    if (other instanceof Enemy || (thrower instanceof Mob mob && mob.getTarget() == other)) {
+      return true;
+    }
+    return other instanceof Mob mob && mob.getTarget() != null
+        && (mob.getTarget() == thrower || isAlly(thrower, mob.getTarget()));
+  }
+
+  /**
+   * Whether a splash burst at the target would catch anyone the test picks out,
+   * the target aside. A thrown potion reaches everyone within four blocks across
+   * and two up or down of where it breaks, and a lingering cloud spreads less
+   * than that, so the check is that box around the target.
+   */
+  public static boolean splashWouldCatch(LivingEntity thrower, LivingEntity target, Predicate<LivingEntity> who) {
     for (LivingEntity nearby : thrower.level().getEntitiesOfClass(LivingEntity.class,
         target.getBoundingBox().inflate(4.0D, 2.0D, 4.0D))) {
-      if (nearby != target && nearby.isAlive() && isAlly(thrower, nearby)) {
+      if (nearby != target && nearby.isAlive() && who.test(nearby)) {
         return true;
       }
     }
     return false;
+  }
+
+  /** Whether a harmful burst at the target would catch an ally, the cleric included. */
+  public static boolean harmfulSplashWouldCatchAlly(LivingEntity thrower, LivingEntity target) {
+    return splashWouldCatch(thrower, target, other -> isAlly(thrower, other));
+  }
+
+  /** Whether a helpful burst at the target would catch an enemy (Aaron, 2026-09-12). */
+  public static boolean helpfulSplashWouldCatchEnemy(LivingEntity thrower, LivingEntity target) {
+    return splashWouldCatch(thrower, target, other -> isEnemy(thrower, other));
   }
 
   /**

--- a/src/main/java/com/quzzar/kithkyn/entities/OffHandUse.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/OffHandUse.java
@@ -1,0 +1,107 @@
+package com.quzzar.kithkyn.entities;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * The off hand is the cleric's one working slot (Aaron, 2026-09-12). A bottle
+ * to throw or drink is brought into it for the use, and whatever the hand held
+ * goes down into the bottle's pack slot until the use is over, then comes back.
+ * Potions do not stack, so a finished throw or drink leaves the hand empty and
+ * the swap back always has room. Bottles are MOVED, never copied, like any held
+ * item: a copy would duplicate on death.
+ *
+ * <p>One use holds a villager's off hand at a time. A throw being aimed and a
+ * potion being drunk would otherwise each put the other's bottle away, so a
+ * second use waits until the first has restored the hand ({@link #inUse}).
+ */
+public final class OffHandUse {
+
+  private static final Map<RealPerson, OffHandUse> HOLDING = new WeakHashMap<>();
+
+  /** The pack slot now holding what the hand held, or -1 when nothing was moved. */
+  private int slot = -1;
+  private ItemStack displaced = ItemStack.EMPTY;
+
+  /** Whether some use is holding this villager's off hand. */
+  public static boolean inUse(RealPerson person) {
+    return HOLDING.containsKey(person);
+  }
+
+  /**
+   * Bring one of the villager's own stacks into the off hand, found by
+   * identity. True when it is there. False, and nothing moved, when another use
+   * holds the hand, the villager is eating or using an item, or no longer
+   * carries the stack. A bottle in the main hand, left there by the old
+   * two-handed kit, moves across and the main hand is left empty.
+   */
+  public boolean ready(RealPerson person, ItemStack stack) {
+    restore(person);
+    OffHandUse holder = HOLDING.get(person);
+    if (stack.isEmpty() || (holder != null && holder != this) || person.isEating() || person.isUsingItem()) {
+      return false;
+    }
+    if (person.getOffhandItem() == stack) {
+      HOLDING.put(person, this);
+      return true;
+    }
+    if (person.getMainHandItem() == stack) {
+      int empty = emptySlot(person);
+      if (empty < 0) {
+        return false;
+      }
+      this.displaced = person.getOffhandItem();
+      person.personMainInv.setItem(empty, this.displaced);
+      person.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
+      person.setItemSlot(EquipmentSlot.OFFHAND, stack);
+      this.slot = empty;
+      HOLDING.put(person, this);
+      return true;
+    }
+    for (int index = 0; index < person.personMainInv.getContainerSize(); index++) {
+      if (person.personMainInv.getItem(index) == stack) {
+        this.displaced = person.getOffhandItem();
+        person.setItemSlot(EquipmentSlot.OFFHAND,
+            EquipmentSwap.exchange(person.personMainInv, index, this.displaced));
+        this.slot = index;
+        HOLDING.put(person, this);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * End the use: what the hand held comes back from its pack slot, and the
+   * bottle, if anything is left of it, takes that slot. Left alone when the
+   * slot was emptied or refilled meanwhile; the daily tending of the hand
+   * ({@link RealPerson#tendSignatureGear}) settles it then.
+   */
+  public void restore(RealPerson person) {
+    if (HOLDING.get(person) == this) {
+      HOLDING.remove(person);
+    }
+    if (this.slot < 0) {
+      return;
+    }
+    ItemStack inSlot = person.personMainInv.getItem(this.slot);
+    if (inSlot == this.displaced || (this.displaced.isEmpty() && inSlot.isEmpty())) {
+      person.setItemSlot(EquipmentSlot.OFFHAND,
+          EquipmentSwap.exchange(person.personMainInv, this.slot, person.getOffhandItem()));
+    }
+    this.slot = -1;
+    this.displaced = ItemStack.EMPTY;
+  }
+
+  private static int emptySlot(RealPerson person) {
+    for (int index = 0; index < person.personMainInv.getContainerSize(); index++) {
+      if (person.personMainInv.getItem(index).isEmpty()) {
+        return index;
+      }
+    }
+    return -1;
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/Person.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/Person.java
@@ -83,8 +83,6 @@ import net.minecraft.world.item.BowItem;
 import net.minecraft.world.item.CrossbowItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.SplashPotionItem;
-import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ProjectileWeaponItem;
 import net.minecraft.world.item.component.ChargedProjectiles;
@@ -929,11 +927,15 @@ public class Person extends PathfinderMob implements CrossbowAttackMob, NeutralM
     }
   }
 
-  /** Something a villager can eat or drink to heal: food, or a potion that is not thrown. */
+  /**
+   * Something a villager eats to heal: food, eaten or drunk (a honey bottle is
+   * a meal). A potion is not: the eating path cannot drink one, since a bite a
+   * second ends the use before a drink finishes and a potion has no food value
+   * to heal by. A potion is drunk only when it would help, by DrinkPotionGoal,
+   * which knows what each one does.
+   */
   public static boolean isMeal(ItemStack stack) {
-    return !stack.isEmpty()
-        && (stack.getUseAnimation() == UseAnim.EAT
-            || (stack.getUseAnimation() == UseAnim.DRINK && !(stack.getItem() instanceof SplashPotionItem)));
+    return !stack.isEmpty() && stack.has(DataComponents.FOOD);
   }
 
   /** The pack slot holding the first meal, or -1 when the pack has none. */

--- a/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
@@ -917,6 +917,9 @@ public class RealPerson extends Person {
     if (getVillage() == null) {
       return;
     }
+    if (ClericPotions.isCleric(this)) {
+      stowStockFromMainHand();
+    }
     BlockPos depositTo = LocationManager.getJobLocation(this);
     for (SignatureGear.Piece piece : SignatureGear.of(getOccupation())) {
       String name = StashOffer.plain(piece.item());
@@ -957,6 +960,26 @@ public class RealPerson extends Person {
       }
     }
     return false;
+  }
+
+  /**
+   * The cleric works from the off hand alone (Aaron, 2026-09-12). A bottle
+   * still in the main hand, from the old two-handed kit or put there some other
+   * way, goes into the pack so the hand stays empty. MOVED, never copied; a full
+   * pack leaves it where it is until there is room.
+   */
+  private void stowStockFromMainHand() {
+    ItemStack held = getMainHandItem();
+    if (!ClericPotions.isStock(held)) {
+      return;
+    }
+    for (int slot = 0; slot < this.personMainInv.getContainerSize(); slot++) {
+      if (this.personMainInv.getItem(slot).isEmpty()) {
+        this.personMainInv.setItem(slot, held);
+        setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
+        return;
+      }
+    }
   }
 
   /**
@@ -1636,7 +1659,7 @@ public class RealPerson extends Person {
   }
 
   /**
-   * A cleric's loadout is issued, not authored: any splash potion the village
+   * A cleric's loadout is issued, not authored: any potion the village
    * stores hold of a brew the cleric does not yet carry is lifted into the pack
    * as a new seed, one bottle each, from the nearest chests that have any. A
    * player who leaves a splash of harming in a village chest has armed the
@@ -1649,7 +1672,7 @@ public class RealPerson extends Person {
       return;
     }
     java.util.function.Predicate<ItemStack> newBrew = stack ->
-        ClericPotions.isThrowable(stack)
+        ClericPotions.isStock(stack)
             && ClericPotions.carried(getMainHandItem(), getOffhandItem(),
                 this.personMainInv, stack) == 0;
     for (int visit = 0; visit < 3; visit++) {
@@ -2289,6 +2312,10 @@ public class RealPerson extends Person {
         for (SignatureGear.Piece piece : SignatureGear.of(getOccupation())) {
           kit(piece.slot(), piece.fresh().get());
         }
+        // Anything else the kit brings rides in the pack: the cleric's other two brews.
+        for (ItemStack stack : SignatureGear.startingPack(getOccupation())) {
+          this.addItems(List.of(stack));
+        }
         break;
     }
   }
@@ -2721,6 +2748,8 @@ public class RealPerson extends Person {
 
     this.goalSelector.addGoal(0, new FloatGoal(this));
     this.goalSelector.addGoal(0, new PersonEatFoodGoal(this));
+    // A potion that would help is drunk, never eaten (Person.isMeal), from the off hand like a meal.
+    this.goalSelector.addGoal(0, new com.quzzar.kithkyn.entities.ai.goals.DrinkPotionGoal(this));
     // A hurt villager with a cleric in reach goes to be tended first: the
     // cleric's splash outlasts anything else on offer, and eating holds no
     // movement flag, so a meal is taken on the way and while waiting. Same
@@ -2829,15 +2858,17 @@ public class RealPerson extends Person {
       // the same priority as healing, registered ahead of it, so a cleric with
       // a target and a harmful splash to spare fights before tending; a cleric
       // carrying only healing never acquires a target at all, since the threat
-      // goal below asks for the harmful stock. Brewing sits below both: more
-      // potions are made when nobody needs one thrown.
+      // goal below asks for the harmful stock, judged on each body: a splash of
+      // harming heals the undead, so a zombie is never its target. Brewing sits
+      // below both: more potions are made when nobody needs one thrown.
+      // Drinking is everyone's (DrinkPotionGoal, registered with eating).
       this.goalSelector.addGoal(2, new ThrowPotionAttackGoal(this));
       this.goalSelector.addGoal(2, new WorkLoopGoal<>(this, new HealStep(1, 7, 7.0F)));
       this.goalSelector.addGoal(3, new WorkLoopGoal<>(this, new BrewStep()));
       this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, Mob.class, 10, true, false,
           (mob) -> mob instanceof Enemy && !(mob instanceof Creeper)
-              && ClericPotions.hasThrowable(this,
-                  ClericPotions::isHarmful)));
+              && ClericPotions.hasThrowable(this, stack -> ClericPotions.isHarmful(stack)
+                  && ClericPotions.outcomeOn(stack, mob) == ClericPotions.Outcome.HURTS)));
     }
     if (getOccupation() == Occupation.GUARD) {
       com.quzzar.kithkyn.village.GuardDuty guardDuty = com.quzzar.kithkyn.village.GuardDuty.of(this);

--- a/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/RealPerson.java
@@ -919,6 +919,7 @@ public class RealPerson extends Person {
     }
     if (ClericPotions.isCleric(this)) {
       stowStockFromMainHand();
+      restMarkInOffHand();
     }
     BlockPos depositTo = LocationManager.getJobLocation(this);
     for (SignatureGear.Piece piece : SignatureGear.of(getOccupation())) {
@@ -978,6 +979,31 @@ public class RealPerson extends Person {
         this.personMainInv.setItem(slot, held);
         setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
         return;
+      }
+    }
+  }
+
+  /**
+   * At rest the cleric's off hand holds the mark, the splash of regeneration
+   * (Aaron, 2026-09-12). A different bottle left there, the old kit's splash of
+   * healing or one handed over, is swapped for a matching bottle from the pack.
+   * Never while a throw or drink holds the hand (OffHandUse) or a meal is being
+   * eaten, and a hand holding something that is not a potion is left alone.
+   */
+  private void restMarkInOffHand() {
+    ItemStack held = getOffhandItem();
+    if (!ClericPotions.isStock(held) || OffHandUse.inUse(this) || isEating() || isUsingItem()) {
+      return;
+    }
+    for (SignatureGear.Piece piece : SignatureGear.of(getOccupation())) {
+      if (piece.slot() != EquipmentSlot.OFFHAND || piece.matches(held)) {
+        continue;
+      }
+      for (int slot = 0; slot < this.personMainInv.getContainerSize(); slot++) {
+        if (piece.matches(this.personMainInv.getItem(slot))) {
+          this.setItemSlot(EquipmentSlot.OFFHAND, EquipmentSwap.exchange(this.personMainInv, slot, held));
+          return;
+        }
       }
     }
   }

--- a/src/main/java/com/quzzar/kithkyn/entities/SignatureGear.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/SignatureGear.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.Potion;
 import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.item.alchemy.Potions;
 
@@ -17,7 +18,7 @@ import net.minecraft.world.item.alchemy.Potions;
  * The item a trade holds as the mark of its work, for the trades whose mark is
  * not a tool: the quartermaster's ledger (a writable book), the builder's
  * crafting table, the librarian's book, the blacksmith's iron ingot, the
- * cleric's splash potions of healing and regeneration. This is the one place they are
+ * cleric's splash potion of regeneration. This is the one place they are
  * named, so the starting kit that first hands them out
  * ({@link RealPerson#issueStartingKit}) and the day-to-day check that keeps them
  * in hand ({@link RealPerson#tendSignatureGear}) read the same list.
@@ -49,8 +50,8 @@ public final class SignatureGear {
 
     /**
      * Whether {@code held} is a right item for this piece: the same item, and,
-     * when the mark is a potion, the same brew (so a cleric's healing potion is
-     * not mistaken for their splash of regeneration).
+     * when the mark is a potion, the same brew (so a cleric's splash of healing
+     * is not mistaken for their splash of regeneration).
      */
     public boolean matches(ItemStack held) {
       ItemStack want = this.fresh.get();
@@ -74,27 +75,31 @@ public final class SignatureGear {
       // The quartermaster keeps the village's stores; a writable book reads as
       // the ledger they are forever taking count in.
       case QUARTERMASTER -> List.of(new Piece(EquipmentSlot.MAINHAND, () -> new ItemStack(Items.WRITABLE_BOOK)));
-      // A splash of regeneration in hand and a splash of healing in the off
-      // hand: the two brews every cleric starts with. Unlike the other marks
-      // these are real stock (ClericPotions): a throw consumes one, and the
-      // last bottle of a brew is the seed the cleric brews more from, so it is
-      // never thrown or given away.
-      case CLERIC -> List.of(
-          new Piece(EquipmentSlot.MAINHAND, SignatureGear::regenSplash),
-          new Piece(EquipmentSlot.OFFHAND, SignatureGear::healingSplash));
+      // The cleric works from the off hand alone (Aaron, 2026-09-12): it rests
+      // on a splash of regeneration, and a bottle to throw or drink is swapped
+      // into it for the use (OffHandUse). The main hand stays empty. Unlike the
+      // other marks this is real stock (ClericPotions): a throw consumes it, and
+      // the last bottle of a brew is the seed the cleric brews more from.
+      case CLERIC -> List.of(new Piece(EquipmentSlot.OFFHAND, () -> potion(Items.SPLASH_POTION, Potions.REGENERATION)));
       default -> List.of();
     };
   }
 
-  private static ItemStack regenSplash() {
-    ItemStack stack = new ItemStack(Items.SPLASH_POTION);
-    stack.set(DataComponents.POTION_CONTENTS, new PotionContents(Potions.REGENERATION));
-    return stack;
+  /**
+   * What a trade's starting kit also puts in the pack, beyond the marks it
+   * holds: the cleric's other two brews, a splash of healing and a potion of
+   * regeneration to drink, beside the splash of regeneration in hand (Aaron,
+   * 2026-09-12). Handed out once, with the kit. Empty for every other trade.
+   */
+  public static List<ItemStack> startingPack(Occupation occupation) {
+    return occupation == Occupation.CLERIC
+        ? List.of(potion(Items.SPLASH_POTION, Potions.HEALING), potion(Items.POTION, Potions.REGENERATION))
+        : List.of();
   }
 
-  private static ItemStack healingSplash() {
-    ItemStack stack = new ItemStack(Items.SPLASH_POTION);
-    stack.set(DataComponents.POTION_CONTENTS, new PotionContents(Potions.HEALING));
+  private static ItemStack potion(Item item, net.minecraft.core.Holder<Potion> potion) {
+    ItemStack stack = new ItemStack(item);
+    stack.set(DataComponents.POTION_CONTENTS, new PotionContents(potion));
     return stack;
   }
 }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/HealthRecoveryPolicy.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/HealthRecoveryPolicy.java
@@ -71,6 +71,15 @@ public final class HealthRecoveryPolicy {
     return isBadlyHurt(health, maximumHealth) && !regenerating && !night;
   }
 
+  /**
+   * A potion that mends is drunk below two thirds of health: sooner than
+   * eating, since a potion is carried for exactly this and regeneration heals
+   * over time rather than at once (ClericPotions.need).
+   */
+  public static boolean shouldDrinkForHealth(float health, float maximumHealth) {
+    return maximumHealth > 0.0F && health < maximumHealth * 2.0F / 3.0F;
+  }
+
   /** The first game tick at which another campfire recovery may begin. */
   public static long nextCampfireUse(long gameTime) {
     return gameTime + CAMPFIRE_COOLDOWN_TICKS;

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/DrinkPotionGoal.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/DrinkPotionGoal.java
@@ -1,0 +1,84 @@
+package com.quzzar.kithkyn.entities.ai.goals;
+
+import java.util.Locale;
+
+import javax.annotation.Nullable;
+
+import com.quzzar.kithkyn.Kithkyn;
+import com.quzzar.kithkyn.entities.ClericPotions;
+import com.quzzar.kithkyn.entities.OffHandUse;
+import com.quzzar.kithkyn.entities.RealPerson;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * A villager drinks an ordinary potion that answers what is wrong with them
+ * right now (Aaron, 2026-09-12: ordinary potions are drunk, splash and
+ * lingering ones thrown). Out of air under water, water breathing; burning,
+ * fire resistance; hurt below the drinking line, healing, regeneration,
+ * absorption or health boost ({@link ClericPotions#need}). Only a potion that
+ * helps the drinker as a whole is drunk, so nobody drinks harm, and a cleric
+ * never drinks the last bottle of a brew, the recipe they brew more from.
+ *
+ * <p>The bottle is drunk from the off hand, the hand a cleric works from
+ * ({@link OffHandUse}): it comes up from the pack, the hand's own item goes
+ * down into its slot, and once the drink is done that item comes back. The
+ * drink itself is the vanilla use, animation and sound included, and when it
+ * completes {@code Person.completeUsingItem} applies the effects and empties
+ * the bottle. Like eating, it holds no movement flag, so a villager drinks on
+ * the move.
+ */
+public final class DrinkPotionGoal extends Goal {
+
+  /** Needs are read once a second, not every tick. */
+  private static final int CHECK_INTERVAL_TICKS = 20;
+
+  private final RealPerson person;
+  private final OffHandUse offHand = new OffHandUse();
+
+  @Nullable
+  private ItemStack potion;
+  private int nextCheckTick;
+
+  public DrinkPotionGoal(RealPerson person) {
+    this.person = person;
+  }
+
+  @Override
+  public boolean canUse() {
+    if (this.person.tickCount < this.nextCheckTick || this.person.isSleeping() || this.person.isEating()
+        || this.person.isUsingItem() || OffHandUse.inUse(this.person)) {
+      return false;
+    }
+    this.nextCheckTick = this.person.tickCount + CHECK_INTERVAL_TICKS;
+    this.potion = ClericPotions.drinkFor(this.person);
+    return this.potion != null;
+  }
+
+  @Override
+  public boolean canContinueToUse() {
+    return this.potion != null && this.person.isUsingItem() && this.person.getUseItem() == this.potion;
+  }
+
+  @Override
+  public void start() {
+    if (this.potion == null || !this.offHand.ready(this.person, this.potion)) {
+      this.potion = null;
+      return;
+    }
+    Kithkyn.LOGGER.info("'{}' is drinking a {}", this.person.getFullName(),
+        this.potion.getHoverName().getString().toLowerCase(Locale.ROOT));
+    this.person.startUsingItem(InteractionHand.OFF_HAND);
+  }
+
+  @Override
+  public void stop() {
+    if (this.potion != null && this.person.isUsingItem() && this.person.getUseItem() == this.potion) {
+      this.person.stopUsingItem();
+    }
+    this.offHand.restore(this.person);
+    this.potion = null;
+  }
+}

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/PersonEatFoodGoal.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/PersonEatFoodGoal.java
@@ -43,6 +43,10 @@ public class PersonEatFoodGoal extends Goal {
         || !person.hasMeal()) {
       return false;
     }
+    // The off hand is busy with a potion being drunk or aimed (OffHandUse): the meal waits.
+    if (com.quzzar.kithkyn.entities.OffHandUse.inUse(person)) {
+      return false;
+    }
     return (!person.isRunningToEat() && person.isEating())
         || (person.getTarget() == null && !person.isAggressive());
   }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/RangedShotSafety.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/RangedShotSafety.java
@@ -32,6 +32,27 @@ public final class RangedShotSafety {
     return false;
   }
 
+  /**
+   * An enemy in the corridor would take a helpful throw meant for someone
+   * behind it: the bottle breaks on the first body it meets (Aaron, 2026-09-12:
+   * a helpful potion is never thrown where it would reach an enemy).
+   */
+  public static boolean blockedByEnemy(LivingEntity shooter, LivingEntity target) {
+    Vec3 from = shooter.getEyePosition();
+    Vec3 to = target.getBoundingBox().getCenter();
+    for (LivingEntity nearby : shooter.level().getEntitiesOfClass(LivingEntity.class,
+        new AABB(from, to).inflate(CLEARANCE))) {
+      if (nearby == shooter || nearby == target || !nearby.isAlive()) {
+        continue;
+      }
+      if (com.quzzar.kithkyn.entities.ClericPotions.isEnemy(shooter, nearby)
+          && intersects(from, to, nearby.getBoundingBox())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** A finite segment also excludes allies behind the shooter or beyond the target. */
   static boolean intersects(Vec3 from, Vec3 to, AABB body) {
     AABB clearance = body.inflate(CLEARANCE);

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/ThrowPotionAttackGoal.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/ThrowPotionAttackGoal.java
@@ -2,7 +2,11 @@ package com.quzzar.kithkyn.entities.ai.goals;
 
 import java.util.EnumSet;
 
+import javax.annotation.Nullable;
+
+import com.quzzar.kithkyn.Kithkyn;
 import com.quzzar.kithkyn.entities.ClericPotions;
+import com.quzzar.kithkyn.entities.OffHandUse;
 import com.quzzar.kithkyn.entities.RealPerson;
 
 import net.minecraft.world.InteractionHand;
@@ -16,14 +20,20 @@ import net.minecraft.world.item.ItemStack;
  * 2026-09-12: the swamp's witches are clerics, and a cleric's loadout decides
  * whether they heal, hex, or both).
  *
- * <p>Only a cleric carrying a harmful splash potion with one to spare ever has
- * a target here (the threat goal in {@code RealPerson.registerGoals} checks the
- * same stock), and each throw consumes one bottle. The two safety rules are
- * absolute: a harmful potion is never thrown while an ally stands inside the
- * burst around the target, and never through a friend in the way. When either
- * holds, the cleric closes in and waits for a clear throw rather than throwing
- * badly. Out of harm, the goal ends and the target is dropped; the cleric's
- * healing round takes over if anyone is hurt.
+ * <p>Only a cleric carrying a harmful splash or lingering potion that would
+ * hurt this target, with one to spare, ever has a target here (the threat goal
+ * in {@code RealPerson.registerGoals} checks the same stock). Harm is judged on
+ * the body: a splash of harming heals the undead, so it is never thrown at a
+ * zombie. Each throw consumes one bottle. The two safety rules are absolute: a
+ * harmful potion is never thrown while an ally stands inside the burst around
+ * the target, and never through a friend in the way. When either holds, the
+ * cleric closes in and waits for a clear throw rather than throwing badly. Out
+ * of harm, the goal ends and the target is dropped; the cleric's healing round
+ * takes over if anyone is hurt.
+ *
+ * <p>The throw is made from the off hand ({@link OffHandUse}): the bottle comes
+ * up into it as the cleric crouches to aim, and the hand's resting bottle comes
+ * back once it is thrown or the aim is broken off.
  */
 public final class ThrowPotionAttackGoal extends Goal {
 
@@ -33,6 +43,7 @@ public final class ThrowPotionAttackGoal extends Goal {
   private static final int CHARGE_TICKS = 20;
 
   private final RealPerson person;
+  private final OffHandUse offHand = new OffHandUse();
   private int cooldown;
   private int charge;
 
@@ -45,8 +56,7 @@ public final class ThrowPotionAttackGoal extends Goal {
   public boolean canUse() {
     LivingEntity target = this.person.getTarget();
     return target != null && target.isAlive() && ClericPotions.isCleric(this.person)
-        && !this.person.isSleeping() && !this.person.isEating()
-        && ClericPotions.hasThrowable(this.person, ClericPotions::isHarmful);
+        && !this.person.isSleeping() && !this.person.isEating() && harmFor(target) != null;
   }
 
   @Override
@@ -69,8 +79,11 @@ public final class ThrowPotionAttackGoal extends Goal {
   public void stop() {
     this.person.getNavigation().stop();
     this.person.setPose(Pose.STANDING);
-    if (!ClericPotions.hasThrowable(this.person, ClericPotions::isHarmful)) {
-      this.person.setTarget(null); // nothing left to fight with
+    this.offHand.restore(this.person);
+    this.charge = 0;
+    LivingEntity target = this.person.getTarget();
+    if (target == null || harmFor(target) == null) {
+      this.person.setTarget(null); // nothing left to fight this one with
     }
   }
 
@@ -87,8 +100,7 @@ public final class ThrowPotionAttackGoal extends Goal {
         && !RangedShotSafety.blockedByFriendly(this.person, target)
         && !ClericPotions.harmfulSplashWouldCatchAlly(this.person, target);
     if (!inReach || !clear) {
-      this.charge = 0;
-      this.person.setPose(Pose.STANDING);
+      breakOffAim();
       this.person.getNavigation().moveTo(target, SPEED);
       return;
     }
@@ -97,19 +109,43 @@ public final class ThrowPotionAttackGoal extends Goal {
       this.cooldown--;
       return;
     }
+    if (this.charge == 0) {
+      ItemStack harm = harmFor(target);
+      if (harm == null || !this.offHand.ready(this.person, harm)) {
+        return;
+      }
+    }
     // Crouch to steady the throw, as the healing round does.
     this.person.setPose(Pose.CROUCHING);
     if (++this.charge < CHARGE_TICKS) {
       return;
     }
-    ItemStack harm = ClericPotions.throwable(this.person, ClericPotions::isHarmful);
-    if (harm != null) {
-      this.person.swing(InteractionHand.MAIN_HAND);
-      ClericPotions.throwOne(this.person, target, harm);
+    ItemStack held = this.person.getOffhandItem();
+    if (ClericPotions.isThrowable(held) && ClericPotions.outcomeOn(held, target) == ClericPotions.Outcome.HURTS) {
+      this.person.swing(InteractionHand.OFF_HAND);
+      Kithkyn.LOGGER.debug("'{}' threw a {} at {}", this.person.getFullName(),
+          held.getHoverName().getString(), target.getName().getString());
+      ClericPotions.throwOne(this.person, target, held);
     }
+    this.offHand.restore(this.person);
     this.person.setPose(Pose.STANDING);
     this.charge = 0;
     this.cooldown = THROW_INTERVAL_TICKS;
+  }
+
+  private void breakOffAim() {
+    if (this.charge > 0) {
+      this.offHand.restore(this.person);
+    }
+    this.charge = 0;
+    this.person.setPose(Pose.STANDING);
+  }
+
+  /** A harmful bottle to spare that would hurt this target, or null. */
+  @Nullable
+  private ItemStack harmFor(LivingEntity target) {
+    return ClericPotions.throwable(this.person, stack -> ClericPotions.isHarmful(stack)
+        && ClericPotions.outcomeOn(stack, target) == ClericPotions.Outcome.HURTS);
   }
 
 }

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/HealStep.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/goals/work/HealStep.java
@@ -4,12 +4,16 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import com.quzzar.kithkyn.Kithkyn;
 import com.quzzar.kithkyn.entities.ClericPotions;
+import com.quzzar.kithkyn.entities.OffHandUse;
 import com.quzzar.kithkyn.entities.Person;
 import com.quzzar.kithkyn.entities.RealPerson;
+import com.quzzar.kithkyn.entities.ai.goals.RangedShotSafety;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Pose;
@@ -28,9 +32,16 @@ import net.minecraft.world.item.ItemStack;
  * within three quarters of their range, crouches to steady the throw, waits out
  * a charge that is longer the further away the patient is, and lobs a splash
  * potion from their own stock ({@link ClericPotions}): healing if the patient
- * is nearly dead, regeneration otherwise, whichever they carry. Each throw
- * consumes a bottle, and the last of a brew is never thrown, so a cleric with
- * only their seed potions left has nobody to tend until they brew more.
+ * is nearly dead, regeneration otherwise, then anything else that mends, and
+ * only a brew that helps that patient as a whole. Each throw consumes a bottle,
+ * and the last of a brew is never thrown, so a cleric with only their seed
+ * potions left has nobody to tend until they brew more. A helpful throw is never
+ * made while an enemy stands inside the burst or in the way (Aaron,
+ * 2026-09-12): the cleric holds it until the enemy is clear.
+ *
+ * The bottle comes up into the off hand as the cleric crouches, and the hand's
+ * resting bottle comes back once it is thrown or the throw is held
+ * ({@link OffHandUse}).
  */
 public final class HealStep implements WorkStep<LivingEntity> {
 
@@ -39,6 +50,7 @@ public final class HealStep implements WorkStep<LivingEntity> {
   private final int minChargeTicks;
   private final int maxChargeTicks;
   private final float throwRange;
+  private final OffHandUse offHand = new OffHandUse();
 
   private boolean charging;
   private int chargeLeft;
@@ -82,12 +94,20 @@ public final class HealStep implements WorkStep<LivingEntity> {
     }
     // A potion thrown at a wall helps nobody. Hold the charge and close up.
     if (!person.getSensing().hasLineOfSight(target)) {
-      this.charging = false;
-      person.setPose(Pose.STANDING);
+      holdThrow(person);
       person.getNavigation().moveTo(target, 0.5D);
       return true;
     }
+    // A helpful splash that would also reach an enemy, or break on one on the
+    // way, is held until the enemy is clear.
+    if (ClericPotions.helpfulSplashWouldCatchEnemy(person, target) || RangedShotSafety.blockedByEnemy(person, target)) {
+      holdThrow(person);
+      return true;
+    }
     if (!this.charging) {
+      if (!this.offHand.ready(person, brew)) {
+        return true;
+      }
       this.charging = true;
       person.setPose(Pose.CROUCHING);
       this.chargeLeft = (int) Mth.lerp(person.distanceTo(target) / this.throwRange,
@@ -97,7 +117,14 @@ public final class HealStep implements WorkStep<LivingEntity> {
     if (this.chargeLeft-- > 0) {
       return true;
     }
-    ClericPotions.throwOne(person, target, brew);
+    ItemStack held = person.getOffhandItem();
+    if (ClericPotions.isThrowable(held) && ClericPotions.outcomeOn(held, target) == ClericPotions.Outcome.HELPS) {
+      person.swing(InteractionHand.OFF_HAND);
+      Kithkyn.LOGGER.debug("'{}' threw a {} to {}", person.getFullName(), held.getHoverName().getString(),
+          target.getName().getString());
+      ClericPotions.throwOne(person, target, held);
+    }
+    this.offHand.restore(person);
     this.charging = false;
     person.setPose(Pose.STANDING);
     return false;
@@ -105,9 +132,8 @@ public final class HealStep implements WorkStep<LivingEntity> {
 
   @Override
   public void released(RealPerson person, LivingEntity target) {
-    this.charging = false;
+    holdThrow(person);
     this.chargeLeft = 0;
-    person.setPose(Pose.STANDING);
   }
 
   @Override
@@ -131,6 +157,13 @@ public final class HealStep implements WorkStep<LivingEntity> {
   @Override
   public int actEveryTicks() {
     return 20;
+  }
+
+  /** Stand down from a throw: the resting bottle back in hand, the charge undone. */
+  private void holdThrow(RealPerson person) {
+    this.offHand.restore(person);
+    this.charging = false;
+    person.setPose(Pose.STANDING);
   }
 
   private boolean needsTending(RealPerson person, LivingEntity candidate) {

--- a/src/test/java/com/quzzar/kithkyn/entities/ClericPotionsTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ClericPotionsTest.java
@@ -8,12 +8,15 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.alchemy.Potion;
@@ -24,6 +27,18 @@ class ClericPotionsTest {
 
   private static ItemStack splash(Holder<Potion> potion) {
     ItemStack stack = new ItemStack(Items.SPLASH_POTION);
+    stack.set(DataComponents.POTION_CONTENTS, new PotionContents(potion));
+    return stack;
+  }
+
+  private static ItemStack drink(Holder<Potion> potion) {
+    ItemStack stack = new ItemStack(Items.POTION);
+    stack.set(DataComponents.POTION_CONTENTS, new PotionContents(potion));
+    return stack;
+  }
+
+  private static ItemStack lingering(Holder<Potion> potion) {
+    ItemStack stack = new ItemStack(Items.LINGERING_POTION);
     stack.set(DataComponents.POTION_CONTENTS, new PotionContents(potion));
     return stack;
   }
@@ -136,5 +151,56 @@ class ClericPotionsTest {
       pack.setItem(slot, splash(Potions.REGENERATION));
     }
     assertNull(ClericPotions.lowestBelowTarget(hand, ItemStack.EMPTY, pack));
+  }
+
+  @Test
+  void ordinaryPotionsAreDrunkAndSplashAndLingeringOnesAreThrown() {
+    assertTrue(ClericPotions.isDrinkable(drink(Potions.REGENERATION)));
+    assertFalse(ClericPotions.isThrowable(drink(Potions.REGENERATION)));
+    assertTrue(ClericPotions.isStock(drink(Potions.REGENERATION)));
+    assertTrue(ClericPotions.isThrowable(lingering(Potions.POISON)));
+    assertFalse(ClericPotions.isDrinkable(lingering(Potions.POISON)));
+    assertFalse(ClericPotions.isDrinkable(splash(Potions.HEALING)));
+    assertFalse(ClericPotions.isStock(drink(Potions.WATER)));
+  }
+
+  @Test
+  void whatABrewDoesDependsOnTheBodyItReaches() {
+    Predicate<MobEffectInstance> everything = effect -> true;
+    assertEquals(ClericPotions.Outcome.HELPS, ClericPotions.outcome(splash(Potions.HEALING), false, everything));
+    assertEquals(ClericPotions.Outcome.HURTS, ClericPotions.outcome(splash(Potions.HARMING), false, everything));
+    // The undead: healing and harm trade places, and poison and regeneration do not take.
+    assertEquals(ClericPotions.Outcome.HURTS, ClericPotions.outcome(splash(Potions.HEALING), true, everything));
+    assertEquals(ClericPotions.Outcome.HELPS, ClericPotions.outcome(splash(Potions.HARMING), true, everything));
+    Predicate<MobEffectInstance> undead = effect -> !effect.getEffect().equals(MobEffects.POISON)
+        && !effect.getEffect().equals(MobEffects.REGENERATION);
+    assertEquals(ClericPotions.Outcome.NOTHING, ClericPotions.outcome(splash(Potions.POISON), true, undead));
+    assertEquals(ClericPotions.Outcome.NOTHING, ClericPotions.outcome(drink(Potions.REGENERATION), true, undead));
+    // Help and harm at once: the turtle master's slowness and resistance.
+    assertEquals(ClericPotions.Outcome.MIXED, ClericPotions.outcome(splash(Potions.TURTLE_MASTER), false, everything));
+    assertFalse(ClericPotions.isBeneficial(splash(Potions.TURTLE_MASTER)));
+    assertFalse(ClericPotions.isHarmful(splash(Potions.TURTLE_MASTER)));
+  }
+
+  @Test
+  void aDrinkableBrewHasItsOwnSeed() {
+    SimpleContainer pack = new SimpleContainer(9);
+    pack.setItem(0, drink(Potions.REGENERATION));
+    assertNull(ClericPotions.spare(ItemStack.EMPTY, ItemStack.EMPTY, pack, ClericPotions::isDrinkable));
+    pack.setItem(1, drink(Potions.REGENERATION));
+    assertNotNull(ClericPotions.spare(ItemStack.EMPTY, ItemStack.EMPTY, pack, ClericPotions::isDrinkable));
+    // A splash of the same potion is another brew, not a second bottle of this one.
+    pack.setItem(1, splash(Potions.REGENERATION));
+    assertNull(ClericPotions.spare(ItemStack.EMPTY, ItemStack.EMPTY, pack, ClericPotions::isDrinkable));
+    assertEquals(2, ClericPotions.stock(ItemStack.EMPTY, ItemStack.EMPTY, pack).size());
+    assertEquals(0, ClericPotions.giveable(ItemStack.EMPTY, ItemStack.EMPTY, pack, pack.getItem(0)));
+  }
+
+  @Test
+  void mendingMeansHealingRegenerationAbsorptionOrHealthBoost() {
+    assertTrue(ClericPotions.mends(splash(Potions.HEALING)));
+    assertTrue(ClericPotions.mends(drink(Potions.REGENERATION)));
+    assertFalse(ClericPotions.mends(splash(Potions.SWIFTNESS)));
+    assertFalse(ClericPotions.mends(drink(Potions.FIRE_RESISTANCE)));
   }
 }

--- a/src/test/java/com/quzzar/kithkyn/entities/SignatureGearTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/SignatureGearTest.java
@@ -1,0 +1,50 @@
+package com.quzzar.kithkyn.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.quzzar.kithkyn.village.Occupation;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.Potion;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.item.alchemy.Potions;
+
+class SignatureGearTest {
+
+  private static ItemStack potion(Item item, Holder<Potion> potion) {
+    ItemStack stack = new ItemStack(item);
+    stack.set(DataComponents.POTION_CONTENTS, new PotionContents(potion));
+    return stack;
+  }
+
+  @Test
+  void aClericHoldsOnlyASplashOfRegenerationAndOnlyInTheOffHand() {
+    List<SignatureGear.Piece> pieces = SignatureGear.of(Occupation.CLERIC);
+    assertEquals(1, pieces.size());
+    assertEquals(EquipmentSlot.OFFHAND, pieces.get(0).slot());
+    assertTrue(pieces.get(0).matches(potion(Items.SPLASH_POTION, Potions.REGENERATION)));
+    assertFalse(pieces.get(0).matches(potion(Items.SPLASH_POTION, Potions.HEALING)));
+    assertFalse(pieces.get(0).matches(potion(Items.POTION, Potions.REGENERATION)));
+  }
+
+  @Test
+  void aClericsPackStartsWithASplashOfHealingAndAPotionOfRegeneration() {
+    List<ItemStack> pack = SignatureGear.startingPack(Occupation.CLERIC);
+    assertEquals(2, pack.size());
+    assertTrue(ClericPotions.sameBrew(pack.get(0), potion(Items.SPLASH_POTION, Potions.HEALING)));
+    assertTrue(ClericPotions.sameBrew(pack.get(1), potion(Items.POTION, Potions.REGENERATION)));
+    assertTrue(ClericPotions.isDrinkable(pack.get(1)));
+    assertTrue(SignatureGear.startingPack(Occupation.FARMER).isEmpty());
+  }
+}

--- a/src/test/java/com/quzzar/kithkyn/entities/ai/HealthRecoveryPolicyTest.java
+++ b/src/test/java/com/quzzar/kithkyn/entities/ai/HealthRecoveryPolicyTest.java
@@ -47,4 +47,11 @@ class HealthRecoveryPolicyTest {
     assertFalse(HealthRecoveryPolicy.shouldSeekCampfire(5.0F, 18.0F, true, 1_200L, 1_200L));
     assertTrue(HealthRecoveryPolicy.shouldSeekCampfire(5.0F, 18.0F, false, 1_200L, 1_200L));
   }
+
+  @org.junit.jupiter.api.Test
+  void potionsThatMendAreDrunkBelowTwoThirdsOfHealth() {
+    org.junit.jupiter.api.Assertions.assertTrue(HealthRecoveryPolicy.shouldDrinkForHealth(26.0F, 40.0F));
+    org.junit.jupiter.api.Assertions.assertFalse(HealthRecoveryPolicy.shouldDrinkForHealth(27.0F, 40.0F));
+    org.junit.jupiter.api.Assertions.assertFalse(HealthRecoveryPolicy.shouldDrinkForHealth(10.0F, 0.0F));
+  }
 }


### PR DESCRIPTION
## Summary

Aaron's cleric rules (2026-09-12), with the fixes they needed underneath.

- **One working hand.** The cleric holds a splash of regeneration in the off hand and nothing in the main hand. A bottle to throw or drink is swapped into the off hand for the use, and the resting bottle comes back after (`OffHandUse`). A bottle left in the main hand by the old two-handed kit is stowed in the pack at the next daily tending.
- **Starting kit.** Splash of regeneration in the off hand, plus a splash of healing and a potion of regeneration in the pack (`SignatureGear.startingPack`). Each is the seed of its brew, as before, so a new cleric brews at its station before it throws or drinks any.
- **Drink or throw by kind.** Ordinary potions are drunk, splash and lingering potions are thrown. `DrinkPotionGoal` lets any villager drink a potion that answers a need right now: water breathing when out of air, fire resistance when burning, and below two thirds of health healing, regeneration, absorption or health boost. A cleric never drinks a seed.
- **Throws judged by who they reach.** A brew is judged on the body it lands on (`ClericPotions.outcomeOn`): healing burns the undead, harming heals them, poison and regeneration do not take on them. Helpful throws go to allies and are held while an enemy stands in the splash or in the way. Harmful throws go to enemies and are held while an ally does, as before. A cleric never throws harming at a zombie now.
- **Eating loop fixed.** `Person.isMeal` counted every non-splash potion, lingering ones included, as food. A badly hurt villager with one brought it to hand, and the once-a-second bite ended the use before the drink finished, so it looped without ever drinking. Meals are food only now; potions go through the drinking goal.
- **Chat briefing** counts drinkable brews as stock and tells the cleric how its potions are used. `docs/worker-loops.md` is updated.

## Tests

- `./gradlew test`: 559 tests, 0 failures. New cases cover drink versus throw, per-body outcomes including the undead, drinkable seeds, the kit, and the drinking line.
- Not exercised headlessly. After deploy I check the live clerics' hands and packs and watch the log for drink lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
