### PR TITLE
Fix ladder navigation without editing builds

### DIFF
--- a/docs/tundra-village.md
+++ b/docs/tundra-village.md
@@ -37,7 +37,7 @@ The private datapack contains 23 definitions:
 | `butchery_tundra_1` | T02.1 butcher station and three persistent sheep in the enclosure |
 | `fishery_tundra_1` | T02.3 fisher's hut with its worker bed and storage |
 | `lumberjack_tundra_1` | T02.4 lumber yard with a worker bed, personal and shared storage, and a spruce planting site |
-| `watchtower_tundra_1` | T03.1 sole tower level; crossbow post, guard bed and personal chest; a spruce gate and final ladder rung keep the upper landing navigable |
+| `watchtower_tundra_1` | T03.1 sole tower level; crossbow post, guard bed and personal chest; the authored fence, lantern and six-rung ladder remain unchanged |
 | `church_tundra_1` | T03.2 cleric station with a worker bed and personal chest |
 | `stoneworks_tundra_1` | T03.4 mason station with a worker bed plus separate personal and workplace chests |
 | `blacksmith_tundra_1` | T03.5 forge with a worker bed, personal barrel and workplace chest |
@@ -69,6 +69,11 @@ snow golems and three sheep. It also corrects the three approved market counters
 sit above a complete foundation like the other working regional markets. The private production
 assets remain under `run/tundra-integration/datapack`; source and output hashes are recorded in
 `tools/structure/tundra-catalog-20260912.json`.
+
+T03.1 is exported without navigation-driven block overrides. Person navigation represents the
+open cell above the top ladder rung as a two-way ladder transition and rejects decorative lantern,
+candle, fence, gate and wall tops as false floors. Guards therefore descend through the authored
+ladder opening instead of attempting an impossible lantern-to-railing shortcut.
 
 Manual testing can create the style with `/kithkyn create-village ~ ~ ~ tundra`. Natural founding
 in a snowy or icy lowland uses the same style selector and founding path.

--- a/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
+++ b/src/main/java/com/quzzar/kithkyn/entities/ai/PersonPathNavigation.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.LadderBlock;
 import net.minecraft.world.level.block.CandleBlock;
+import net.minecraft.world.level.block.LanternBlock;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
@@ -56,12 +57,19 @@ import net.minecraft.world.phys.Vec3;
  * a rung (anything in the climbable tag) is a node the feet can stand in, its
  * floor is its own height rather than whatever lies under the ladder, and it
  * is joined to the rungs above and below it. Reaching the top is vanilla's
- * step-up onto the landing; leaving from the top is vanilla's one-block drop
- * into the top rung. What vanilla will not do on its own is the climb itself
- * with nobody pressing into the wall, so {@link #tick()} supplies the vanilla
+ * step-up onto the landing. The open cell immediately above a top rung is a
+ * transition node, even when the body's edge still counts as grounded on the
+ * landing, and it connects back down to that rung. What vanilla will not do
+ * on its own is the climb itself with nobody pressing into the wall, so
+ * {@link #tick()} supplies the vanilla
  * climbing speed while the next node is straight up, and holds the walk still
  * meanwhile: walking into the wall is what vanilla reads as "climb up", which
  * is the wrong answer on the way down.
+ *
+ * <b>Narrow decoration is not a floor.</b> Vanilla can join the collision tops
+ * of a lantern and a fence into a path that a full-width body cannot actually
+ * walk. People reject the tops of lanterns, candles, fences, gates and walls
+ * as footing, so they use the real stair or ladder route through a building.
  *
  * <b>Route sight is not eyesight.</b> Vanilla uses the follow-range attribute
  * both for sensing and as the maximum distance a path search may expand. That
@@ -563,8 +571,8 @@ public final class PersonPathNavigation extends GroundPathNavigation {
       if (this.mob.onClimbable()) {
         return this.getStartNode(feet);
       }
-      if (!this.mob.onGround() && isClimbable(this.currentContext.getBlockState(feet.below()))) {
-        return this.getStartNode(feet.below());
+      if (isLadderTransition(feet)) {
+        return this.getStartNode(feet);
       }
       return super.getStart();
     }
@@ -592,6 +600,9 @@ public final class PersonPathNavigation extends GroundPathNavigation {
       if (type == PathType.OPEN && isClimbable(state)) {
         return PathType.WALKABLE; // a rung is somewhere the feet can be
       }
+      if (type == PathType.OPEN && isLadderTransition(new BlockPos(x, y, z))) {
+        return PathType.WALKABLE;
+      }
       return type;
     }
 
@@ -599,8 +610,22 @@ public final class PersonPathNavigation extends GroundPathNavigation {
     @Override
     public PathType getPathTypeOfMob(PathfindingContext context, int x, int y, int z, Mob mob) {
       PathType type = super.getPathTypeOfMob(context, x, y, z, mob);
+      BlockPos position = new BlockPos(x, y, z);
+      BlockState support = context.getBlockState(position.below());
+      if (type == PathType.WALKABLE && (support.is(BlockTags.FENCES)
+          || support.is(BlockTags.WALLS)
+          || support.getBlock() instanceof FenceGateBlock
+          || support.getBlock() instanceof LanternBlock
+          || support.getBlock() instanceof CandleBlock)) {
+        // Vanilla can chain narrow collision tops into a nominal shortcut,
+        // such as stepping from a lantern onto a fence. A full villager body
+        // cannot execute that route, so these decorative and barrier tops are
+        // obstacles rather than floors. Stairs and slabs retain vanilla's
+        // movement rules.
+        return PathType.BLOCKED;
+      }
       if (type != PathType.BLOCKED || getPathType(context, x, y, z) != PathType.WALKABLE) return type;
-      Vec3 standing = WorkerFooting.standingPosition(mob, new BlockPos(x, y, z));
+      Vec3 standing = WorkerFooting.standingPosition(mob, position);
       if (standing == null || standing.y >= y) return type;
       // Only replace ordinary solid-cell rejection. Gates, rails and hazards keep
       // their existing rules even when their collision shape leaves physical room.
@@ -631,7 +656,8 @@ public final class PersonPathNavigation extends GroundPathNavigation {
     /** A rung's floor is the rung, not whatever is under the ladder. */
     @Override
     protected double getFloorLevel(BlockPos pos) {
-      return isClimbable(this.currentContext.getBlockState(pos)) ? pos.getY() : super.getFloorLevel(pos);
+      return isClimbable(this.currentContext.getBlockState(pos)) || isLadderTransition(pos)
+          ? pos.getY() : super.getFloorLevel(pos);
     }
 
     @Override
@@ -644,25 +670,38 @@ public final class PersonPathNavigation extends GroundPathNavigation {
         if (!crossesOpenPanel(node, neighbor)) outputArray[clearCount++] = neighbor;
       }
       count = clearCount;
-      if (!isClimbable(this.currentContext.getBlockState(new BlockPos(node.x, node.y, node.z)))) {
+      BlockPos nodePos = new BlockPos(node.x, node.y, node.z);
+      if (isLadderTransition(nodePos)) {
+        Node rung = rung(node.x, node.y - 1, node.z);
+        if (this.isNeighborValid(rung, node)) outputArray[count++] = rung;
         return count;
       }
-      // Vanilla may offer a fall to the ground beside a high rung. Taking that
-      // edge leaves the ladder early and can strand the body on a nearby rail.
-      // Descend the rungs first; ordinary same-height and one-step exits remain.
-      int safeCount = 0;
-      for (int i = 0; i < count; i++) {
-        Node neighbor = outputArray[i];
-        if (neighbor.y >= node.y - 1) outputArray[safeCount++] = neighbor;
-      }
-      count = safeCount;
-      for (int step : new int[] {1, -1}) {
-        Node rung = rung(node.x, node.y + step, node.z);
-        if (this.isNeighborValid(rung, node)) {
-          outputArray[count++] = rung;
+      if (isClimbable(this.currentContext.getBlockState(nodePos))) {
+        // Vanilla may offer a fall to the ground beside a high rung. Taking that
+        // edge leaves the ladder early and can strand the body on a nearby rail.
+        // Descend the rungs first; ordinary same-height and one-step exits remain.
+        int safeCount = 0;
+        for (int i = 0; i < count; i++) {
+          Node neighbor = outputArray[i];
+          if (neighbor.y >= node.y - 1) outputArray[safeCount++] = neighbor;
         }
+        count = safeCount;
+        for (int step : new int[] {1, -1}) {
+          Node rung = rung(node.x, node.y + step, node.z);
+          if (this.isNeighborValid(rung, node)) {
+            outputArray[count++] = rung;
+          }
+        }
+        return count;
       }
       return count;
+    }
+
+    /** The open cell immediately above a ladder's top rung, where a climber crosses onto its landing. */
+    private boolean isLadderTransition(BlockPos pos) {
+      return this.currentContext.getBlockState(pos).getCollisionShape(
+          this.currentContext.level(), pos).isEmpty()
+          && this.currentContext.getBlockState(pos.below()).getBlock() instanceof LadderBlock;
     }
 
     /** An open leaf is passable along its aperture, but still blocks transverse approaches. */

--- a/tools/structure/README.md
+++ b/tools/structure/README.md
@@ -45,6 +45,12 @@ palette entries, are review fixtures, never building content. Blocks outside an 
 are invalid for the same reason. The native exporter enforces both invariants while writing a
 template. `./gradlew check` runs the audit over the public catalog automatically.
 
+A navigation failure is evidence about pathfinding or an authored route; it is not permission to
+edit the build. Do not add, remove or replace authored structure cells merely to make `navcheck` or
+a native access fixture pass. Keep the approved build unchanged, fix the navigation behavior when
+the route is physically valid, or record the failure for design review. Structure geometry changes
+only when the user explicitly authors or approves that design revision.
+
 Leveled market templates follow the filename convention `*market*_<level>.nbt`. Their level is
 also their number of stalls, so the audit requires exactly that many carpet cells at local Y=1:
 one supported entrance carpet per stall. Two adjacent carpets of the same color are rejected

--- a/tools/structure/tundra-catalog-20260912.json
+++ b/tools/structure/tundra-catalog-20260912.json
@@ -190,7 +190,7 @@
       "source": "run/tundra-selection-draft-20260912/captures/T03.1.nbt",
       "source_sha256": "e0aacd68a7eac5659d5b13480b3972319477b1016cec55f40f7f75b840439c69",
       "asset": "run/tundra-integration/datapack/data/kithkyn/structure/watchtower_tundra_1.nbt",
-      "asset_sha256": "b2ef26ba425e84a6c3ca8d81594065a90541019ba902b39d10e25da783d88766",
+      "asset_sha256": "a8f31b5c87da468858f032b9bb7cfd92dabc89384c824976efec97e2f26441a2",
       "definition": "run/tundra-integration/datapack/data/kithkyn/kithkyn/buildings/watchtower_tundra_1.json",
       "definition_sha256": "fd2138d67b4253642d45cfb8f0750ab980b43075fa33959018b946576cee163a"
     },
@@ -417,7 +417,7 @@
     }
   ],
   "verification": {
-    "gradle_build": "passed",
+    "gradle_check": "passed",
     "template_audit": {
       "result": "passed",
       "templates": 23,
@@ -474,6 +474,11 @@
       "failed": 0,
       "log": "run/tundra-integration/access/latest-verification.log"
     },
+    "watchtower_source_geometry": {
+      "result": "passed",
+      "non_air_coordinate_sets_equal": true,
+      "state_changes": "Only the two authored red bed halves are neutralized to white for village-color substitution."
+    },
     "visual_review": "passed in the live Tundra gallery before production promotion"
   },
   "revisions": [
@@ -487,10 +492,11 @@
       ]
     },
     {
-      "reason": "A guard could reach the T03.1 upper post but the solid rail blocked the preferred descent route.",
-      "change": "Added the final ladder rung and replaced one matching spruce rail cell with a closed spruce gate that guards open during descent.",
+      "reason": "T03.1 exposed a one-way top-of-ladder transition and a false lantern-to-fence route in person navigation.",
+      "change": "Removed the access-driven rung and gate overrides, restored the approved solid geometry, and fixed PersonPathNavigation to use the authored ladder route in both directions.",
       "scope": [
-        "watchtower_tundra_1"
+        "watchtower_tundra_1",
+        "PersonPathNavigation"
       ]
     }
   ]


### PR DESCRIPTION
The Tundra watchtower exposed a pathfinder bug: a guard could climb to the upper post, but the return route treated a lantern and fence as walkable surfaces and stalled against the railing. The approved T03.1 structure had been altered with an extra rung and gate to make the route pass.

This restores the authored watchtower geometry and fixes navigation instead. The open cell above a top ladder rung is now a two-way transition, and narrow decorative or barrier tops are rejected as walking floors. The structure workflow now records that navigation failures do not authorize edits to approved builds.

Validation:
- `./gradlew check` — 567 tests, zero failures
- Private Tundra audit — 23 templates, zero barriers or malformed entrances
- Placement/restart — 184 placements; 184 buildings and 64 entities persisted
- Founding — four rotations and snowy biome selection
- Center access — 48 physical routes
- Catalog access — 88 rotated structures and 288 physical routes, zero failures
- T03.1 source comparison — identical non-air coordinates; only its two bed halves are neutralized for village colors
